### PR TITLE
Reinstate Tommy and Christian as reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,8 @@ approvers:
  - ckadner
  - Tomcli
 reviewers:
+ - ckadner
+ - Tomcli
  - afrittoli
  - jinchihe
  - fenglixa


### PR DESCRIPTION
Since @Tomcli and @ckadner were promoted to project `approvers` they no longer are added as (suggested) reviewers to pull requests and hence won't get notified for new PRs (unless watching all repository events). 

Since project `approvers` can also `reviewers`, I suggest reinstating `Tomcli` and `ckadner` as `reviewers` as well.