### PR TITLE
Add compiler progress report to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,35 @@
 matrix:
   include:
-    - language: python
+    - name: "Unit tests, Python 3.6"
+      language: python
       python: "3.6"
       env: TOXENV=py36
       install:
         - python3 -m pip install $TRAVIS_BUILD_DIR/sdk/python
       script:
-        # KFP Tekton SDK unit tests
         - cd $TRAVIS_BUILD_DIR/sdk/python/tests
         - ./run_tests.sh
-    - language: python
+    - name: "Unit tests, Python 3.7"
+      language: python
       python: "3.7"
       env: TOXENV=py37
       install:
         - python3 -m pip install $TRAVIS_BUILD_DIR/sdk/python
       script:
-        # KFP Tekton SDK unit tests
         - cd $TRAVIS_BUILD_DIR/sdk/python/tests
         - ./run_tests.sh
+    - name: "Progress report on compiling KFP DSL test scripts"
+      language: python
+      python: "3.7"
+      install:
+        - python3 -m pip install -e $TRAVIS_BUILD_DIR/sdk/python
+      script:
+        - cd $TRAVIS_BUILD_DIR/sdk/python/tests
+        - ./test_kfp_samples.sh
+    - name: "Lint Python code with flake8"
+      language: python
+      python: "3.7"
+      install:
+        - pip install flake8
+      script:
+        - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/sdk/python/tests/test_kfp_samples.sh
+++ b/sdk/python/tests/test_kfp_samples.sh
@@ -24,10 +24,10 @@
 KFP_VERSION=${1:-0.2.2}
 KFP_REPO_URL="https://github.com/kubeflow/pipelines.git"
 
-SCRIPT_DIR="$(dirname "$0")"
-PROJECT_DIR="$(cd "${SCRIPT_DIR%/sdk/python/tests}"; pwd)"
+SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
+PROJECT_DIR="${TRAVIS_BUILD_DIR:-$(cd "${SCRIPT_DIR%/sdk/python/tests}"; pwd)}"
 TEMP_DIR="${PROJECT_DIR}/temp"
-VENV_DIR="${TEMP_DIR}/.venv"
+VENV_DIR="${VIRTUAL_ENV:-${TEMP_DIR}/.venv}"
 KFP_CLONE_DIR="${TEMP_DIR}/kubeflow/pipelines"
 KFP_TESTDATA_DIR="${KFP_CLONE_DIR}/sdk/python/tests/compiler/testdata"
 TEKTON_COMPILED_YAML_DIR="${TEMP_DIR}/tekton_compiler_output"
@@ -37,47 +37,38 @@ COMPILER_OUTPUTS_FILE="${TEMP_DIR}/test_kfp_samples_output.txt"
 mkdir -p "${TEMP_DIR}"
 mkdir -p "${TEKTON_COMPILED_YAML_DIR}"
 
-KFP_REQ_VERSION=$(grep "kfp" "${PROJECT_DIR}/sdk/python/requirements.txt" | sed -n -E "s/^kfp[=<>]+([0-9.]+)$/\1/p")
-
-if [ "$KFP_VERSION" != "$KFP_REQ_VERSION" ]; then
-  echo "NOTE: the KFP version in the 'requirements.txt' file does not match"
-  echo "  KFP_VERSION:      $KFP_VERSION"
-  echo "  requirements.txt: $KFP_REQ_VERSION"
-fi
-
+# clone kubeflow/pipeline repo to get the testdata DSL scripts
 if [ ! -d "${KFP_CLONE_DIR}" ]; then
-  git clone -b "${KFP_VERSION}" "${KFP_REPO_URL}" "${KFP_CLONE_DIR}"
+  git -c advice.detachedHead=false clone -b "${KFP_VERSION}" "${KFP_REPO_URL}" "${KFP_CLONE_DIR}" -q
 else
   cd "${KFP_CLONE_DIR}"
-  git checkout "${KFP_VERSION}"
+  git -c advice.detachedHead=false checkout "${KFP_VERSION}" -f -q
   cd - &> /dev/null
 fi
+echo "KFP version: $(git --git-dir "${KFP_CLONE_DIR}"/.git tag --points-at HEAD)"
 
+# check if we are running in a Python virtual environment, if not create one
 if [ ! -d "${VENV_DIR}" ]; then
   echo "Creating Python virtual environment..."
   python3 -m venv "${VENV_DIR}"
   source "${VENV_DIR}/bin/activate"
   pip install --upgrade pip
 fi
-
 source "${VENV_DIR}/bin/activate"
 
-if ! (pip show kfp | grep Location | grep -q "${KFP_CLONE_DIR}"); then
-  pip install -e "${KFP_CLONE_DIR}/sdk/python"
-fi
-
-if ! (pip show kfp | grep Version | grep -q "${KFP_VERSION}"); then
-  pip install -e "${KFP_CLONE_DIR}/sdk/python"
-fi
-
+# install KFP-Tekton compiler, unless already installed
 if ! (pip show "kfp-tekton" | grep Location | grep -q "${PROJECT_DIR}"); then
   pip install -e "${PROJECT_DIR}/sdk/python"
 fi
 
-pip list | grep "kfp\|tekton" | grep -v "-server-api"
+echo  # just adding some separation for console output
 
-echo
+# keep a record of the previous compilation status
+SUCCESS_BEFORE=$(grep -c "SUCCESS" "${COMPILE_REPORT_FILE}")
+FAILURE_BEFORE=$(grep -c "FAILURE" "${COMPILE_REPORT_FILE}")
+TOTAL_BEFORE=$(grep -c . "${COMPILE_REPORT_FILE}")
 
+# delete the previous compiler output file
 rm -f "${COMPILER_OUTPUTS_FILE}"
 
 for f in "${KFP_TESTDATA_DIR}"/*.py; do
@@ -90,20 +81,30 @@ for f in "${KFP_TESTDATA_DIR}"/*.py; do
   fi
 done | tee "${COMPILE_REPORT_FILE}"
 
+# compile the report
 SUCCESS=$(grep -c "SUCCESS" "${COMPILE_REPORT_FILE}")
 FAILURE=$(grep -c "FAILURE" "${COMPILE_REPORT_FILE}")
 TOTAL=$(grep -c . "${COMPILE_REPORT_FILE}")
-
 (
   echo
   echo "Success: ${SUCCESS}"
   echo "Failure: ${FAILURE}"
   echo "Total:   ${TOTAL}"
 ) | tee -a "${COMPILE_REPORT_FILE}"
-
 echo
-echo "The compilation status report was stored in ${COMPILE_REPORT_FILE}"
-echo "The accumulated console logs can be found in ${COMPILER_OUTPUTS_FILE}"
+echo "Compilation status report:   ${COMPILE_REPORT_FILE#${PROJECT_DIR}/}"
+echo "Accumulated compiler logs:   ${COMPILER_OUTPUTS_FILE#${PROJECT_DIR}/}"
+echo "Compiled Tekton YAML files:  ${TEKTON_COMPILED_YAML_DIR#${PROJECT_DIR}/}/"
 echo
 
-deactivate
+# for Travis/CI integration return exit code 1 if success rate declined
+if [ ${SUCCESS} -lt "${SUCCESS_BEFORE}" ]; then
+  echo "It appears that fewer KFP test scripts are compiling than before!"
+  echo
+  echo "Success before: ${SUCCESS_BEFORE}"
+  echo "Failure before: ${FAILURE_BEFORE}"
+  echo "Total before:   ${TOTAL_BEFORE}"
+  exit 1
+else
+  exit 0
+fi

--- a/sdk/python/tests/test_kfp_samples_report.txt
+++ b/sdk/python/tests/test_kfp_samples_report.txt
@@ -14,7 +14,7 @@ SUCCESS: recursive_do_while.py
 SUCCESS: recursive_while.py
 FAILURE: resourceop_basic.py
 SUCCESS: sidecar.py
-FAILURE: timeout.py
+SUCCESS: timeout.py
 SUCCESS: volume.py
 FAILURE: volume_snapshotop_rokurl.py
 FAILURE: volume_snapshotop_sequential.py
@@ -29,6 +29,6 @@ SUCCESS: withparam_global_dict.py
 SUCCESS: withparam_output.py
 SUCCESS: withparam_output_dict.py
 
-Success: 17
-Failure: 13
+Success: 18
+Failure: 12
 Total:   30


### PR DESCRIPTION
This PR adds two additional jobs to the Travis CI script:
- ensure that no fewer KFP DSL scripts pass the compilation than before
- ensure Python scripts formatting passes the lint check (though very relaxed)

I also added job names to make it easier to distinguish the Travis jobs.

We have a total of 4 Travis CI build jobs now:
.


Job | Python | ENV | OS | State
-- | -- | -- | -- | --
Unit tests, Python 3.6 | 3.6 | TOXENV=py36 | Linux | passed
Unit tests, Python 3.7 | 3.7 | TOXENV=py37 | Linux | passed
Progress report on compiling KFP DSL test scripts | 3.7 |   | Linux | passed
Lint Python code with flake8 | 3.7 |   | Linux | passed

