### PR TITLE
Rename main step name to "main"

### DIFF
--- a/sdk/FEATURES.md
+++ b/sdk/FEATURES.md
@@ -9,6 +9,7 @@ Below are the list of features that are currently available in the KFP Tekton co
     + [Timeout for Tasks and Pipelines](#timeout-for-tasks-and-pipelines)
     + [RunAfter](#runafter)
     + [Input Parameters](#input-parameters)
+    + [ContainerOp](#containerop)
 - [Pipeline DSL features with custom Tekton implementation](#pipeline-dsl-features-with-custom-tekton-implementation)
   * [Features with same behavior as Argo](#features-with-same-behavior-as-argo)
     + [InitContainers](#initcontainers)
@@ -67,6 +68,12 @@ Input Parameters are for passing pipeline parameters or other component outputs 
 with Tekton's [parameters](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md#specifying-parameters) features under Tekton
 task. The [parallel_join](/sdk/python/tests/compiler/testdata/parallel_join.py) python test is an example of how to use this
 feature.
+
+### ContainerOp
+ContainerOp defines the container spec for a pipeline component. It is implemented with Tekton's
+[steps](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md#defining-steps) features under Tekton task. The generated 
+Tekton task name is the same as the containerOp name whereas the step name is always called "main". The
+[sequential](/sdk/python/tests/compiler/testdata/sequential.py) python test is an example of how to use this feature.
 
 # Pipeline DSL features with custom Tekton implementation
 ## Features with same behavior as Argo

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -402,7 +402,8 @@ def _op_to_template(op: BaseOp, enable_artifacts=False):
             processed_op.container
         )
 
-        step = {'name': processed_op.name}
+        # Calling containerOp step as "main" to align with Argo
+        step = {'name': "main"}
         step.update(container)
 
         template = {

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -127,7 +127,7 @@ def _get_resourceOp_template(op: BaseOp,
                         "--set-ownerreference=$(params.set-ownerreference)"
                     ],
                     "image": "$(params.image)",
-                    "name": name,
+                    "name": "main",
                     "resources": {}
                 }
             ]

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -21,7 +21,7 @@ spec:
   - command:
     - sleep 1
     image: busybox
-    name: sleep
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/artifact_location.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_location.yaml
@@ -31,7 +31,7 @@ spec:
     - -c
     - echo hello > $(results.output.path)
     image: busybox:$(inputs.params.tag)
-    name: generate-output
+    name: main
   - env:
     - name: PIPELINERUN
       valueFrom:

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -24,7 +24,7 @@ spec:
     - sh
     - -c
     image: python:3.5-jessie
-    name: exiting
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -44,7 +44,7 @@ spec:
     - sh
     - -c
     image: python:3.5-jessie
-    name: get-frequent
+    name: main
     resources:
       requests:
         memory: 200M
@@ -67,7 +67,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk
-    name: save
+    name: main
     resources:
       limits:
         cloud-tpus.google.com/v2: '8'

--- a/sdk/python/tests/compiler/testdata/compose.yaml
+++ b/sdk/python/tests/compiler/testdata/compose.yaml
@@ -29,7 +29,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk
-    name: download
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -49,7 +49,7 @@ spec:
     - sh
     - -c
     image: python:3.5-jessie
-    name: get-frequent
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -67,7 +67,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk
-    name: save
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/condition.yaml
+++ b/sdk/python/tests/compiler/testdata/condition.yaml
@@ -82,7 +82,7 @@ spec:
     - sh
     - -c
     image: python:alpine3.6
-    name: flip
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -100,7 +100,7 @@ spec:
     - sh
     - -c
     image: python:alpine3.6
-    name: flip-again
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -114,7 +114,7 @@ spec:
     - echo
     - $(inputs.params.flip-again-output)
     image: alpine:3.6
-    name: print1
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -128,7 +128,7 @@ spec:
     - echo
     - $(inputs.params.flip-again-output)
     image: alpine:3.6
-    name: print2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
+++ b/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
@@ -31,7 +31,7 @@ spec:
     command:
     - /bin/bash
     image: aipipeline/echo-text:latest
-    name: download-file
+    name: main
   - image: busybox
     name: copy-results
     script: '#!/bin/sh
@@ -60,7 +60,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: echo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -30,7 +30,7 @@ spec:
     - sh
     - -c
     image: python:3.5-jessie
-    name: get-frequent
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/init_container.yaml
+++ b/sdk/python/tests/compiler/testdata/init_container.yaml
@@ -27,7 +27,7 @@ spec:
     - echo
     - hello
     image: alpine:latest
-    name: hello
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -35,7 +35,7 @@ spec:
     - cat
     - /tmp/inputs/text/data
     image: alpine
-    name: component-with-inline-input-artifact
+    name: main
   volumes:
   - emptyDir: {}
     name: text
@@ -63,7 +63,7 @@ spec:
     - cat
     - /tmp/inputs/text/data
     image: alpine
-    name: component-with-input-artifact
+    name: main
   volumes:
   - emptyDir: {}
     name: text
@@ -91,7 +91,7 @@ spec:
     - cat
     - /tmp/inputs/text/data
     image: alpine
-    name: component-with-input-artifact-2
+    name: main
   volumes:
   - emptyDir: {}
     name: text
@@ -121,7 +121,7 @@ spec:
     - cat
     - /tmp/inputs/text/data
     image: alpine
-    name: component-with-input-artifact-3
+    name: main
   volumes:
   - emptyDir: {}
     name: text

--- a/sdk/python/tests/compiler/testdata/katib.yaml
+++ b/sdk/python/tests/compiler/testdata/katib.yaml
@@ -67,7 +67,7 @@ spec:
     - --experimentTimeoutMinutes
     - $(inputs.params.experimentTimeoutMinutes)
     image: liuhougangxa/katib-experiment-launcher:latest
-    name: mnist-hpo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -83,7 +83,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: my-out-cop
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/loop_static.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static.yaml
@@ -27,7 +27,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: my-in-coop1
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -43,7 +43,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: my-in-coop2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -59,7 +59,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: my-out-cop
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -21,7 +21,7 @@ spec:
   - command:
     - sleep 1
     image: busybox
-    name: sleep
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/parallel_join.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join.yaml
@@ -31,7 +31,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk:279.0.0
-    name: gcs-download
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -52,7 +52,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk:279.0.0
-    name: gcs-download-2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -71,7 +71,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: echo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/parallel_join_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_pipelinerun.yaml
@@ -31,7 +31,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk:279.0.0
-    name: gcs-download
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -52,7 +52,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk:279.0.0
-    name: gcs-download-2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -71,7 +71,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: echo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
@@ -31,7 +31,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk:279.0.0
-    name: gcs-download
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -52,7 +52,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk:279.0.0
-    name: gcs-download-2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -71,7 +71,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: echo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
@@ -26,7 +26,7 @@ spec:
     - echo
     - hey, what are you up to?
     image: alpine:3.6
-    name: print
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -42,7 +42,7 @@ spec:
     - echo
     - train my model.
     image: alpine:3.6
-    name: print-2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/pipelineparams.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.yaml
@@ -35,7 +35,7 @@ spec:
     - sh
     - -c
     image: busybox:$(inputs.params.tag)
-    name: download
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -54,7 +54,7 @@ spec:
     - name: MSG
       value: 'pipelineParams: '
     image: library/bash
-    name: echo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -64,7 +64,7 @@ spec:
     - --failure-condition=$(params.failure-condition)
     - --set-ownerreference=$(params.set-ownerreference)
     image: $(params.image)
-    name: test-step
+    name: main
     resources: {}
 ---
 apiVersion: tekton.dev/v1beta1

--- a/sdk/python/tests/compiler/testdata/retry.yaml
+++ b/sdk/python/tests/compiler/testdata/retry.yaml
@@ -26,7 +26,7 @@ spec:
     - python
     - -c
     image: python:alpine3.6
-    name: random-failure
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -42,7 +42,7 @@ spec:
     - python
     - -c
     image: python:alpine3.6
-    name: random-failure-2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/sequential.yaml
+++ b/sdk/python/tests/compiler/testdata/sequential.yaml
@@ -28,7 +28,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk:216.0.0
-    name: gcs-download
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -45,7 +45,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: echo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/sidecar.yaml
+++ b/sdk/python/tests/compiler/testdata/sidecar.yaml
@@ -32,7 +32,7 @@ spec:
     - sh
     - -c
     image: busybox
-    name: download
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -48,7 +48,7 @@ spec:
     - sh
     - -c
     image: library/bash
-    name: echo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout.yaml
@@ -25,7 +25,7 @@ spec:
     - python
     - -c
     image: python:alpine3.6
-    name: random-failure
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -40,7 +40,7 @@ spec:
     - python
     - -c
     image: python:alpine3.6
-    name: random-failure-2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
@@ -25,7 +25,7 @@ spec:
     - python
     - -c
     image: python:alpine3.6
-    name: random-failure
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -40,7 +40,7 @@ spec:
     - python
     - -c
     image: python:alpine3.6
-    name: random-failure-2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -27,7 +27,7 @@ spec:
     - sh
     - -c
     image: busybox
-    name: download
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/volume.yaml
+++ b/sdk/python/tests/compiler/testdata/volume.yaml
@@ -32,7 +32,7 @@ spec:
     - name: Foo
       value: bar
     image: google/cloud-sdk
-    name: download
+    name: main
     volumeMounts:
     - mountPath: /secret/gcp-credentials
       name: gcp-credentials
@@ -55,7 +55,7 @@ spec:
     - sh
     - -c
     image: library/bash
-    name: echo
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/sdk/python/tests/compiler/testdata/volume_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_op.yaml
@@ -70,7 +70,7 @@ spec:
         fieldRef:
           fieldPath: metadata.labels['tekton.dev/pipelineRun']
     image: $(params.image)
-    name: create-pvc
+    name: main
     resources: {}
 ---
 apiVersion: tekton.dev/v1beta1

--- a/sdk/python/tests/compiler/testdata/volume_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_op.yaml
@@ -87,7 +87,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: cop
+    name: main
     volumeMounts:
     - mountPath: /mnt
       name: create-pvc

--- a/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
@@ -69,7 +69,7 @@ spec:
         fieldRef:
           fieldPath: metadata.labels['tekton.dev/pipelineRun']
     image: $(params.image)
-    name: create-volume
+    name: main
     resources: {}
 ---
 apiVersion: tekton.dev/v1beta1
@@ -154,7 +154,7 @@ spec:
         fieldRef:
           fieldPath: metadata.labels['tekton.dev/pipelineRun']
     image: $(params.image)
-    name: step1-snap
+    name: main
     resources: {}
 ---
 apiVersion: tekton.dev/v1beta1
@@ -238,7 +238,7 @@ spec:
         fieldRef:
           fieldPath: metadata.labels['tekton.dev/pipelineRun']
     image: $(params.image)
-    name: step2-snap
+    name: main
     resources: {}
 ---
 apiVersion: tekton.dev/v1beta1
@@ -322,7 +322,7 @@ spec:
         fieldRef:
           fieldPath: metadata.labels['tekton.dev/pipelineRun']
     image: $(params.image)
-    name: step3-snap
+    name: main
     resources: {}
 ---
 apiVersion: tekton.dev/v1beta1

--- a/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
@@ -87,7 +87,7 @@ spec:
     - sh
     - -c
     image: google/cloud-sdk:279.0.0
-    name: step1-ingest
+    name: main
     volumeMounts:
     - mountPath: /data
       name: create-volume
@@ -171,7 +171,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: step2-gunzip
+    name: main
     volumeMounts:
     - mountPath: /data
       name: create-volume
@@ -255,7 +255,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: step3-copy
+    name: main
     volumeMounts:
     - mountPath: /data
       name: create-volume
@@ -338,7 +338,7 @@ spec:
     - /data/step2/file1
     - /data/step3/file3
     image: library/bash:4.4.23
-    name: step4-output
+    name: main
     volumeMounts:
     - mountPath: /data
       name: create-volume

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -27,7 +27,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: my-in-coop1
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -46,7 +46,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: my-inner-inner-coop
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -62,7 +62,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: my-in-coop2
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -78,7 +78,7 @@ spec:
     - sh
     - -c
     image: library/bash:4.4.23
-    name: my-out-cop
+    name: main
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #154 

**Description of your changes:**
Since Tekton allows multiple step spec in a task whereas Argo only allows one container spec per task, it's not obvious for Tekton to tell which step is from the main ContainerOp. Therefore, we want to rename all the containerOp step name to "main" to distinguish between the initContainers and main step.

This has no impact to our existing examples because we just change the container name for logging with the API.

**Environment tested:**

* Python Version (use `python --version`): 3.6.4
* Tekton Version (use `tkn version`): 0.11.3
* Kubernetes Version (use `kubectl version`): 1.16
* OS (e.g. from `/etc/os-release`):
