### PR TITLE
Add support for pulling the image secret

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -388,6 +388,24 @@ class TektonCompiler(Compiler) :
       if pipeline_conf.timeout:
         pipelinerun['spec']['timeout'] = '%ds' % pipeline_conf.timeout
 
+      # generate the Tekton service account template
+      service_template = {}
+      if len(pipeline_conf.image_pull_secrets) > 0:
+        service_template = {
+          'apiVersion': 'v1',
+          'kind': 'ServiceAccount',
+          'metadata': {'name': 'secrets'}
+        }
+        service_template['imagePullSecrets'] = []
+        image_pull_secrets = []
+        for image_pull_secret in pipeline_conf.image_pull_secrets:
+          image_pull_secrets.append(convert_k8s_obj_to_json(image_pull_secret))
+        service_template['imagePullSecrets'] = [{'name': image_pull_secret.name}]
+
+      if service_template:
+        workflow = workflow + [service_template]
+        pipelinerun['spec']['serviceAccountName'] = service_template['metadata']['name']
+
       workflow = workflow + [pipelinerun]
 
     # Use regex to replace all the Argo variables to Tekton variables. For variables that are unique to Argo,

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -396,9 +396,7 @@ class TektonCompiler(Compiler) :
           'kind': 'ServiceAccount',
           'metadata': {'name': 'secrets'}
         }
-      image_pull_secrets = []
       for image_pull_secret in pipeline_conf.image_pull_secrets:
-        image_pull_secrets.append(convert_k8s_obj_to_json(image_pull_secret))
         service_template['imagePullSecrets'] = [{'name': image_pull_secret.name}]
 
       if service_template:

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -394,7 +394,7 @@ class TektonCompiler(Compiler) :
         service_template = {
           'apiVersion': 'v1',
           'kind': 'ServiceAccount',
-          'metadata': {'name': 'secrets'}
+          'metadata': {'name': pipelinerun['metadata']['name'] + '-sa'}
         }
       for image_pull_secret in pipeline_conf.image_pull_secrets:
         service_template['imagePullSecrets'] = [{'name': image_pull_secret.name}]

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -396,10 +396,9 @@ class TektonCompiler(Compiler) :
           'kind': 'ServiceAccount',
           'metadata': {'name': 'secrets'}
         }
-        service_template['imagePullSecrets'] = []
-        image_pull_secrets = []
-        for image_pull_secret in pipeline_conf.image_pull_secrets:
-          image_pull_secrets.append(convert_k8s_obj_to_json(image_pull_secret))
+      image_pull_secrets = []
+      for image_pull_secret in pipeline_conf.image_pull_secrets:
+        image_pull_secrets.append(convert_k8s_obj_to_json(image_pull_secret))
         service_template['imagePullSecrets'] = [{'name': image_pull_secret.name}]
 
       if service_template:

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -165,6 +165,13 @@ class TestTektonCompiler(unittest.TestCase):
     """
     from .testdata.katib import mnist_hpo
     self._test_pipeline_workflow(mnist_hpo, 'katib.yaml')
+    
+  def test_imagepullsecrets_workflow(self):
+    """ 
+    Test compiling a imagepullsecrets workflow.
+    """
+    from .testdata.imagepullsecrets import imagepullsecrets_pipeline
+    self._test_pipeline_workflow(imagepullsecrets_pipeline, 'imagepullsecrets.yaml', generate_pipelinerun=True)
 
   def _test_pipeline_workflow(self, 
                               pipeline_function,

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.py
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.py
@@ -45,7 +45,7 @@ class GetFrequentWordOp(dsl.ContainerOp):
   description='Get Most Frequent Word and Save to GCS'
 )
 # def save_most_frequent_word(message: str):
-def save_most_frequent_word(message="This is testing"):
+def imagepullsecrets_pipeline(message="This is testing"):
   """A pipeline function describing the orchestration of the workflow."""
 
   counter = GetFrequentWordOp(
@@ -58,4 +58,4 @@ def save_most_frequent_word(message="This is testing"):
 if __name__ == '__main__':
   # don't use top-level import of TektonCompiler to prevent monkey-patching KFP compiler when using KFP's dsl-compile
   from kfp_tekton.compiler import TektonCompiler
-  TektonCompiler().compile(save_most_frequent_word, __file__.replace('.py', '.yaml'))
+  TektonCompiler().compile(imagepullsecrets_pipeline, __file__.replace('.py', '.yaml'), generate_pipelinerun=True)

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.py
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2020 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,4 +56,6 @@ def save_most_frequent_word(message="This is testing"):
     .set_image_pull_secrets([k8s_client.V1ObjectReference(name="secretA")])
 
 if __name__ == '__main__':
-  kfp.compiler.Compiler().compile(save_most_frequent_word, __file__ + '.yaml')
+  # don't use top-level import of TektonCompiler to prevent monkey-patching KFP compiler when using KFP's dsl-compile
+  from kfp_tekton.compiler import TektonCompiler
+  TektonCompiler().compile(save_most_frequent_word, __file__.replace('.py', '.yaml'))

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.py
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Toy example demonstrating how to specify imagepullsecrets to access protected
+container registry.
+"""
+
+import kfp
+import kfp.dsl as dsl
+from kubernetes import client as k8s_client
+
+
+class GetFrequentWordOp(dsl.ContainerOp):
+  """A get frequent word class representing a component in ML Pipelines.
+
+  The class provides a nice interface to users by hiding details such as container,
+  command, arguments.
+  """
+  def __init__(self, name, message):
+    """Args:
+         name: An identifier of the step which needs to be unique within a pipeline.
+         message: a dsl.PipelineParam object representing an input message.
+    """
+    super(GetFrequentWordOp, self).__init__(
+        name=name,
+        image='python:3.5-jessie',
+        command=['sh', '-c'],
+        arguments=['python -c "from collections import Counter; '
+                   'words = Counter(\'%s\'.split()); print(max(words, key=words.get))" '
+                   '| tee /tmp/message.txt' % message],
+        file_outputs={'word': '/tmp/message.txt'})
+
+@dsl.pipeline(
+  name='Save Most Frequent',
+  description='Get Most Frequent Word and Save to GCS'
+)
+# def save_most_frequent_word(message: str):
+def save_most_frequent_word(message="This is testing"):
+  """A pipeline function describing the orchestration of the workflow."""
+
+  counter = GetFrequentWordOp(
+          name='get-Frequent',
+          message=message)
+  # Call set_image_pull_secrets after get_pipeline_conf().
+  dsl.get_pipeline_conf()\
+    .set_image_pull_secrets([k8s_client.V1ObjectReference(name="secretA")])
+
+if __name__ == '__main__':
+  kfp.compiler.Compiler().compile(save_most_frequent_word, __file__ + '.yaml')

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: get-frequent
+spec:
+  params:
+  - name: message
+  results:
+  - description: /tmp/message.txt
+    name: word
+  steps:
+  - args:
+    - python -c "from collections import Counter; words = Counter('$(inputs.params.message)'.split());
+      print(max(words, key=words.get))" | tee $(results.word.path)
+    command:
+    - sh
+    - -c
+    image: python:3.5-jessie
+    name: get-frequent
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Get Most Frequent Word
+      and Save to GCS", "inputs": [{"default": "This is testing", "name": "message",
+      "optional": true}], "name": "Save Most Frequent"}'
+  name: save-most-frequent
+spec:
+  params:
+  - default: This is testing
+    name: message
+  tasks:
+  - name: get-frequent
+    params:
+    - name: message
+      value: $(params.message)
+    taskRef:
+      name: get-frequent
+---
+apiVersion: v1
+imagePullSecrets:
+- name: secretA
+kind: ServiceAccount
+metadata:
+  name: test-secrets
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: save-most-frequent-run
+spec:
+  params:
+  - name: message
+    value: This is testing
+  pipelineRef:
+    name: save-most-frequent
+  serviceAccountName: test-secrets

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -57,7 +57,7 @@ imagePullSecrets:
 - name: secretA
 kind: ServiceAccount
 metadata:
-  name: secrets
+  name: save-most-frequent-run-sa
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -69,4 +69,4 @@ spec:
     value: This is testing
   pipelineRef:
     name: save-most-frequent
-  serviceAccountName: secrets
+  serviceAccountName: save-most-frequent-run-sa

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -57,7 +57,7 @@ imagePullSecrets:
 - name: secretA
 kind: ServiceAccount
 metadata:
-  name: test-secrets
+  name: secrets
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -69,4 +69,4 @@ spec:
     value: This is testing
   pipelineRef:
     name: save-most-frequent
-  serviceAccountName: test-secrets
+  serviceAccountName: secrets


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 

Related #54 
**Description of your changes:**
We need image pull secret so that we can pull images from private repo. kfp-tekton compiler will generated Tekton pipeline based on the kubeflow pipeline DSL, if the DSL contains image secret, the compiler will generate a service account, and store the secret under the service account. A better approach will be adding the image pull secret into a podtemplate, but currently Tekton doesn't have this support. We opened an issue [2339](https://github.com/tektoncd/pipeline/issues/2339) there.
**Environment tested:**

* Python Version (use `python --version`):
Python 3.7.4
* Tekton Version (use `tkn version`):
Client version: 0.8.0
Pipeline version: v0.11.0-rc2
* Kubernetes Version (use `kubectl version`):

Openshift Client Version: v4.3.1
Kubernetes Version: v1.16.2

* OS (e.g. from `/etc/os-release`):
macOS Mojave 10.14.6