### PR TITLE
Use apps/v1 instead of extensions/v1beta1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ bin
 .venv/
 *.egg-info/
 
+# VSCode
+.vscode
+
 # Ignore files for MacOS
 **/.DS_Store
 

--- a/samples/kfp-tfx/tfx-taxi-on-prem/pvc/filebrowser.yaml
+++ b/samples/kfp-tfx/tfx-taxi-on-prem/pvc/filebrowser.yaml
@@ -14,7 +14,7 @@ spec:
     app: filebrowser
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: filebrowser
@@ -22,6 +22,9 @@ metadata:
   labels:
     app: filebrowser
 spec:
+  selector:
+    matchLabels:
+      app: filebrowser
   template:
     metadata:
       labels:


### PR DESCRIPTION
Change deployment by using apps/v1 instead of extensions/v1beta1, as mentioned here : https://github.com/kubernetes/kubernetes/issues/61430

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfp-tekton/43)
<!-- Reviewable:end -->
