### PR TITLE
Extend compiler to support timeout defining for pipeline tasks

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -176,8 +176,7 @@ def _op_to_template(op: BaseOp):
 
     # timeout
     if processed_op.timeout:
-        raise NotImplementedError("'timeout' is not (yet) implemented")
-        template['activeDeadlineSeconds'] = processed_op.timeout
+        template['timeout'] = '%ds' % processed_op.timeout
 
     # initContainers
     if processed_op.init_containers:

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -87,20 +87,24 @@ class TektonCompiler(Compiler) :
     tasks = self._create_dag_templates(pipeline, op_transformers, params)
 
     # generate task reference list for Tekton pipeline
-    task_refs = [
-      {
-        'name': t['metadata']['name'],
-        'taskRef': {
-          'name': t['metadata']['name']
-        },
-        'params': [{
-            'name': p['name'],
-            'value': p.get('default', '')
-          } for p in t['spec'].get('params', [])
-        ]
-      }
-      for t in tasks
-    ]
+    task_refs = []
+    for t in tasks:
+      task_json = {
+          'name': t['metadata']['name'],
+          'taskRef': {
+            'name': t['metadata']['name']
+          },
+          'params': [{
+              'name': p['name'],
+              'value': p.get('default', '')
+            } for p in t['spec'].get('params', [])
+          ]
+        }
+      # add timeout params to task_refs, instead of task.
+      if 'timeout' in t:
+        task_json['timeout'] = t['timeout']
+        del t['timeout']
+      task_refs.append(task_json)
 
     # add task dependencies
     for task in task_refs:

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -56,6 +56,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.volume import volume_pipeline
     self._test_pipeline_workflow(volume_pipeline, 'volume.yaml')
 
+  def test_timeout_workflow(self):
+    """
+    Test compiling a timeout workflow.
+    """
+    from .testdata.timeout import timeout_sample_pipeline
+    self._test_pipeline_workflow(timeout_sample_pipeline, 'timeout.yaml')
+
   def _test_pipeline_workflow(self, pipeline_function, pipeline_yaml):
     test_data_dir = os.path.join(os.path.dirname(__file__), 'testdata')
     golden_yaml_file = os.path.join(test_data_dir, pipeline_yaml)

--- a/sdk/python/tests/compiler/testdata/timeout.py
+++ b/sdk/python/tests/compiler/testdata/timeout.py
@@ -1,0 +1,37 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import kfp.dsl as dsl
+
+
+class RandomFailure1Op(dsl.ContainerOp):
+  """A component that fails randomly."""
+
+  def __init__(self, exit_codes):
+    super(RandomFailure1Op, self).__init__(
+      name='random_failure',
+      image='python:alpine3.6',
+      command=['python', '-c'],
+      arguments=["import random; import sys; exit_code = random.choice([%s]); print(exit_code); import time; time.sleep(30); sys.exit(exit_code)" % exit_codes])
+
+
+@dsl.pipeline(
+  name='pipeline includes two steps which fail randomly.',
+  description='shows how to use ContainerOp set_timeout().'
+)
+def timeout_sample_pipeline():
+  op1 = RandomFailure1Op('0,1,2,3').set_timeout(20)
+  op2 = RandomFailure1Op('0,1')
+  dsl.get_pipeline_conf()

--- a/sdk/python/tests/compiler/testdata/timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout.yaml
@@ -1,0 +1,63 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: random-failure
+spec:
+  steps:
+  - args:
+    - import random; import sys; exit_code = random.choice([0,1,2,3]); print(exit_code);
+      import time; time.sleep(30); sys.exit(exit_code)
+    command:
+    - python
+    - -c
+    image: python:alpine3.6
+    name: random-failure
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: random-failure-2
+spec:
+  steps:
+  - args:
+    - import random; import sys; exit_code = random.choice([0,1]); print(exit_code);
+      import time; time.sleep(30); sys.exit(exit_code)
+    command:
+    - python
+    - -c
+    image: python:alpine3.6
+    name: random-failure-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use ContainerOp
+      set_timeout().", "name": "pipeline includes two steps which fail randomly."}'
+  name: pipeline-includes-two-steps-which-fail-randomly
+spec:
+  params: []
+  tasks:
+  - name: random-failure
+    params: []
+    taskRef:
+      name: random-failure
+    timeout: 20s
+  - name: random-failure-2
+    params: []
+    taskRef:
+      name: random-failure-2


### PR DESCRIPTION
Add suuport for timeout. 

Tekton pipeline already supported timeout property, doc refer to [here](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md) (pipeline), and [here](https://github.com/tektoncd/pipeline/blob/master/docs/pipelineruns.md) (pipelinerun).

But there are some differences with argo. In tekton, the Timeout property of a Pipeline Task allows a timeout to be defined for a TaskRun. and whole pipeline timeout need to be defined in pipelinerun. So:
1. timeout for task: implemented in this PR.
2. timeout for whole pipeline:  run `tkn p start pipeline-includes-two-steps-which-fail-randomly --showlog --timeout 180s`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfp-tekton/46)
<!-- Reviewable:end -->
