### PR TITLE
Extend compiler to support retries for tasks

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -175,11 +175,6 @@ def _op_to_template(op: BaseOp):
         if processed_op.pod_labels:
             template['metadata']['labels'] = processed_op.pod_labels
 
-    # retries
-    if processed_op.num_retries:
-        raise NotImplementedError("'retries' is not (yet) implemented")
-        template['retryStrategy'] = {'limit': processed_op.num_retries}
-
     # timeout
     if processed_op.timeout:
         raise NotImplementedError("'timeout' is not (yet) implemented")

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -122,6 +122,12 @@ class TektonCompiler(Compiler) :
               tp['value'] = '$(tasks.%s.results.%s)' % (pp.op_name, pp.name.replace('_', '-'))
               break
 
+    # add retries params
+    for task in task_refs:
+      op = pipeline.ops.get(task['name'])
+      if op.num_retries:
+        task['retries'] = op.num_retries
+
     # generate the Tekton Pipeline document
     pipeline = {
       'apiVersion': tekton_api_version,

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -63,6 +63,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.pipelineparams import pipelineparams_pipeline
     self._test_pipeline_workflow(pipelineparams_pipeline, 'pipelineparams.yaml')
 
+  def test_retry_workflow(self):
+    """
+    Test compiling a retry task in workflow.
+    """
+    from .testdata.retry import retry_sample_pipeline
+    self._test_pipeline_workflow(retry_sample_pipeline, 'retry.yaml')
+
   def test_volume_workflow(self):
     """
     Test compiling a volume workflow.

--- a/sdk/python/tests/compiler/testdata/retry.py
+++ b/sdk/python/tests/compiler/testdata/retry.py
@@ -1,0 +1,36 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import kfp
+from kfp import dsl
+
+
+def random_failure_op(exit_codes):
+    """A component that fails randomly."""
+    return dsl.ContainerOp(
+        name='random_failure',
+        image='python:alpine3.6',
+        command=['python', '-c'],
+        arguments=['import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]); print(exit_code); sys.exit(exit_code)', exit_codes]
+    )
+
+
+@dsl.pipeline(
+    name='Retry random failures',
+    description='The pipeline includes two steps which fail randomly. It shows how to use ContainerOp(...).set_retry(...).'
+)
+def retry_sample_pipeline():
+    op1 = random_failure_op('0,1,2,3').set_retry(10)
+    op2 = random_failure_op('0,1').set_retry(5)

--- a/sdk/python/tests/compiler/testdata/retry.yaml
+++ b/sdk/python/tests/compiler/testdata/retry.yaml
@@ -1,0 +1,67 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: random-failure
+spec:
+  steps:
+  - args:
+    - import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]);
+      print(exit_code); sys.exit(exit_code)
+    - 0,1,2,3
+    command:
+    - python
+    - -c
+    image: python:alpine3.6
+    name: random-failure
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: random-failure-2
+spec:
+  steps:
+  - args:
+    - import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]);
+      print(exit_code); sys.exit(exit_code)
+    - 0,1
+    command:
+    - python
+    - -c
+    image: python:alpine3.6
+    name: random-failure-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline includes
+      two steps which fail randomly. It shows how to use ContainerOp(...).set_retry(...).",
+      "name": "Retry random failures"}'
+  name: retry-random-failures
+spec:
+  params: []
+  tasks:
+  - name: random-failure
+    params: []
+    retries: 10
+    taskRef:
+      name: random-failure
+  - name: random-failure-2
+    params: []
+    retries: 5
+    taskRef:
+      name: random-failure-2


### PR DESCRIPTION
Sometimes you need a policy for retrying tasks which have problems such as network errors, missing dependencies or upload problems. Any of those issues must be reflected as False (corev1.ConditionFalse) within the TaskRun Status Succeeded Condition. For that reason there is an optional attribute called retries which declares how many times that task should be retried in case of failure.

UT PASS:
```
Name:           retry-random-failures-run-s9zdc
Namespace:      default
Pipeline Ref:   retry-random-failures

🌡️  Status

STARTED         DURATION     STATUS
2 minutes ago   35 seconds   Succeeded

📦 Resources

 No resources

⚓ Params

 No params

🗂  Taskruns

 NAME                                                       TASK NAME          STARTED         DURATION     STATUS
 ∙ retry-random-failures-run-s9zdc-random-failure-fk9dq     random-failure     2 minutes ago   12 seconds   Succeeded
 ∙ retry-random-failures-run-s9zdc-random-failure-2-nbwr7   random-failure-2   2 minutes ago   13 seconds   Succeeded

# kc get po
NAME                                                              READY   STATUS      RESTARTS   AGE
retry-random-failures-run-s9zdc-random-failure-2-nbwr7-po-79rhx   0/1     Completed   0          59m
retry-random-failures-run-s9zdc-random-failure-fk9dq-pod-9wkm7    0/1     Error       0          59m
retry-random-failures-run-s9zdc-random-failure-fk9dq-pod-b4k5l    0/1     Completed   0          59m
```
Fixes #48