### PR TITLE
Add pipelineparams which contains multi params and sidecars support

### DIFF
--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -49,6 +49,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.sidecar import sidecar_pipeline
     self._test_pipeline_workflow(sidecar_pipeline, 'sidecar.yaml')
 
+  def test_pipelineparams_workflow(self):
+    """
+    Test compiling a pipelineparams workflow.
+    """
+    from .testdata.pipelineparams import pipelineparams_pipeline
+    self._test_pipeline_workflow(pipelineparams_pipeline, 'pipelineparams.yaml')
+
   def test_volume_workflow(self):
     """
     Test compiling a Waston ML workflow.

--- a/sdk/python/tests/compiler/testdata/pipelineparams.py
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.py
@@ -1,0 +1,42 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kfp.dsl as dsl
+from kubernetes.client.models import V1EnvVar
+
+
+@dsl.pipeline(name='PipelineParams', description='A pipeline with multiple pipeline params.')
+def pipelineparams_pipeline(tag: str = 'latest', sleep_ms: int = 10):
+
+    echo = dsl.Sidecar(
+        name='echo',
+        image='hashicorp/http-echo:%s' % tag,
+        args=['-text="hello world"'],
+    )
+
+    op1 = dsl.ContainerOp(
+        name='download',
+        image='busybox:%s' % tag,
+        command=['sh', '-c'],
+        arguments=['sleep %s; wget localhost:5678 -O /tmp/results.txt' % sleep_ms],
+        sidecars=[echo],
+        file_outputs={'downloaded': '/tmp/results.txt'})
+
+    op2 = dsl.ContainerOp(
+        name='echo',
+        image='library/bash',
+        command=['sh', '-c'],
+        arguments=['echo $MSG %s' % op1.output])
+    
+    op2.container.add_env_variable(V1EnvVar(name='MSG', value='pipelineParams: '))

--- a/sdk/python/tests/compiler/testdata/pipelineparams.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.yaml
@@ -1,0 +1,88 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: download
+spec:
+  params:
+  - name: sleep_ms
+  - name: tag
+  results:
+  - description: /tmp/results.txt
+    name: downloaded
+  sidecars:
+  - args:
+    - -text="hello world"
+    image: hashicorp/http-echo:$(inputs.params.tag)
+    name: echo
+  steps:
+  - args:
+    - sleep $(inputs.params.sleep_ms); wget localhost:5678 -O $(results.downloaded.path)
+    command:
+    - sh
+    - -c
+    image: busybox:$(inputs.params.tag)
+    name: download
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: echo
+spec:
+  params:
+  - name: download-downloaded
+  steps:
+  - args:
+    - echo $MSG $(inputs.params.download-downloaded)
+    command:
+    - sh
+    - -c
+    env:
+    - name: MSG
+      value: 'pipelineParams: '
+    image: library/bash
+    name: echo
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with multiple
+      pipeline params.", "inputs": [{"default": "latest", "name": "tag", "optional":
+      true, "type": "String"}, {"default": "10", "name": "sleep_ms", "optional": true,
+      "type": "Integer"}], "name": "PipelineParams"}'
+  name: pipelineparams
+spec:
+  params:
+  - default: latest
+    name: tag
+  - default: '10'
+    name: sleep_ms
+  tasks:
+  - name: download
+    params:
+    - name: sleep_ms
+      value: $(params.sleep_ms)
+    - name: tag
+      value: $(params.tag)
+    taskRef:
+      name: download
+  - name: echo
+    params:
+    - name: download-downloaded
+      value: $(tasks.download.results.downloaded)
+    taskRef:
+      name: echo

--- a/sdk/python/tests/test_kfp_samples_report.txt
+++ b/sdk/python/tests/test_kfp_samples_report.txt
@@ -9,13 +9,13 @@ FAILURE: input_artifact_raw_value.py
 SUCCESS: loop_over_lightweight_output.py
 SUCCESS: param_op_transform.py
 FAILURE: param_substitutions.py
-FAILURE: pipelineparams.py
+SUCCESS: pipelineparams.py
 SUCCESS: recursive_do_while.py
 SUCCESS: recursive_while.py
 FAILURE: resourceop_basic.py
-FAILURE: sidecar.py
+SUCCESS: sidecar.py
 FAILURE: timeout.py
-FAILURE: volume.py
+SUCCESS: volume.py
 FAILURE: volume_snapshotop_rokurl.py
 FAILURE: volume_snapshotop_sequential.py
 FAILURE: volumeop_basic.py
@@ -29,6 +29,6 @@ SUCCESS: withparam_global_dict.py
 SUCCESS: withparam_output.py
 SUCCESS: withparam_output_dict.py
 
-Success: 14
-Failure: 16
+Success: 17
+Failure: 13
 Total:   30


### PR DESCRIPTION
Since we fixed the issue of multi params in one pipeline task (PR #40), and support sidecars (PR #42),  we can run pipelineparams sucessfully now. Let me add pipelineparams to our testdata and integrate test incidentally.

Record my test result here as well.
```
Name:           pipelineparams-run-v8cb5
Namespace:      default
Pipeline Ref:   pipelineparams

🌡️  Status

STARTED        DURATION   STATUS
1 minute ago   1 minute   Succeeded

📦 Resources

 No resources

⚓ Params

 NAME         VALUE
 ∙ tag        latest
 ∙ sleep_ms   10

🗂  Taskruns

 NAME                                        TASK NAME   STARTED        DURATION     STATUS
 ∙ pipelineparams-run-v8cb5-echo-2vxfx       echo        1 minute ago   29 seconds   Succeeded
 ∙ pipelineparams-run-v8cb5-download-5q9td   download    1 minute ago   47 seconds   Succeeded
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfp-tekton/45)
<!-- Reviewable:end -->
