### PR TITLE
Generate Tekton Pipeline with Tasks

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,7 +1,7 @@
 # Compiler for Tekton
 
 There is an [SDK](https://www.kubeflow.org/docs/pipelines/sdk/sdk-overview/) 
-for `Kubeflow Pipeline` for end users to define pipelines for AI and ML. 
+for `Kubeflow Pipeline` for end users to define end to end machine learning and data pipelines.
 The output of the KFP SDK compiler is YAML for [Argo](https://github.com/argoproj/argo).
 
 Here we update the `Compiler` of the KFP SDK to generate `Tekton` YAML for 
@@ -39,4 +39,12 @@ a basic sequential pipeline.
 5. Run the sample pipeline on a Tekton cluster:
 
     - `kubectl apply -f pipeline.yaml`
-    - `tkn task start sequential-pipeline`
+    - `tkn pipeline start sequential-pipeline`
+
+
+## Tested Versions
+
+ - Python: `3.7.5`
+ - Kubeflow Pipelines: [`0.2.2`](https://github.com/kubeflow/pipelines/releases/tag/0.2.2)
+ - Tekton: [`0.10.0`](https://github.com/tektoncd/pipeline/releases/tag/v0.10.0)
+ 

--- a/sdk/python/kfp_tekton/compiler/__init__.py
+++ b/sdk/python/kfp_tekton/compiler/__init__.py
@@ -40,7 +40,10 @@ def monkey_patch():
     kfp.compiler._op_to_template._op_to_template = tekton_op_to_template
     kfp.compiler._op_to_template._process_base_ops = tekton_process_base_ops
     KFPCompiler._create_dag_templates = TektonCompiler._create_dag_templates
+    KFPCompiler._create_and_write_workflow = TektonCompiler._create_and_write_workflow
     KFPCompiler._create_pipeline_workflow = TektonCompiler._create_pipeline_workflow
+    KFPCompiler._create_workflow = TektonCompiler._create_workflow
+    KFPCompiler._write_workflow = TektonCompiler._write_workflow
 
 
 try:

--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import List, Text, Dict, Any
 
 
-def fix_big_data_passing(workflow: dict) -> dict:
+def fix_big_data_passing(workflow: List[Dict[Text, Any]]) -> List[Dict[Text, Any]]:  # Tekton change signature
     """
-    Noop
+    No-op
     """
     return workflow

--- a/sdk/python/tests/compiler/testdata/sequential.py
+++ b/sdk/python/tests/compiler/testdata/sequential.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import kfp
+from kfp_tekton.compiler import TektonCompiler
 from kfp import dsl
 
 
@@ -46,6 +46,8 @@ def sequential_pipeline(url='gs://ml-pipeline-playground/shakespeare1.txt', path
     download_task = gcs_download_op(url)
     echo_task = echo_op(path)
 
+    echo_task.after(download_task)
+
 
 if __name__ == '__main__':
-    kfp.compiler.Compiler().compile(sequential_pipeline, __file__ + '.zip')
+    TektonCompiler().compile(sequential_pipeline, 'sequential.yaml')

--- a/sdk/python/tests/compiler/testdata/sequential.yaml
+++ b/sdk/python/tests/compiler/testdata/sequential.yaml
@@ -14,19 +14,11 @@
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
-  annotations:
-    pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with two sequential
-      steps.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
-      "name": "url", "optional": true}, {"default": "/tmp/results.txt", "name": "path",
-      "optional": true}], "name": "Sequential pipeline"}'
-  name: sequential-pipeline
+  name: gcs-download
 spec:
   inputs:
     params:
-    - default: gs://ml-pipeline-playground/shakespeare1.txt
-      name: url
-    - default: /tmp/results.txt
-      name: path
+    - name: url
   steps:
   - args:
     - gsutil cat $0 | tee $1
@@ -37,6 +29,16 @@ spec:
     - -c
     image: google/cloud-sdk:216.0.0
     name: gcs-download
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: echo
+spec:
+  inputs:
+    params:
+    - name: path
+  steps:
   - args:
     - echo "$0"
     - $(inputs.params.path)
@@ -45,3 +47,34 @@ spec:
     - -c
     image: library/bash:4.4.23
     name: echo
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with two sequential
+      steps.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
+      "name": "url", "optional": true}, {"default": "/tmp/results.txt", "name": "path",
+      "optional": true}], "name": "Sequential pipeline"}'
+  name: sequential-pipeline
+spec:
+  params:
+  - default: gs://ml-pipeline-playground/shakespeare1.txt
+    name: url
+  - default: /tmp/results.txt
+    name: path
+  tasks:
+  - name: gcs-download
+    params:
+    - name: url
+      value: $(params.url)
+    taskRef:
+      name: gcs-download
+  - name: echo
+    params:
+    - name: path
+      value: $(params.path)
+    runAfter:
+    - gcs-download
+    taskRef:
+      name: echo

--- a/sdk/samples/sequential/sequential.py
+++ b/sdk/samples/sequential/sequential.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# Copyright 2019 Google LLC
+
+# Copyright 2019-2020 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import kfp
+from kfp_tekton.compiler import TektonCompiler
 from kfp import dsl
 
 
@@ -35,6 +35,7 @@ def echo_op(text):
         arguments=['echo "$0"', text]
     )
 
+
 @dsl.pipeline(
     name='Sequential pipeline',
     description='A pipeline with two sequential steps.'
@@ -45,5 +46,8 @@ def sequential_pipeline(url='gs://ml-pipeline-playground/shakespeare1.txt', path
     download_task = gcs_download_op(url)
     echo_task = echo_op(path)
 
+    echo_task.after(download_task)
+
+
 if __name__ == '__main__':
-    kfp.compiler.Compiler().compile(sequential_pipeline, __file__ + '.zip')
+    TektonCompiler().compile(sequential_pipeline, 'sequential.yaml')


### PR DESCRIPTION
Replace `steps` with `tasks` to allow _parallel_ task execution.
Use `runAfter` to support _sequential_ task execution.

The compile now generates multiple documents in one YAML file, one per `Task` and one for the `Pipeline`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfp-tekton/17)
<!-- Reviewable:end -->
