### PR TITLE
make lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,5 @@ matrix:
     - name: "Lint Python code with flake8"
       language: python
       python: "3.7"
-      install:
-        - pip install flake8
       script:
-        - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        - make lint

--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,16 @@
 # limitations under the License.
 
 # Acknowledgements:
-#  - the help target was derived from https://stackoverflow.com/a/35730328/5601796
+#  - The help target was derived from https://stackoverflow.com/a/35730328/5601796
 
-#
-# Configuration variables
-#
 VENV ?= .venv
 export VIRTUAL_ENV := $(abspath ${VENV})
 export PATH := ${VIRTUAL_ENV}/bin:${PATH}
 
 .PHONY: help
 help: ## Display the Make targets
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: venv
 venv: $(VENV)/bin/activate ## Create and activate virtual environment
@@ -40,6 +38,14 @@ test: venv ## Run compiler unit tests
 .PHONY: report
 report: ## Report compilation status of KFP testdata DSL scripts
 	@cd sdk/python/tests && ./test_kfp_samples.sh
+
+.PHONY: lint
+lint: venv ## Check Python code style compliance
+	@which flake8 > /dev/null || pip install flake8
+	flake8 sdk/python --count --show-source --statistics \
+		--select=E9,E2,E3,E5,F63,F7,F82,F4,F841,W291,W292 \
+		--per-file-ignores sdk/python/tests/compiler/testdata/*:F841 \
+ 		--max-line-length=140  && echo OK
 
 .PHONY: check_license
 check_license: ## Check for license header in source files

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -145,7 +145,20 @@ The Python code in this project follows the [Google Python style guide](http://g
 You can make use of a [yapf](https://github.com/google/yapf) configuration file to auto-format Python code and adopt the
 Google Python style. We encouraged to lint Python docstrings using [docformatter](https://github.com/myint/docformatter).
 Our CI/CD integration with Travis uses [Flake8](https://pypi.org/project/flake8/) and the current set of enforced rules
-can be found in [.travis.yml](/.travis.yml).
+can be found in [Makefile](/Makefile):
+
+```Makefile
+.PHONY: lint
+lint: venv ## Check Python code style compliance
+	@which flake8 > /dev/null || pip install flake8
+	flake8 sdk/python --count --show-source --statistics \
+		--select=E9,E2,E3,E5,F63,F7,F82,F4,F841,W291,W292 \
+		--per-file-ignores sdk/python/tests/compiler/testdata/*:F841 \
+ 		--max-line-length=140  && echo OK
+```
+
+Make sure to run `make lint` before you create a pull request (PR) that includes changes to Python source files.
+
 
 ## Testing
 

--- a/sdk/python/kfp_tekton/compiler/__init__.py
+++ b/sdk/python/kfp_tekton/compiler/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .compiler import TektonCompiler
+from .compiler import TektonCompiler  # noqa F401

--- a/sdk/python/kfp_tekton/compiler/_k8s_helper.py
+++ b/sdk/python/kfp_tekton/compiler/_k8s_helper.py
@@ -96,7 +96,7 @@ def convert_k8s_obj_to_json(k8s_obj):
                    for sub_obj in k8s_obj)
     elif isinstance(k8s_obj, (datetime, date)):
       return k8s_obj.isoformat()
-    elif isinstance(k8s_obj, dsl.PipelineParam): 
+    elif isinstance(k8s_obj, dsl.PipelineParam):
       if isinstance(k8s_obj.value, str):
         return k8s_obj.value
       return '$(inputs.params.%s)' % k8s_obj.full_name  # change for Tekton

--- a/sdk/python/kfp_tekton/compiler/main.py
+++ b/sdk/python/kfp_tekton/compiler/main.py
@@ -55,7 +55,8 @@ def parse_arguments():
   return args
 
 
-def _compile_pipeline_function(pipeline_funcs, function_name, output_path, type_check, generate_pipelinerun=False, enable_artifacts=False):
+def _compile_pipeline_function(pipeline_funcs, function_name, output_path, type_check,
+                               generate_pipelinerun=False, enable_artifacts=False):
   if len(pipeline_funcs) == 0:
     raise ValueError('A function with @dsl.pipeline decorator is required in the py file.')
 
@@ -71,7 +72,9 @@ def _compile_pipeline_function(pipeline_funcs, function_name, output_path, type_
   else:
     pipeline_func = pipeline_funcs[0]
 
-  TektonCompiler().compile(pipeline_func, output_path, type_check, generate_pipelinerun=generate_pipelinerun, enable_artifacts=enable_artifacts)
+  TektonCompiler().compile(pipeline_func, output_path, type_check,
+                           generate_pipelinerun=generate_pipelinerun,
+                           enable_artifacts=enable_artifacts)
 
 
 def compile_pyfile(pyfile, function_name, output_path, type_check, generate_pipelinerun=False, enable_artifacts=False):

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 
 NAME = "kfp-tekton"
-#VERSION = .... Change the version in kfp_tekton/__init__.py
+# VERSION = .... Change the version in kfp_tekton/__init__.py
 LICENSE = "Apache 2.0"
 HOMEPAGE = "https://github.com/kubeflow/kfp-tekton/"
 

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -239,7 +239,7 @@ class TestTektonCompiler(unittest.TestCase):
     self._test_pipeline_workflow(mnist_hpo, 'katib.yaml')
     
   def test_imagepullsecrets_workflow(self):
-    """ 
+    """
     Test compiling a imagepullsecrets workflow.
     """
     from .testdata.imagepullsecrets import imagepullsecrets_pipeline
@@ -265,7 +265,7 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata import compose
     self._test_nested_workflow('compose.yaml', [compose.save_most_frequent_word, compose.download_save_most_frequent_word])
     
-  def _test_pipeline_workflow(self, 
+  def _test_pipeline_workflow(self,
                               pipeline_function,
                               pipeline_yaml,
                               generate_pipelinerun=False,
@@ -306,7 +306,7 @@ class TestTektonCompiler(unittest.TestCase):
     finally:
       shutil.rmtree(temp_dir)
 
-  def _test_nested_workflow(self, 
+  def _test_nested_workflow(self,
                             pipeline_yaml,
                             pipeline_list,
                             generate_pipelinerun=False,

--- a/sdk/python/tests/compiler/k8s_helper_tests.py
+++ b/sdk/python/tests/compiler/k8s_helper_tests.py
@@ -82,5 +82,6 @@ class TestK8sHelper(unittest.TestCase):
             "sidecar.istio.io/inject",
         }
         self.assertEqual(
-            [sanitize_k8s_name(key, allow_capital_underscore=True, allow_dot=True, allow_slash=True, max_length=253) for key in annotation_keys],
+            [sanitize_k8s_name(key, allow_capital_underscore=True, allow_dot=True, allow_slash=True,
+                               max_length=253) for key in annotation_keys],
             [key[:253] for key in expected_k8s_annotation_keys])

--- a/sdk/python/tests/compiler/testdata/affinity.py
+++ b/sdk/python/tests/compiler/testdata/affinity.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from kubernetes.client import V1Affinity, V1NodeSelector, V1NodeSelectorRequirement, V1NodeSelectorTerm, V1NodeAffinity
-from kfp.dsl import ContainerOp
 from kfp import dsl
 
 
@@ -23,6 +22,7 @@ def some_op():
         image='busybox',
         command=['sleep 1'],
     )
+
 
 @dsl.pipeline(
     name='affinity',

--- a/sdk/python/tests/compiler/testdata/artifact_location.py
+++ b/sdk/python/tests/compiler/testdata/artifact_location.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import kfp
 from kfp import dsl
 from kubernetes.client import V1SecretKeySelector
 

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.py
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import kfp.dsl as dsl
 import kfp.gcp as gcp
 
@@ -20,15 +19,17 @@ import kfp.gcp as gcp
 message_param = dsl.PipelineParam(name='message')
 output_path_param = dsl.PipelineParam(name='outputpath', value='default_output')
 
+
 class GetFrequentWordOp(dsl.ContainerOp):
   """A get frequent word class representing a component in ML Pipelines.
   The class provides a nice interface to users by hiding details such as container,
   command, arguments.
   """
   def __init__(self, name, message):
-    """Args:
-         name: An identifier of the step which needs to be unique within a pipeline.
-         message: a dsl.PipelineParam object representing an input message.
+    """__init__
+    Args:
+      name: An identifier of the step which needs to be unique within a pipeline.
+      message: a dsl.PipelineParam object representing an input message.
     """
     super(GetFrequentWordOp, self).__init__(
         name=name,
@@ -59,14 +60,14 @@ class SaveMessageOp(dsl.ContainerOp):
 
 
 class ExitHandlerOp(dsl.ContainerOp):
-  """A class representing a component in ML Pipelines.
-  """
+  """A class representing a component in ML Pipelines."""
   def __init__(self, name):
     super(ExitHandlerOp, self).__init__(
         name=name,
         image='python:3.5-jessie',
         command=['sh', '-c'],
         arguments=['echo exit!'])
+
 
 def save_most_frequent_word():
   exit_op = ExitHandlerOp('exiting')
@@ -86,7 +87,7 @@ def save_most_frequent_word():
         'cloud.google.com/gke-accelerator',
         'nvidia-tesla-k80')
     saver.apply(
-        gcp.use_tpu(tpu_cores = 8, tpu_resource = 'v2', tf_version = '1.12'))
+        gcp.use_tpu(tpu_cores=8, tpu_resource='v2', tf_version='1.12'))
 
 
 if __name__ == '__main__':

--- a/sdk/python/tests/compiler/testdata/condition.py
+++ b/sdk/python/tests/compiler/testdata/condition.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import kfp
 from kfp import dsl
 
 

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.py
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.py
@@ -16,7 +16,6 @@
 container registry.
 """
 
-import kfp
 import kfp.dsl as dsl
 from kubernetes import client as k8s_client
 

--- a/sdk/python/tests/compiler/testdata/init_container.py
+++ b/sdk/python/tests/compiler/testdata/init_container.py
@@ -20,6 +20,7 @@ echo = dsl.UserContainer(
     image='alpine:latest',
     command=['echo', 'bye'])
 
+
 @dsl.pipeline(name='InitContainer', description='A pipeline with init container.')
 def init_container_pipeline():
     dsl.ContainerOp(

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.py
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.py
@@ -12,43 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import sys
+
+from kfp import dsl
 from pathlib import Path
 
 sys.path.insert(0, __file__ + '/../../../../')
-
-import kfp
-from kfp import dsl
 
 
 def component_with_inline_input_artifact(text: str):
     return dsl.ContainerOp(
         name='component_with_inline_input_artifact',
         image='alpine',
-        command=['cat', dsl.InputArgumentPath(text, path='/tmp/inputs/text/data', input='text')], # path and input are optional
+        command=['cat', dsl.InputArgumentPath(text, path='/tmp/inputs/text/data', input='text')],  # path and input are optional
     )
 
 
 def component_with_input_artifact(text):
-    '''A component that passes text as input artifact'''
+    """A component that passes text as input artifact"""
 
     return dsl.ContainerOp(
         name='component_with_input_artifact',
         artifact_argument_paths=[
-            dsl.InputArgumentPath(argument=text, path='/tmp/inputs/text/data', input='text'), # path and input are optional
+            dsl.InputArgumentPath(argument=text, path='/tmp/inputs/text/data', input='text'),  # path and input are optional
         ],
         image='alpine',
         command=['cat', '/tmp/inputs/text/data'],
     )
 
+
 def component_with_hardcoded_input_artifact_value():
-    '''A component that passes hard-coded text as input artifact'''
+    """A component that passes hard-coded text as input artifact"""
     return component_with_input_artifact('hard-coded artifact value')
 
 
 def component_with_input_artifact_value_from_file(file_path):
-    '''A component that passes contents of a file as input artifact'''
+    """A component that passes contents of a file as input artifact"""
     return component_with_input_artifact(Path(file_path).read_text())
 
 

--- a/sdk/python/tests/compiler/testdata/katib.py
+++ b/sdk/python/tests/compiler/testdata/katib.py
@@ -15,6 +15,7 @@
 import json
 import kfp.dsl as dsl
 
+
 @dsl.pipeline(
     name="Launch katib experiment",
     description="An example to launch katib experiment."
@@ -33,9 +34,9 @@ def mnist_hpo(
       "objectiveMetricName": "Validation-accuracy",
       "additionalMetricNames": ["accuracy"]
     }
-    algorithmConfig = {"algorithmName" : "random"}
+    algorithmConfig = {"algorithmName": "random"}
     parameters = [
-      {"name": "--lr", "parameterType": "double", "feasibleSpace": {"min": "0.01","max": "0.03"}},
+      {"name": "--lr", "parameterType": "double", "feasibleSpace": {"min": "0.01", "max": "0.03"}},
       {"name": "--num-layers", "parameterType": "int", "feasibleSpace": {"min": "2", "max": "5"}},
       {"name": "--optimizer", "parameterType": "categorical", "feasibleSpace": {"list": ["sgd", "adam", "ftrl"]}}
     ]
@@ -54,7 +55,7 @@ def mnist_hpo(
               {"name": "{{.Trial}}",
                "image": "docker.io/katib/mxnet-mnist-example",
                "command": [
-                   "python /mxnet/example/image-classification/train_mnist.py --batch-size=64 {{- with .HyperParameters}} {{- range .}} {{.Name}}={{.Value}} {{- end}} {{- end}}"
+                   "python /mxnet/example/image-classification/train_mnist.py --batch-size=64 {{- with .HyperParameters}} {{- range .}} {{.Name}}={{.Value}} {{- end}} {{- end}}"  # noqa E501
                ]
               }
             ]
@@ -103,9 +104,9 @@ def katib_experiment_launcher_op(
       deleteAfterDone=True,
       outputFile='/output.txt'):
     return dsl.ContainerOp(
-        name = "mnist-hpo",
-        image = 'liuhougangxa/katib-experiment-launcher:latest',
-        arguments = [
+        name="mnist-hpo",
+        image='liuhougangxa/katib-experiment-launcher:latest',
+        arguments=[
             '--name', name,
             '--namespace', namespace,
             '--maxTrialCount', maxTrialCount,
@@ -120,7 +121,7 @@ def katib_experiment_launcher_op(
             '--deleteAfterDone', deleteAfterDone,
             '--experimentTimeoutMinutes', experimentTimeoutMinutes,
         ],
-        file_outputs = {'bestHyperParameter': outputFile}
+        file_outputs={'bestHyperParameter': outputFile}
     )
 
 

--- a/sdk/python/tests/compiler/testdata/node_selector.py
+++ b/sdk/python/tests/compiler/testdata/node_selector.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp.dsl import ContainerOp
 from kfp import dsl
 
 
@@ -22,6 +21,7 @@ def some_op():
         image='busybox',
         command=['sleep 1'],
     )
+
 
 @dsl.pipeline(
     name='node_selector',

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.py
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import kfp
 from kfp import dsl
 
 

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.py
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.py
@@ -41,7 +41,7 @@ _CONTAINER_MANIFEST = """
                 "restartPolicy": "Never"
             }
         },
-        "backoffLimit": 4      
+        "backoffLimit": 4
     }
 }
 """

--- a/sdk/python/tests/compiler/testdata/retry.py
+++ b/sdk/python/tests/compiler/testdata/retry.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import kfp
 from kfp import dsl
 
 
@@ -23,7 +21,8 @@ def random_failure_op(exit_codes):
         name='random_failure',
         image='python:alpine3.6',
         command=['python', '-c'],
-        arguments=['import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]); print(exit_code); sys.exit(exit_code)', exit_codes]
+        arguments=['import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]); '
+                   'print(exit_code); sys.exit(exit_code)', exit_codes]
     )
 
 

--- a/sdk/python/tests/compiler/testdata/sidecar.py
+++ b/sdk/python/tests/compiler/testdata/sidecar.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import kfp.dsl as dsl
-from kubernetes import client as k8s_client
 
 
 @dsl.pipeline(name='Sidecar', description='A pipeline with sidecars.')

--- a/sdk/python/tests/compiler/testdata/timeout.py
+++ b/sdk/python/tests/compiler/testdata/timeout.py
@@ -25,7 +25,8 @@ class RandomFailure1Op(dsl.ContainerOp):
             image='python:alpine3.6',
             command=['python', '-c'],
             arguments=[
-                "import random; import sys; exit_code = random.choice([%s]); print(exit_code); import time; time.sleep(30); sys.exit(exit_code)" % exit_codes])
+                "import random; import sys; exit_code = random.choice([%s]); print(exit_code); "
+                "import time; time.sleep(30); sys.exit(exit_code)" % exit_codes])
 
 
 @dsl.pipeline(

--- a/sdk/python/tests/compiler/testdata/tolerations.py
+++ b/sdk/python/tests/compiler/testdata/tolerations.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from kubernetes.client import V1Toleration
-from kfp.dsl import ContainerOp
 from kfp import dsl
 
 

--- a/sdk/python/tests/compiler/testdata/volume_op.py
+++ b/sdk/python/tests/compiler/testdata/volume_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import kfp
 import kfp.dsl as dsl
 
 

--- a/sdk/python/tests/compiler/testdata/withitem_nested.py
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.py
@@ -15,6 +15,7 @@
 import kfp.dsl as dsl
 from kfp.dsl import _for_loop
 
+
 class Coder:
     def __init__(self, ):
         self._code_id = 0

--- a/sdk/python/tests/test_util.py
+++ b/sdk/python/tests/test_util.py
@@ -14,14 +14,13 @@
 
 import sys
 import os
-import unittest
 from shutil import copyfile
 from compiler.compiler_tests import TestTektonCompiler
 
 if __name__ == '__main__':
     test_name = os.path.splitext(os.path.split(sys.argv[1])[1])[0]
     save_path = sys.argv[2]
-    golden_path = os.path.join(os.path.dirname(__file__), 'compiler/testdata', test_name+'.yaml')
+    golden_path = os.path.join(os.path.dirname(__file__), 'compiler/testdata', test_name + '.yaml')
 
     if test_name == "compose":
         test = TestTektonCompiler().test_compose


### PR DESCRIPTION
**Description of your changes:**

- Added `lint` target to `Makefile` which runs `flake8` to verify code style compliance on Python source files
- Changed `.travis.yml` to make use of the new `make lint` target
- Updated [Developer Guide](https://github.com/ckadner/kfp-tekton/tree/make_lint/sdk/python#coding-style) with instructions to use `make lint` before creating a PR
- Fixed respective [code style](https://www.flake8rules.com/) violations in Python sources

**Code style violations corrected in this PR:**
```
1     E202 whitespace before ')'
3     E203 whitespace before ':'
1     E225 missing whitespace around operator
5     E231 missing whitespace after ','
14    E251 unexpected spaces around keyword / parameter equals
16    E252 missing whitespace around parameter equals
8     E302 expected 2 blank lines, found 1
5     E303 too many blank lines (2)
2     E402 module level import not at top of file
20    F401 imported but unused
8     W291 trailing whitespace
2     W292 no newline at end of file

* https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
```

**Flake8 parameters:**
```
flake8 sdk/python \
    --select=E9,E2,E3,E5,F63,F7,F82,F4,F841,W291,W292 \
    --per-file-ignores sdk/python/tests/compiler/testdata/*:F841 \
    --max-line-length=140 \
    --count --show-source --statistics
```