### PR TITLE
Extend compiler to support workflow level timeout

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -129,6 +129,7 @@ class TektonCompiler(Compiler) :
         task['retries'] = op.num_retries
 
     # add timeout params to task_refs, instead of task.
+    pipeline_conf = pipeline.conf
     for task in task_refs:
       op = pipeline.ops.get(task['name'])
       if op.timeout:
@@ -169,6 +170,10 @@ class TektonCompiler(Compiler) :
           }
         }
       }
+
+      # add workflow level timeout to pipeline run
+      if pipeline_conf.timeout:
+        pipelinerun['spec']['timeout'] = '%ds' % pipeline_conf.timeout
 
       workflow = workflow + [pipelinerun]
 

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -84,9 +84,16 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.volume import volume_pipeline
     self._test_pipeline_workflow(volume_pipeline, 'volume.yaml')
 
+  def test_timeout_pipelinerun(self):
+    """
+    Test compiling a timeout for a whole workflow.
+    """
+    from .testdata.timeout import timeout_sample_pipeline
+    self._test_pipeline_workflow(timeout_sample_pipeline, 'timeout_pipelinerun.yaml', generate_pipelinerun=True)
+
   def test_timeout_workflow(self):
     """
-    Test compiling a timeout workflow.
+    Test compiling a step level timeout workflow.
     """
     from .testdata.timeout import timeout_sample_pipeline
     self._test_pipeline_workflow(timeout_sample_pipeline, 'timeout.yaml')

--- a/sdk/python/tests/compiler/testdata/timeout.py
+++ b/sdk/python/tests/compiler/testdata/timeout.py
@@ -15,7 +15,6 @@
 
 import kfp.dsl as dsl
 
-
 class RandomFailure1Op(dsl.ContainerOp):
   """A component that fails randomly."""
 
@@ -34,4 +33,9 @@ class RandomFailure1Op(dsl.ContainerOp):
 def timeout_sample_pipeline():
   op1 = RandomFailure1Op('0,1,2,3').set_timeout(20)
   op2 = RandomFailure1Op('0,1')
-  dsl.get_pipeline_conf()
+  dsl.get_pipeline_conf().set_timeout(40)
+
+if __name__ == '__main__':
+    # don't use top-level import of TektonCompiler to prevent monkey-patching KFP compiler when using KFP's dsl-compile
+    from kfp_tekton.compiler import TektonCompiler
+    TektonCompiler().compile(timeout_sample_pipeline, __file__.replace('.py', '.yaml'))

--- a/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
@@ -1,0 +1,73 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: random-failure
+spec:
+  steps:
+  - args:
+    - import random; import sys; exit_code = random.choice([0,1,2,3]); print(exit_code);
+      import time; time.sleep(30); sys.exit(exit_code)
+    command:
+    - python
+    - -c
+    image: python:alpine3.6
+    name: random-failure
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: random-failure-2
+spec:
+  steps:
+  - args:
+    - import random; import sys; exit_code = random.choice([0,1]); print(exit_code);
+      import time; time.sleep(30); sys.exit(exit_code)
+    command:
+    - python
+    - -c
+    image: python:alpine3.6
+    name: random-failure-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use ContainerOp
+      set_timeout().", "name": "pipeline includes two steps which fail randomly."}'
+  name: pipeline-includes-two-steps-which-fail-randomly
+spec:
+  params: []
+  tasks:
+  - name: random-failure
+    params: []
+    taskRef:
+      name: random-failure
+    timeout: 20s
+  - name: random-failure-2
+    params: []
+    taskRef:
+      name: random-failure-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline-includes-two-steps-which-fail-randomly-run
+spec:
+  params: []
+  pipelineRef:
+    name: pipeline-includes-two-steps-which-fail-randomly
+  timeout: 40s


### PR DESCRIPTION
Specifies timeout after which the PipelineRun will fail. If the value of timeout is empty, the default timeout will be applied. If the value is set to 0, there is no timeout.
as below, it's the result of:  task-1 was set timout as 20s, pipelinerun timeout was set as 40s.
```
# tkn pr describe pipeline-includes-two-steps-which-fail-randomly-run
Name:           pipeline-includes-two-steps-which-fail-randomly-run
Namespace:      default
Pipeline Ref:   pipeline-includes-two-steps-which-fail-randomly

🌡️  Status

STARTED          DURATION     STATUS
42 seconds ago   40 seconds   Failed

💌 Message

TaskRun pipeline-includes-two-steps-which-fail-randomly-run-rando-8r5ck has failed (TaskRun &#34;pipeline-includes-two-steps-which-fail-randomly-run-rando-8r5ck&#34; failed to finish within &#34;20s&#34;)

📦 Resources

 No resources

⚓ Params

 No params

🗂  Taskruns

 NAME                                                                TASK NAME          STARTED          DURATION     STATUS
 ∙ pipeline-includes-two-steps-which-fail-randomly-run-rando-8r5ck   random-failure     42 seconds ago   20 seconds   Failed(TaskRunTimeout)
 ∙ pipeline-includes-two-steps-which-fail-randomly-run-rando-wzjqz   random-failure-2   42 seconds ago   40 seconds   Failed(TaskRunTimeout)
```