### PR TITLE
Verify source files contain license header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ matrix:
         - python3 -m pip install -e sdk/python
       script:
         - make report
+    - name: "Verify source files contain the license header"
+      language: bash
+      script:
+        - make check_license
     - name: "Lint Python code with flake8"
       language: python
       python: "3.7"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Acknowledgements:
+#  - the help target was derived from https://stackoverflow.com/a/35730328/5601796
+
 #
 # Configuration variables
 #
@@ -19,8 +22,7 @@ VENV ?= .venv
 export VIRTUAL_ENV := $(abspath ${VENV})
 export PATH := ${VIRTUAL_ENV}/bin:${PATH}
 
-# Use the command from https://stackoverflow.com/a/35730328/5601796
-.PHONY: help 
+.PHONY: help
 help: ## Display the Make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
@@ -32,9 +34,16 @@ $(VENV)/bin/activate: sdk/python/setup.py
 	@touch $(VENV)/bin/activate
 
 .PHONY: test
-test: venv ## Run kfp/tekton unit test
+test: venv ## Run compiler unit tests
 	@sdk/python/tests/run_tests.sh
 
 .PHONY: report
-report: ## Report kfp sample stats
+report: ## Report compilation status of KFP testdata DSL scripts
 	@cd sdk/python/tests && ./test_kfp_samples.sh
+
+.PHONY: check_license
+check_license: ## Check for license header in source files
+	@find ./sdk/python -type f \( -name '*.py' -o -name '*.yaml' \) -exec \
+		grep -H -E -o -c  'Copyright 20.* kubeflow.org'  {} \; | \
+		grep -E ':0$$' | sed 's/..$$//' | \
+		grep . && echo "The files listed above are missing the license header" && exit 1 || echo "OK"

--- a/sdk/python/tests/config.yaml
+++ b/sdk/python/tests/config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 pipeline: compose.py
 type: nested
 components:


### PR DESCRIPTION
**Description of your changes:**

Add a `check_license` target to the `Makefile` to verify the source files (`*.py`, `*.yaml`) contain the license header.

Add the license check to Travis/CI.

**Environment tested:**

* Python Version (use `python --version`): `3.7.5`
* Tekton Version (use `tkn version`): 
   - Client version: `0.9.0`
   - Pipeline version: `v0.11.0-rc2`
* Kubernetes Version (use `kubectl version`): `1.16`
* OS (e.g. from `/etc/os-release`): `Darwin 19.3.0`
