### PR TITLE
Minor fixes for markdown, headers, and warnings.

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,7 +1,7 @@
 # KFP Tekton Samples
 
 Below are the list of samples that are currently running end to end taking the compiled Tekton yaml and deploying on a Tekton cluster directly. 
-If you are interested more in the larger list of pipelines samples we are testing for whether they can be 'compiled to Tekton' format, please [look at the corresponding status page](/sdk//python/tests/README.md)
+If you are interested more in the larger list of pipelines samples we are testing for whether they can be 'compiled to Tekton' format, please [look at the corresponding status page](/sdk/python/tests/README.md)
 
 + [MNIST End to End example with Kubeflow components](/samples/e2e-mnist)
 + [Hyperparameter tuning using Katib](/samples/katib)

--- a/samples/trusted-ai/README.md
+++ b/samples/trusted-ai/README.md
@@ -25,7 +25,7 @@ kubectl apply -f trusted-ai.yaml -n anonymous
 
 3. Run the trusted-ai pipeline, click the `enter` key to use the default pipeline variables.
 ```shell
-tkn pipeline start launch-katib-experiment -s default-editor -n anonymous --showlog
+tkn pipeline start launch-trusted-ai-pipeline -s default-editor -n anonymous --showlog
 ```
 
 This pipeline will run for 10 to 15 minutes, then you should able to see the best hyperparameter tuning result at the end of the logs.

--- a/samples/watson-train-serve/README.md
+++ b/samples/watson-train-serve/README.md
@@ -23,8 +23,10 @@ kubectl apply -f watson-train-server.yaml
 2. If your default service account dosn't have edit permission, follow this [sa-and-rbac](/sdk/sa-and-rbac.md) to setup.
 
 3. Run the kfp-on-wml-training pipeline, click the `enter` key to use the default pipeline variables except for these two variables,
-`GITHUB_TOKEN`: your github token
-`CONFIG_FILE_URL`: your configuration file which stores the credential information, here is the example of [creds.ini file](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/ibm-samples/watson/credentials/creds.ini) 
+
+    `GITHUB_TOKEN`: your github token
+
+    `CONFIG_FILE_URL`: your configuration file which stores the credential information, here is the example of [creds.ini file](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/ibm-samples/watson/credentials/creds.ini) 
 
 ```shell
 tkn pipeline start kfp-on-wml-training --showlog

--- a/sdk/FEATURES.md
+++ b/sdk/FEATURES.md
@@ -1,6 +1,6 @@
 # KFP Tekton compiler features
 
-Below are the list of features that are currently avaliable in the KFP Tekton compiler along with its implementation. With the current implementation, we are getting a greater than [80% success rate for compilation tests we are running over approximately 90 pipelines](/sdk//python/tests/README.md) spread across different parts of the Kubeflow Pipeline samples and tests. 
+Below are the list of features that are currently avaliable in the KFP Tekton compiler along with its implementation. With the current implementation, we are getting a greater than [80% success rate for compilation tests we are running over approximately 90 pipelines](/sdk/python/tests/README.md) spread across different parts of the Kubeflow Pipeline samples and tests. 
 
 - [Pipeline DSL features with native Tekton implementation](#pipeline-dsl-features-with-native-tekton-implementation)
     + [pod_annotations and pod_labels](#pod_annotations-and-pod_labels)

--- a/sdk/FEATURES.md
+++ b/sdk/FEATURES.md
@@ -1,6 +1,6 @@
 # KFP Tekton compiler features
 
-Below are the list of features that are currently avaliable in the KFP Tekton compiler along with its implementation. With the current implementation, we are getting a greater than [80% success rate for compilation tests we are running over approximately 90 pipelines](/sdk/python/tests/README.md) spread across different parts of the Kubeflow Pipeline samples and tests. 
+Below are the list of features that are currently available in the KFP Tekton compiler along with its implementation. With the current implementation, we are getting a greater than [80% success rate for compilation tests we are running over approximately 90 pipelines](/sdk/python/tests/README.md) spread across different parts of the Kubeflow Pipeline samples and tests. 
 
 - [Pipeline DSL features with native Tekton implementation](#pipeline-dsl-features-with-native-tekton-implementation)
     + [pod_annotations and pod_labels](#pod_annotations-and-pod_labels)

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -129,7 +129,6 @@ class TektonCompiler(Compiler) :
         if task_name is None:
           return '$(params.%s)' % parameter_name
         else:
-          logging.warning("Warning: Using parameter passing from task outputs to condition parameters requires running the pipeline on Tekton built from the master branch")
           return '$(params.%s)' % task_name
       else:
         return '$(params.%s)' % parameter_name

--- a/sdk/python/tests/compiler/testdata/parallel_join.py
+++ b/sdk/python/tests/compiler/testdata/parallel_join.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2020 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.py
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2020 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/python/tests/compiler/testdata/sequential.py
+++ b/sdk/python/tests/compiler/testdata/sequential.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2020 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/python/tests/test_util.py
+++ b/sdk/python/tests/test_util.py
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright 2020 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
- Minor fixes for markdown format and typo
- Remove python usr/bin headers for consistency
- Remove conditional warnings since we no longer need master build for this feature.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):
