### PR TITLE
Add init_container support

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -110,6 +110,12 @@ def _op_to_template(op: BaseOp):
         # }
         raise NotImplementedError("dsl.ResourceOp is not yet implemented")
 
+    # initContainers
+    if processed_op.init_containers:
+        steps = processed_op.init_containers.copy()
+        steps.extend(template['spec']['steps'])
+        template['spec']['steps'] = steps
+
     # inputs
     input_artifact_paths = processed_op.input_artifact_paths if isinstance(processed_op, dsl.ContainerOp) else None
     artifact_arguments = processed_op.artifact_arguments if isinstance(processed_op, dsl.ContainerOp) else None
@@ -178,11 +184,6 @@ def _op_to_template(op: BaseOp):
     if processed_op.timeout:
         raise NotImplementedError("'timeout' is not (yet) implemented")
         template['activeDeadlineSeconds'] = processed_op.timeout
-
-    # initContainers
-    if processed_op.init_containers:
-        raise NotImplementedError("'initContainers' is not (yet) implemented")
-        template['initContainers'] = processed_op.init_containers
 
     # sidecars
     if processed_op.sidecars:

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -28,6 +28,13 @@ GENERATE_GOLDEN_YAML = False
 
 class TestTektonCompiler(unittest.TestCase):
 
+  def test_init_container_workflow(self):
+    """
+    Test compiling a initial container workflow.
+    """
+    from .testdata.init_container import init_container_pipeline
+    self._test_pipeline_workflow(init_container_pipeline, 'init_container.yaml')
+
   def test_sequential_workflow(self):
     """
     Test compiling a sequential workflow.
@@ -51,7 +58,7 @@ class TestTektonCompiler(unittest.TestCase):
 
   def test_volume_workflow(self):
     """
-    Test compiling a Waston ML workflow.
+    Test compiling a volume workflow.
     """
     from .testdata.volume import volume_pipeline
     self._test_pipeline_workflow(volume_pipeline, 'volume.yaml')

--- a/sdk/python/tests/compiler/testdata/init_container.py
+++ b/sdk/python/tests/compiler/testdata/init_container.py
@@ -1,0 +1,29 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import dsl
+
+
+echo = dsl.UserContainer(
+    name='echo',
+    image='alpine:latest',
+    command=['echo', 'bye'])
+
+@dsl.pipeline(name='InitContainer', description='A pipeline with init container.')
+def init_container_pipeline():
+    dsl.ContainerOp(
+        name='hello',
+        image='alpine:latest',
+        command=['echo', 'hello'],
+        init_containers=[echo])

--- a/sdk/python/tests/compiler/testdata/init_container.yaml
+++ b/sdk/python/tests/compiler/testdata/init_container.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: hello
+spec:
+  steps:
+  - command:
+    - echo
+    - bye
+    image: alpine:latest
+    name: echo
+  - command:
+    - echo
+    - hello
+    image: alpine:latest
+    name: hello
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with init container.",
+      "name": "InitContainer"}'
+  name: initcontainer
+spec:
+  params: []
+  tasks:
+  - name: hello
+    params: []
+    taskRef:
+      name: hello


### PR DESCRIPTION
Adding init_container as initial steps since the execution order is the same. 

Since init_container is not a valid field in Tekton task, I prepend all the init_containers to run them before the main step. Also moving the initContainers before inputs/outputs processing in order to process params for all steps. 