### PR TITLE
Fix edge cases such as disable istio-inject for Tekton compiler

### DIFF
--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -226,18 +226,7 @@ class TestTektonCompiler(unittest.TestCase):
     golden_yaml_file = os.path.join(test_data_dir, pipeline_yaml)
     temp_dir = tempfile.mkdtemp()
     compiled_yaml_file = os.path.join(temp_dir, 'workflow.yaml')
-    try:
-      compiler.TektonCompiler().compile(pipeline_function,
-                                        compiled_yaml_file,
-                                        generate_pipelinerun=generate_pipelinerun,
-                                        enable_artifacts=enable_artifacts)
-      with open(compiled_yaml_file, 'r') as f:
-        f = normalize_compiler_output_function(
-          f.read()) if normalize_compiler_output_function else f
-        compiled = list(yaml.safe_load_all(f))
-      if GENERATE_GOLDEN_YAML:
-        with open(golden_yaml_file, 'w') as f:
-          f.write(textwrap.dedent("""\
+    license_header = textwrap.dedent("""\
                                   # Copyright 2020 kubeflow.org
                                   #
                                   # Licensed under the Apache License, Version 2.0 (the "License");
@@ -252,7 +241,19 @@ class TestTektonCompiler(unittest.TestCase):
                                   # See the License for the specific language governing permissions and
                                   # limitations under the License.
 
-                                  """))
+                                  """)
+    try:
+      compiler.TektonCompiler().compile(pipeline_function,
+                                        compiled_yaml_file,
+                                        generate_pipelinerun=generate_pipelinerun,
+                                        enable_artifacts=enable_artifacts)
+      with open(compiled_yaml_file, 'r') as f:
+        f = normalize_compiler_output_function(
+          f.read()) if normalize_compiler_output_function else f
+        compiled = list(yaml.safe_load_all(f))
+      if GENERATE_GOLDEN_YAML:
+        with open(golden_yaml_file, 'w') as f:
+          f.write(license_header)
         with open(golden_yaml_file, 'a+') as f:
           yaml.dump_all(compiled, f, default_flow_style=False)
       else:

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -18,6 +18,7 @@ import tempfile
 import unittest
 import yaml
 import re
+import textwrap
 
 from kfp_tekton import compiler
 
@@ -236,6 +237,23 @@ class TestTektonCompiler(unittest.TestCase):
         compiled = list(yaml.safe_load_all(f))
       if GENERATE_GOLDEN_YAML:
         with open(golden_yaml_file, 'w') as f:
+          f.write(textwrap.dedent("""\
+                                  # Copyright 2020 kubeflow.org
+                                  #
+                                  # Licensed under the Apache License, Version 2.0 (the "License");
+                                  # you may not use this file except in compliance with the License.
+                                  # You may obtain a copy of the License at
+                                  #
+                                  #      http://www.apache.org/licenses/LICENSE-2.0
+                                  #
+                                  # Unless required by applicable law or agreed to in writing, software
+                                  # distributed under the License is distributed on an "AS IS" BASIS,
+                                  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                  # See the License for the specific language governing permissions and
+                                  # limitations under the License.
+
+                                  """))
+        with open(golden_yaml_file, 'a+') as f:
           yaml.dump_all(compiled, f, default_flow_style=False)
       else:
         with open(golden_yaml_file, 'r') as f:

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -27,6 +27,24 @@ from kfp_tekton import compiler
 # in order to generate new "golden" YAML files
 GENERATE_GOLDEN_YAML = False
 
+# License header for Kubeflow project
+LICENSE_HEADER = textwrap.dedent("""\
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""")
+
 
 class TestTektonCompiler(unittest.TestCase):
 
@@ -226,22 +244,6 @@ class TestTektonCompiler(unittest.TestCase):
     golden_yaml_file = os.path.join(test_data_dir, pipeline_yaml)
     temp_dir = tempfile.mkdtemp()
     compiled_yaml_file = os.path.join(temp_dir, 'workflow.yaml')
-    license_header = textwrap.dedent("""\
-                                  # Copyright 2020 kubeflow.org
-                                  #
-                                  # Licensed under the Apache License, Version 2.0 (the "License");
-                                  # you may not use this file except in compliance with the License.
-                                  # You may obtain a copy of the License at
-                                  #
-                                  #      http://www.apache.org/licenses/LICENSE-2.0
-                                  #
-                                  # Unless required by applicable law or agreed to in writing, software
-                                  # distributed under the License is distributed on an "AS IS" BASIS,
-                                  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                  # See the License for the specific language governing permissions and
-                                  # limitations under the License.
-
-                                  """)
     try:
       compiler.TektonCompiler().compile(pipeline_function,
                                         compiled_yaml_file,
@@ -253,7 +255,7 @@ class TestTektonCompiler(unittest.TestCase):
         compiled = list(yaml.safe_load_all(f))
       if GENERATE_GOLDEN_YAML:
         with open(golden_yaml_file, 'w') as f:
-          f.write(license_header)
+          f.write(LICENSE_HEADER)
         with open(golden_yaml_file, 'a+') as f:
           yaml.dump_all(compiled, f, default_flow_style=False)
       else:

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -29,6 +29,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with affinity",
       "name": "affinity"}'
+    sidecar.istio.io/inject: 'false'
   name: affinity
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/artifact_location.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_location.yaml
@@ -57,10 +57,14 @@ spec:
           name: $(inputs.params.secret_name)
     image: minio/mc
     name: copy-artifacts
-    script: |-
-      #!/usr/bin/env sh
-      mc config host add storage http://minio-service.$(inputs.params.namespace):9000 $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
+    script: '#!/usr/bin/env sh
+
+      mc config host add storage http://minio-service.$(inputs.params.namespace):9000
+      $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
+
       mc cp $(results.output.path) storage/$(inputs.params.bucket)/runs/$PIPELINERUN/$PODNAME/output.txt
+
+      '
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
@@ -74,6 +78,7 @@ metadata:
       true, "type": "String"}, {"default": "kubeflow", "name": "namespace", "optional":
       true, "type": "String"}, {"default": "mlpipeline", "name": "bucket", "optional":
       true, "type": "String"}], "name": "custom_artifact_location_pipeline"}'
+    sidecar.istio.io/inject: 'false'
   name: custom-artifact-location-pipeline
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/condition.yaml
+++ b/sdk/python/tests/compiler/testdata/condition.yaml
@@ -136,6 +136,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use dsl.Condition.",
       "name": "pipeline flip coin"}'
+    sidecar.istio.io/inject: 'false'
   name: pipeline-flip-coin
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
+++ b/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
@@ -34,10 +34,13 @@ spec:
     name: download-file
   - image: busybox
     name: copy-results
-    script: |
-      #!/bin/sh
+    script: '#!/bin/sh
+
       set -exo pipefail
+
       cp /tmp/results.txt $(results.data.path);
+
+      '
   volumes:
   - emptyDir: {}
     name: data
@@ -65,6 +68,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Run a script that passes
       file to a non configurable path", "name": "Hidden output file pipeline"}'
+    sidecar.istio.io/inject: 'false'
   name: hidden-output-file-pipeline
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -39,6 +39,7 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Get Most Frequent Word
       and Save to GCS", "inputs": [{"default": "This is testing", "name": "message",
       "optional": true}], "name": "Save Most Frequent"}'
+    sidecar.istio.io/inject: 'false'
   name: save-most-frequent
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/init_container.yaml
+++ b/sdk/python/tests/compiler/testdata/init_container.yaml
@@ -35,6 +35,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with init container.",
       "name": "InitContainer"}'
+    sidecar.istio.io/inject: 'false'
   name: initcontainer
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -24,10 +24,13 @@ spec:
   steps:
   - image: busybox
     name: copy-inputs
-    script: |
-      #!/bin/sh
+    script: '#!/bin/sh
+
       set -exo pipefail
+
       echo -n "Constant artifact value" > /tmp/inputs/text/data
+
+      '
   - command:
     - cat
     - /tmp/inputs/text/data
@@ -49,10 +52,13 @@ spec:
   steps:
   - image: busybox
     name: copy-inputs
-    script: |
-      #!/bin/sh
+    script: '#!/bin/sh
+
       set -exo pipefail
+
       echo -n "Constant artifact value" > /tmp/inputs/text/data
+
+      '
   - command:
     - cat
     - /tmp/inputs/text/data
@@ -74,10 +80,13 @@ spec:
   steps:
   - image: busybox
     name: copy-inputs
-    script: |
-      #!/bin/sh
+    script: '#!/bin/sh
+
       set -exo pipefail
+
       echo -n "hard-coded artifact value" > /tmp/inputs/text/data
+
+      '
   - command:
     - cat
     - /tmp/inputs/text/data
@@ -99,11 +108,15 @@ spec:
   steps:
   - image: busybox
     name: copy-inputs
-    script: |
-      #!/bin/sh
+    script: '#!/bin/sh
+
       set -exo pipefail
+
       echo -n "Text from a file with hard-coded artifact value
+
       " > /tmp/inputs/text/data
+
+      '
   - command:
     - cat
     - /tmp/inputs/text/data
@@ -120,6 +133,7 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline shows how to
       define artifact inputs and pass raw artifacts to them.", "name": "Pipeline with
       artifact input raw argument value."}'
+    sidecar.istio.io/inject: 'false'
   name: pipeline-with-artifact-input-raw-argument-value
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/katib.yaml
+++ b/sdk/python/tests/compiler/testdata/katib.yaml
@@ -97,6 +97,7 @@ metadata:
       {"default": "60", "name": "experimentTimeoutMinutes", "optional": true}, {"default":
       "True", "name": "deleteAfterDone", "optional": true}], "name": "Launch katib
       experiment"}'
+    sidecar.istio.io/inject: 'false'
   name: launch-katib-experiment
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/loop_static.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static.yaml
@@ -67,6 +67,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "my_pipe_param",
       "optional": true}], "name": "my-pipeline"}'
+    sidecar.istio.io/inject: 'false'
   name: my-pipeline
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -29,6 +29,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with Node Selector",
       "name": "node_selector"}'
+    sidecar.istio.io/inject: 'false'
   name: node-selector
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/parallel_join.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join.yaml
@@ -81,6 +81,7 @@ metadata:
       in parallel and prints the concatenated result.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url1", "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
       "name": "url2", "optional": true}], "name": "Parallel pipeline"}'
+    sidecar.istio.io/inject: 'false'
   name: parallel-pipeline
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/parallel_join_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_pipelinerun.yaml
@@ -81,6 +81,7 @@ metadata:
       in parallel and prints the concatenated result.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url1", "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
       "name": "url2", "optional": true}], "name": "Parallel pipeline"}'
+    sidecar.istio.io/inject: 'false'
   name: parallel-pipeline
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
@@ -68,6 +82,7 @@ metadata:
       [{"default": "gs://ml-pipeline-playground/shakespeare1.txt", "name": "url1",
       "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
       "name": "url2", "optional": true}], "name": "Parallel pipeline with argo vars"}'
+    sidecar.istio.io/inject: 'false'
   name: parallel-pipeline-with-argo-vars
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
@@ -51,6 +51,7 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline shows how
       to apply functions to all ops in the pipeline by pipeline transformers", "name":
       "Pipeline transformer"}'
+    sidecar.istio.io/inject: 'false'
   name: pipeline-transformer
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/pipelineparams.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.yaml
@@ -64,6 +64,7 @@ metadata:
       pipeline params.", "inputs": [{"default": "latest", "name": "tag", "optional":
       true, "type": "String"}, {"default": "10", "name": "sleep_ms", "optional": true,
       "type": "Integer"}], "name": "PipelineParams"}'
+    sidecar.istio.io/inject: 'false'
   name: pipelineparams
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -73,6 +73,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A Basic Example on ResourceOp
       Usage.", "name": "ResourceOp Basic"}'
+    sidecar.istio.io/inject: 'false'
   name: resourceop-basic
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/retry.yaml
+++ b/sdk/python/tests/compiler/testdata/retry.yaml
@@ -51,6 +51,7 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline includes
       two steps which fail randomly. It shows how to use ContainerOp(...).set_retry(...).",
       "name": "Retry random failures"}'
+    sidecar.istio.io/inject: 'false'
   name: retry-random-failures
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/sequential.yaml
+++ b/sdk/python/tests/compiler/testdata/sequential.yaml
@@ -55,6 +55,7 @@ metadata:
       steps.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url", "optional": true}, {"default": "/tmp/results.txt", "name": "path",
       "optional": true}], "name": "Sequential pipeline"}'
+    sidecar.istio.io/inject: 'false'
   name: sequential-pipeline
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/sidecar.yaml
+++ b/sdk/python/tests/compiler/testdata/sidecar.yaml
@@ -56,6 +56,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with sidecars.",
       "name": "Sidecar"}'
+    sidecar.istio.io/inject: 'false'
   name: sidecar
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use ContainerOp
       set_timeout().", "name": "pipeline includes two steps which fail randomly."}'
+    sidecar.istio.io/inject: 'false'
   name: pipeline-includes-two-steps-which-fail-randomly
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use ContainerOp
       set_timeout().", "name": "pipeline includes two steps which fail randomly."}'
+    sidecar.istio.io/inject: 'false'
   name: pipeline-includes-two-steps-which-fail-randomly
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -35,6 +35,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with tolerations",
       "name": "tolerations"}'
+    sidecar.istio.io/inject: 'false'
   name: tolerations
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/volume.yaml
+++ b/sdk/python/tests/compiler/testdata/volume.yaml
@@ -63,6 +63,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with volume.",
       "name": "Volume"}'
+    sidecar.istio.io/inject: 'false'
   name: volume
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/volume_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_op.yaml
@@ -102,6 +102,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A Basic Example on VolumeOp
       Usage.", "inputs": [{"name": "size"}], "name": "VolumeOp Basic"}'
+    sidecar.istio.io/inject: 'false'
   name: volumeop-basic
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
@@ -355,6 +355,7 @@ metadata:
       the design doc. Please enable the\n    volume snapshot feature gate in order
       to run this pipeline.", "inputs": [{"name": "url"}], "name": "VolumeSnapshotOp
       Sequential"}'
+    sidecar.istio.io/inject: 'false'
   name: volumesnapshotop-sequential
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -86,6 +86,7 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "my_pipe_param",
       "optional": true, "type": "Integer"}], "name": "my-pipeline"}'
+    sidecar.istio.io/inject: 'false'
   name: my-pipeline
 spec:
   params:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #114 

**Description of your changes:**
- Add new annotation to disable istio-inject
- Remove literal string conversion for pyyaml since there could be conflicts with yaml 1.1 and 1.2 on some [edge cases](https://github.com/yaml/pyyaml/issues/98). If we want this feature back then we have to use ruamel.yaml. We are using pyyaml right now because we need to be consistent with the kfp package. 
- Add headers to golden test yaml
- Fix minor syntax bugs

**Environment tested:**

* Python Version (use `python --version`): 3.6.4
* Tekton Version (use `tkn version`): 0.11.3
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):
