### PR TITLE
Update to use taskRunSpec for podTemplate spec. 

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -308,19 +308,18 @@ class TektonCompiler(Compiler) :
       }
     }
 
-    # Generate PodTemplate
-    pod_template = {}
+    task_run_spec = []
     for task in task_refs:
       op = pipeline.ops.get(task['name'])
+      task_spec = {"pipelineTaskName":task['name'], "taskPodTemplate": {}}
       if op.affinity:
-        pod_template['affinity'] = convert_k8s_obj_to_json(op.affinity)
+        task_spec["taskPodTemplate"]["affinity"] = op.affinity
       if op.tolerations:
-        pod_template['tolerations'] = pod_template.get('tolerations', []) + op.tolerations
+        task_spec["taskPodTemplate"]['tolerations'] = op.tolerations
       if op.node_selector:
-        pod_template['nodeSelector'] = op.node_selector
-
-    if pod_template:
-      pipelinerun['spec']['podtemplate'] = pod_template
+        task_spec["taskPodTemplate"]['nodeSelector'] = op.node_selector
+      task_run_spec.append(task_spec)
+    pipelinerun['spec']['taskRunSpec'] = task_run_spec
 
     # add workflow level timeout to pipeline run
     if pipeline.conf.timeout:

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -313,13 +313,15 @@ class TektonCompiler(Compiler) :
       op = pipeline.ops.get(task['name'])
       task_spec = {"pipelineTaskName":task['name'], "taskPodTemplate": {}}
       if op.affinity:
-        task_spec["taskPodTemplate"]["affinity"] = op.affinity
+        task_spec["taskPodTemplate"]["affinity"] = convert_k8s_obj_to_json(op.affinity)
       if op.tolerations:
         task_spec["taskPodTemplate"]['tolerations'] = op.tolerations
       if op.node_selector:
         task_spec["taskPodTemplate"]['nodeSelector'] = op.node_selector
-      task_run_spec.append(task_spec)
-    pipelinerun['spec']['taskRunSpec'] = task_run_spec
+      if bool(task_spec["taskPodTemplate"]):
+        task_run_spec.append(task_spec)
+    if len(task_run_spec) > 0:
+      pipelinerun['spec']['taskRunSpec'] = task_run_spec
 
     # add workflow level timeout to pipeline run
     if pipeline.conf.timeout:

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -312,7 +312,8 @@ class TektonCompiler(Compiler) :
     task_run_spec = []
     for task in task_refs:
       op = pipeline.ops.get(task['name'])
-      task_spec = {"pipelineTaskName":task['name'], "taskPodTemplate": {}}
+      task_spec = {"pipelineTaskName": task['name'], 
+                   "taskPodTemplate": {}}
       if op.affinity:
         task_spec["taskPodTemplate"]["affinity"] = convert_k8s_obj_to_json(op.affinity)
       if op.tolerations:

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -307,7 +307,8 @@ class TektonCompiler(Compiler) :
         }
       }
     }
-
+    
+    # Generate TaskRunSpec PodTemplate:s
     task_run_spec = []
     for task in task_refs:
       op = pipeline.ops.get(task['name'])

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -1,17 +1,3 @@
-# Copyright 2020 kubeflow.org
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
@@ -47,13 +33,15 @@ spec:
   params: []
   pipelineRef:
     name: affinity
-  podtemplate:
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-          - matchExpressions:
-            - key: beta.kubernetes.io/instance-type
-              operator: In
-              values:
-              - p2.xlarge
+  taskRunSpec:
+  - pipelineTaskName: sleep
+    taskPodTemplate:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/instance-type
+                operator: In
+                values:
+                - p2.xlarge

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -1,3 +1,4 @@
+# Copyright 2020 kubeflow.org
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -1,4 +1,17 @@
 # Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -47,6 +47,8 @@ spec:
   params: []
   pipelineRef:
     name: node-selector
-  podtemplate:
-    nodeSelector:
-      accelerator: nvidia-tesla-k80
+  taskRunSpec:
+  - pipelineTaskName: sleep
+    taskPodTemplate:
+      nodeSelector:
+        accelerator: nvidia-tesla-k80

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -53,9 +53,11 @@ spec:
   params: []
   pipelineRef:
     name: tolerations
-  podtemplate:
-    tolerations:
-    - effect: NoSchedule
-      key: gpu
-      operator: Equal
-      value: run
+  taskRunSpec:
+  - pipelineTaskName: download
+    taskPodTemplate:
+      tolerations:
+      - effect: NoSchedule
+        key: gpu
+        operator: Equal
+        value: run


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
This PR tries to resolve: https://github.com/kubeflow/kfp-tekton/issues/146 by using the taskRunSpec instead allowing for settings on task level. 

This PR replicates the usage with taskRun podTemplate spec. However the taskRunSpec also allow for further settings on task level. 

**Description of your changes:**
Update to use taskRunSpec podtemplate. Also update the tests to represent the new implementation. 

**Environment tested:**
python version 3.7 is used for testing. 
* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):
