### PR TITLE
Fix regular expression parsing to only fail on argo specific variables

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -288,7 +288,7 @@ class TektonCompiler(Compiler) :
     for regex_rule in tekton_var_regex_rules:
       workflow_dump = re.sub(regex_rule['argo_rule'], regex_rule['tekton_rule'], workflow_dump)
 
-    unsupported_vars = re.findall(r"{{[^ \t\n:,;{}]+}}", workflow_dump)
+    unsupported_vars = re.findall(r"{{[^ \t\n.:,;{}]+\.[^ \t\n:,;{}]+}}", workflow_dump)
     if unsupported_vars:
       raise ValueError('These Argo variables are not supported in Tekton Pipeline: %s' % ", ".join(str(v) for v in set(unsupported_vars)))
     workflow = json.loads(workflow_dump)

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -159,6 +159,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.pipeline_transformers import transform_pipeline
     self._test_pipeline_workflow(transform_pipeline, 'pipeline_transformers.yaml')
 
+  def test_katib_workflow(self):
+    """
+    Test compiling a katib workflow.
+    """
+    from .testdata.katib import mnist_hpo
+    self._test_pipeline_workflow(mnist_hpo, 'katib.yaml')
+
   def _test_pipeline_workflow(self, 
                               pipeline_function,
                               pipeline_yaml,

--- a/sdk/python/tests/compiler/testdata/katib.py
+++ b/sdk/python/tests/compiler/testdata/katib.py
@@ -1,0 +1,129 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import kfp.dsl as dsl
+
+@dsl.pipeline(
+    name="Launch katib experiment",
+    description="An example to launch katib experiment."
+)
+def mnist_hpo(
+        name="mnist",
+        namespace="kubeflow",
+        goal=0.99,
+        parallelTrialCount=3,
+        maxTrialCount=12,
+        experimentTimeoutMinutes=60,
+        deleteAfterDone=True):
+    objectiveConfig = {
+      "type": "maximize",
+      "goal": goal,
+      "objectiveMetricName": "Validation-accuracy",
+      "additionalMetricNames": ["accuracy"]
+    }
+    algorithmConfig = {"algorithmName" : "random"}
+    parameters = [
+      {"name": "--lr", "parameterType": "double", "feasibleSpace": {"min": "0.01","max": "0.03"}},
+      {"name": "--num-layers", "parameterType": "int", "feasibleSpace": {"min": "2", "max": "5"}},
+      {"name": "--optimizer", "parameterType": "categorical", "feasibleSpace": {"list": ["sgd", "adam", "ftrl"]}}
+    ]
+    rawTemplate = {
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {
+         "name": "{{.Trial}}",
+         "namespace": "{{.NameSpace}}"
+      },
+      "spec": {
+        "template": {
+          "spec": {
+            "restartPolicy": "Never",
+            "containers": [
+              {"name": "{{.Trial}}",
+               "image": "docker.io/katib/mxnet-mnist-example",
+               "command": [
+                   "python /mxnet/example/image-classification/train_mnist.py --batch-size=64 {{- with .HyperParameters}} {{- range .}} {{.Name}}={{.Value}} {{- end}} {{- end}}"
+               ]
+              }
+            ]
+          }
+        }
+      }
+    }
+    trialTemplate = {
+      "goTemplate": {
+        "rawTemplate": json.dumps(rawTemplate)
+      }
+    }
+    op1 = katib_experiment_launcher_op(
+            name,
+            namespace,
+            parallelTrialCount=parallelTrialCount,
+            maxTrialCount=maxTrialCount,
+            objectiveConfig=str(objectiveConfig),
+            algorithmConfig=str(algorithmConfig),
+            trialTemplate=str(trialTemplate),
+            parameters=str(parameters),
+            experimentTimeoutMinutes=experimentTimeoutMinutes,
+            deleteAfterDone=deleteAfterDone
+    )
+
+    op_out = dsl.ContainerOp(
+        name="my-out-cop",
+        image="library/bash:4.4.23",
+        command=["sh", "-c"],
+        arguments=["echo hyperparameter: %s" % op1.output],
+    )
+
+
+def katib_experiment_launcher_op(
+      name,
+      namespace,
+      maxTrialCount=100,
+      parallelTrialCount=3,
+      maxFailedTrialCount=3,
+      objectiveConfig='{}',
+      algorithmConfig='{}',
+      metricsCollector='{}',
+      trialTemplate='{}',
+      parameters='[]',
+      experimentTimeoutMinutes=60,
+      deleteAfterDone=True,
+      outputFile='/output.txt'):
+    return dsl.ContainerOp(
+        name = "mnist-hpo",
+        image = 'liuhougangxa/katib-experiment-launcher:latest',
+        arguments = [
+            '--name', name,
+            '--namespace', namespace,
+            '--maxTrialCount', maxTrialCount,
+            '--maxFailedTrialCount', maxFailedTrialCount,
+            '--parallelTrialCount', parallelTrialCount,
+            '--objectiveConfig', objectiveConfig,
+            '--algorithmConfig', algorithmConfig,
+            '--metricsCollector', metricsCollector,
+            '--trialTemplate', trialTemplate,
+            '--parameters', parameters,
+            '--outputFile', outputFile,
+            '--deleteAfterDone', deleteAfterDone,
+            '--experimentTimeoutMinutes', experimentTimeoutMinutes,
+        ],
+        file_outputs = {'bestHyperParameter': outputFile}
+    )
+
+if __name__ == '__main__':
+    # don't use top-level import of TektonCompiler to prevent monkey-patching KFP compiler when using KFP's dsl-compile
+    from kfp_tekton.compiler import TektonCompiler
+    TektonCompiler().compile(mnist_hpo, __file__.replace('.py', '.yaml'))

--- a/sdk/python/tests/compiler/testdata/katib.yaml
+++ b/sdk/python/tests/compiler/testdata/katib.yaml
@@ -1,0 +1,141 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mnist-hpo
+spec:
+  params:
+  - name: deleteAfterDone
+  - name: experimentTimeoutMinutes
+  - name: goal
+  - name: maxTrialCount
+  - name: name
+  - name: namespace
+  - name: parallelTrialCount
+  results:
+  - description: /output.txt
+    name: bestHyperParameter
+  steps:
+  - args:
+    - --name
+    - $(inputs.params.name)
+    - --namespace
+    - $(inputs.params.namespace)
+    - --maxTrialCount
+    - $(inputs.params.maxTrialCount)
+    - --maxFailedTrialCount
+    - '3'
+    - --parallelTrialCount
+    - $(inputs.params.parallelTrialCount)
+    - --objectiveConfig
+    - '{''type'': ''maximize'', ''goal'': $(inputs.params.goal), ''objectiveMetricName'':
+      ''Validation-accuracy'', ''additionalMetricNames'': [''accuracy'']}'
+    - --algorithmConfig
+    - '{''algorithmName'': ''random''}'
+    - --metricsCollector
+    - '{}'
+    - --trialTemplate
+    - '{''goTemplate'': {''rawTemplate'': ''{"apiVersion": "batch/v1", "kind": "Job",
+      "metadata": {"name": "{{.Trial}}", "namespace": "{{.NameSpace}}"}, "spec": {"template":
+      {"spec": {"restartPolicy": "Never", "containers": [{"name": "{{.Trial}}", "image":
+      "docker.io/katib/mxnet-mnist-example", "command": ["python /mxnet/example/image-classification/train_mnist.py
+      --batch-size=64 {{- with .HyperParameters}} {{- range .}} {{.Name}}={{.Value}}
+      {{- end}} {{- end}}"]}]}}}}''}}'
+    - --parameters
+    - '[{''name'': ''--lr'', ''parameterType'': ''double'', ''feasibleSpace'': {''min'':
+      ''0.01'', ''max'': ''0.03''}}, {''name'': ''--num-layers'', ''parameterType'':
+      ''int'', ''feasibleSpace'': {''min'': ''2'', ''max'': ''5''}}, {''name'': ''--optimizer'',
+      ''parameterType'': ''categorical'', ''feasibleSpace'': {''list'': [''sgd'',
+      ''adam'', ''ftrl'']}}]'
+    - --outputFile
+    - $(results.bestHyperParameter.path)
+    - --deleteAfterDone
+    - $(inputs.params.deleteAfterDone)
+    - --experimentTimeoutMinutes
+    - $(inputs.params.experimentTimeoutMinutes)
+    image: liuhougangxa/katib-experiment-launcher:latest
+    name: mnist-hpo
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: my-out-cop
+spec:
+  params:
+  - name: mnist-hpo-bestHyperParameter
+  steps:
+  - args:
+    - 'echo hyperparameter: $(inputs.params.mnist-hpo-bestHyperParameter)'
+    command:
+    - sh
+    - -c
+    image: library/bash:4.4.23
+    name: my-out-cop
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "An example to launch katib
+      experiment.", "inputs": [{"default": "mnist", "name": "name", "optional": true},
+      {"default": "kubeflow", "name": "namespace", "optional": true}, {"default":
+      "0.99", "name": "goal", "optional": true}, {"default": "3", "name": "parallelTrialCount",
+      "optional": true}, {"default": "12", "name": "maxTrialCount", "optional": true},
+      {"default": "60", "name": "experimentTimeoutMinutes", "optional": true}, {"default":
+      "True", "name": "deleteAfterDone", "optional": true}], "name": "Launch katib
+      experiment"}'
+  name: launch-katib-experiment
+spec:
+  params:
+  - default: mnist
+    name: name
+  - default: kubeflow
+    name: namespace
+  - default: '0.99'
+    name: goal
+  - default: '3'
+    name: parallelTrialCount
+  - default: '12'
+    name: maxTrialCount
+  - default: '60'
+    name: experimentTimeoutMinutes
+  - default: 'True'
+    name: deleteAfterDone
+  tasks:
+  - name: mnist-hpo
+    params:
+    - name: deleteAfterDone
+      value: $(params.deleteAfterDone)
+    - name: experimentTimeoutMinutes
+      value: $(params.experimentTimeoutMinutes)
+    - name: goal
+      value: $(params.goal)
+    - name: maxTrialCount
+      value: $(params.maxTrialCount)
+    - name: name
+      value: $(params.name)
+    - name: namespace
+      value: $(params.namespace)
+    - name: parallelTrialCount
+      value: $(params.parallelTrialCount)
+    taskRef:
+      name: mnist-hpo
+  - name: my-out-cop
+    params:
+    - name: mnist-hpo-bestHyperParameter
+      value: $(tasks.mnist-hpo.results.bestHyperParameter)
+    taskRef:
+      name: my-out-cop


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
The current regular expression for finding {{variable}} has some conflicts with Katib specific variables as well. Therefore, we need to update the regular expression to only map {{variable.(variable)+}} for Argo specific variables

**Environment tested:**

* Python Version (use `python --version`): 3.6.4
* Tekton Version (use `tkn version`): 0.11
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):
