### PR TITLE
add instructions to install tekton pipeline and storage

### DIFF
--- a/samples/kfp-tekton/flip-coin/README.md
+++ b/samples/kfp-tekton/flip-coin/README.md
@@ -7,6 +7,12 @@ is used to demonstrate the use of conditions.
 
 * Tekton: the [Tekton]() version was built to match the Argo one. This pipeline is over-engineered for what it does, but it demonstrate using `Condition`s in combination with `Task`s and `PipelineResource`s. To run this pipeline using `tkn`:
 
+* [Installing Tekton Pipelines on Kubernetes](https://github.com/tektoncd/pipeline/blob/master/docs/install.md#installing-tekton-pipelines-on-kubernetes) 
+
+* [Installing Tekton Pipelines on OpenShift](https://github.com/tektoncd/pipeline/blob/master/docs/install.md#installing-tekton-pipelines-on-openshift)
+
+* [Configuring artifact storage](https://github.com/tektoncd/pipeline/blob/master/docs/install.md#configuring-artifact-storage): When using S3 bucket, make sure to update your bucket name.
+
 ```
 # Install tasks, conditions and pipeline
 kubectl apply -f samples/kfp-tekton/flip-coin/tekton/flip-coin-tekton.yaml


### PR DESCRIPTION
When run the [flip-coin example ](https://github.com/kubeflow/kfp-tekton/tree/master/samples/kfp-tekton/flip-coin) on openshift using openshift pipeline, it needs to setup the storage in the [flip-coin-tekton-resources.yaml](https://github.com/kubeflow/kfp-tekton/blob/master/samples/kfp-tekton/flip-coin/tekton/flip-coin-tekton-resources.yaml) before running this step:

```
# Prepare the resources and apply them
kubectl apply -f samples/kfp-tekton/flip-coin/tekton/flip-coin-tekton-resources.yaml
```

So I add the information in the readme to clarify.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfp-tekton/47)
<!-- Reviewable:end -->
