### PR TITLE
Fix for big data passing

### DIFF
--- a/samples/bigger_data_passing/big_data_passing_description.ipynb
+++ b/samples/bigger_data_passing/big_data_passing_description.ipynb
@@ -1,0 +1,946 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Data passing tutorial\n",
+    "Data passing is the most important aspect of Pipelines.\n",
+    "\n",
+    "In Kubeflow Pipelines, the pipeline authors compose pipelines by creating component instances (tasks) and connecting them together.\n",
+    "\n",
+    "Component have inputs and outputs. They can consume and produce arbitrary data.\n",
+    "\n",
+    "Pipeline authors establish connections between component tasks by connecting their data inputs and outputs - by passing the output of one task as an argument to another task's input.\n",
+    "\n",
+    "The system takes care of storing the data produced by components and later passing that data to other components for consumption as instructed by the pipeline.\n",
+    "\n",
+    "This tutorial shows how to create python components that produce, consume and transform data.\n",
+    "It shows how to create data passing pipelines by instantiating components and connecting them together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import NamedTuple\n",
+    "\n",
+    "import kfp\n",
+    "from kfp.components import InputPath, InputTextFile, OutputPath, OutputTextFile\n",
+    "from kfp.components import func_to_container_op\n",
+    "from kfp_tekton.compiler import TektonCompiler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Small data\n",
+    "\n",
+    "Small data is the data that you'll be comfortable passing as program's command-line argument. Small data size should not exceed few kilobytes.\n",
+    "\n",
+    "Some examples of typical types of small data are: number, URL, small string (e.g. column name).\n",
+    "\n",
+    "Small lists, dictionaries and JSON structures are fine, but keep an eye on the size and consider switching to file-based data passing methods taht are more suitable for bigger data (more than several kilobytes) or binary data.\n",
+    "\n",
+    "All small data outputs will be at some point serialized to strings and all small data input values will be at some point deserialized from strings (passed as command-line argumants). There are built-in serializers and deserializers for several common types (e.g. `str`, `int`, `float`, `bool`, `list`, `dict`). All other types of data need to be serialized manually before returning the data. Make sure to properly specify type annotations, otherwize there would be no automatic deserialization and the component function will receive strings instead of deserialized objects."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Consuming small data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@func_to_container_op\n",
+    "def print_small_text(text: str):\n",
+    "    '''Print small text'''\n",
+    "    print(text)\n",
+    "\n",
+    "def constant_to_consumer_pipeline():\n",
+    "    '''Pipeline that passes small constant string to to consumer'''\n",
+    "    consume_task = print_small_text('Hello world') # Passing constant as argument to consumer\n",
+    "\n",
+    "TektonCompiler().compile(constant_to_consumer_pipeline,\n",
+    "                         'constant_to_consumer_pipeline.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/print-small-text created\n",
+      "pipeline.tekton.dev/constant-to-consumer-pipeline created\n",
+      "pipelinerun.tekton.dev/constant-to-consumer-pipeline-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f constant_to_consumer_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           constant-to-consumer-pipeline-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   constant-to-consumer-pipeline\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED                DURATION    STATUS\r\n",
+      "373 milliseconds ago   4 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " No params\r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                                         TASK NAME          STARTED                DURATION    STATUS\r\n",
+      " ∙ constant-to-consumer-pipeline-run-print-small-text-wj9p4   print-small-text   373 milliseconds ago   4 seconds   \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe constant-to-consumer-pipeline-run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def pipeline_parameter_to_consumer_pipeline(text: str):\n",
+    "    '''Pipeline that passes small pipeline parameter string to to consumer'''\n",
+    "    consume_task = print_small_text(text) # Passing pipeline parameter as argument to consumer\n",
+    "\n",
+    "TektonCompiler().compile(pipeline_parameter_to_consumer_pipeline,\n",
+    "                         'pipeline_parameter_to_consumer_pipeline.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/print-small-text configured\n",
+      "pipeline.tekton.dev/pipeline-parameter-to-consumer-pipeline created\n",
+      "pipelinerun.tekton.dev/pipeline-parameter-to-consumer-pipeline-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f pipeline_parameter_to_consumer_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           pipeline-parameter-to-consumer-pipeline-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   pipeline-parameter-to-consumer-pipeline\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED                 DURATION    STATUS\r\n",
+      "-206 milliseconds ago   5 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " NAME     VALUE\r\n",
+      " ∙ text   \r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                                                TASK NAME          STARTED                 DURATION    STATUS\r\n",
+      " ∙ pipeline-parameter-to-consumer-pipeline-run-print-small-t-mr7fl   print-small-text   -206 milliseconds ago   4 seconds   \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe pipeline-parameter-to-consumer-pipeline-run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Producing small data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@func_to_container_op\n",
+    "def produce_one_small_output() -> str:\n",
+    "    return 'Hello world'\n",
+    "\n",
+    "def task_output_to_consumer_pipeline():\n",
+    "    '''Pipeline that passes small data from producer to consumer'''\n",
+    "    produce_task = produce_one_small_output()\n",
+    "    # Passing producer task output as argument to consumer\n",
+    "    consume_task1 = print_small_text(produce_task.output) # task.output only works for single-output components\n",
+    "    consume_task2 = print_small_text(produce_task.outputs['output']) # task.outputs[...] always works\n",
+    "\n",
+    "TektonCompiler().compile(task_output_to_consumer_pipeline,\n",
+    "                         'task_output_to_consumer_pipeline.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/produce-one-small-output created\n",
+      "task.tekton.dev/print-small-text configured\n",
+      "task.tekton.dev/print-small-text-2 created\n",
+      "pipeline.tekton.dev/task-output-to-consumer-pipeline created\n",
+      "pipelinerun.tekton.dev/task-output-to-consumer-pipeline-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f task_output_to_consumer_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           task-output-to-consumer-pipeline-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   task-output-to-consumer-pipeline\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED         DURATION    STATUS\r\n",
+      "4 minutes ago   8 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " No params\r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                                                TASK NAME                  STARTED         DURATION    STATUS\r\n",
+      " ∙ task-output-to-consumer-pipeline-run-print-small-text-2-rpcmf     print-small-text-2         4 minutes ago   4 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ task-output-to-consumer-pipeline-run-print-small-text-gqsnc       print-small-text           4 minutes ago   4 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ task-output-to-consumer-pipeline-run-produce-one-small-ou-l48pb   produce-one-small-output   4 minutes ago   4 seconds   \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe task-output-to-consumer-pipeline-run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Producing and consuming multiple arguments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@func_to_container_op\n",
+    "def produce_two_small_outputs() -> NamedTuple('Outputs', [('text', str), ('number', int)]):\n",
+    "    return (\"data 1\", 42)\n",
+    "\n",
+    "@func_to_container_op\n",
+    "def consume_two_arguments(text: str, number: int):\n",
+    "    print('Text={}'.format(text))\n",
+    "    print('Number={}'.format(str(number)))\n",
+    "\n",
+    "def producers_to_consumers_pipeline(text: str = \"Hello world\"):\n",
+    "    '''Pipeline that passes data from producer to consumer'''\n",
+    "    produce1_task = produce_one_small_output()\n",
+    "    produce2_task = produce_two_small_outputs()\n",
+    "\n",
+    "    consume_task1 = consume_two_arguments(produce1_task.output, 42)\n",
+    "    consume_task2 = consume_two_arguments(text, produce2_task.outputs['number'])\n",
+    "    consume_task3 = consume_two_arguments(produce2_task.outputs['text'], produce2_task.outputs['number'])\n",
+    "\n",
+    "TektonCompiler().compile(producers_to_consumers_pipeline,\n",
+    "                         'producers_to_consumers_pipeline.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/produce-one-small-output configured\n",
+      "task.tekton.dev/produce-two-small-outputs created\n",
+      "task.tekton.dev/consume-two-arguments created\n",
+      "task.tekton.dev/consume-two-arguments-2 created\n",
+      "task.tekton.dev/consume-two-arguments-3 created\n",
+      "pipeline.tekton.dev/producers-to-consumers-pipeline created\n",
+      "pipelinerun.tekton.dev/producers-to-consumers-pipeline-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f producers_to_consumers_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           producers-to-consumers-pipeline-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   producers-to-consumers-pipeline\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED         DURATION     STATUS\r\n",
+      "4 minutes ago   12 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " NAME     VALUE\r\n",
+      " ∙ text   Hello world\r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                                                TASK NAME                   STARTED         DURATION    STATUS\r\n",
+      " ∙ producers-to-consumers-pipeline-run-consume-two-arguments-ncb5m   consume-two-arguments-2     4 minutes ago   6 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ producers-to-consumers-pipeline-run-consume-two-arguments-nh8b9   consume-two-arguments-3     4 minutes ago   6 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ producers-to-consumers-pipeline-run-consume-two-arguments-v855p   consume-two-arguments       4 minutes ago   6 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ producers-to-consumers-pipeline-run-produce-one-small-out-r5fkh   produce-one-small-output    4 minutes ago   6 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ producers-to-consumers-pipeline-run-produce-two-small-out-h8jh2   produce-two-small-outputs   4 minutes ago   6 seconds   \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe producers-to-consumers-pipeline-run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Consuming and producing data at the same time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@func_to_container_op\n",
+    "def get_item_from_list(list_of_strings: list, index: int) -> str:\n",
+    "    return list_of_strings[index]\n",
+    "\n",
+    "@func_to_container_op\n",
+    "def truncate_text(text: str, max_length: int) -> str:\n",
+    "    return text[0:max_length]\n",
+    "\n",
+    "def processing_pipeline(text: str = \"Hello world\"):\n",
+    "    truncate_task = truncate_text(text, max_length=5)\n",
+    "    get_item_task = get_item_from_list(list_of_strings=[3, 1, truncate_task.output, 1, 5, 9, 2, 6, 7], index=2)\n",
+    "    print_small_text(get_item_task.output)\n",
+    "\n",
+    "\n",
+    "TektonCompiler().compile(processing_pipeline,\n",
+    "                         'processing_pipeline.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/truncate-text created\n",
+      "task.tekton.dev/get-item-from-list created\n",
+      "task.tekton.dev/print-small-text configured\n",
+      "pipeline.tekton.dev/processing-pipeline created\n",
+      "pipelinerun.tekton.dev/processing-pipeline-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f processing_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           processing-pipeline-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   processing-pipeline\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED         DURATION     STATUS\r\n",
+      "5 minutes ago   13 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " NAME     VALUE\r\n",
+      " ∙ text   Hello world\r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                                 TASK NAME            STARTED         DURATION    STATUS\r\n",
+      " ∙ processing-pipeline-run-print-small-text-7g484     print-small-text     5 minutes ago   4 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ processing-pipeline-run-get-item-from-list-fcfq8   get-item-from-list   5 minutes ago   4 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ processing-pipeline-run-truncate-text-cnr7x        truncate-text        5 minutes ago   5 seconds   \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe processing-pipeline-run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bigger data (files)\n",
+    "\n",
+    "Bigger data should be read from files and written to files.\n",
+    "\n",
+    "The paths for the input and output files are chosen by the system and are passed into the function (as strings).\n",
+    "\n",
+    "Use the `InputPath` parameter annotation to tell the system that the function wants to consume the corresponding input data as a file. The system will download the data, write it to a local file and then pass the **path** of that file to the function.\n",
+    "\n",
+    "Use the `OutputPath` parameter annotation to tell the system that the function wants to produce the corresponding output data as a file. The system will prepare and pass the **path** of a file where the function should write the output data. After the function exits, the system will upload the data to the storage system so that it can be passed to downstream components.\n",
+    "\n",
+    "You can specify the type of the consumed/produced data by specifying the type argument to `InputPath` and `OutputPath`. The type can be a python type or an arbitrary type name string. `OutputPath('TFModel')` means that the function states that the data it has written to a file has type 'TFModel'. `InputPath('TFModel')` means that the function states that it expect the data it reads from a file to have type 'TFModel'. When the pipeline author connects inputs to outputs the system checks whether the types match.\n",
+    "\n",
+    "Note on input/output names: When the function is converted to component, the input and output names generally follow the parameter names, but the \"\\_path\" and \"\\_file\" suffixes are stripped from file/path inputs and outputs. E.g. the `number_file_path: InputPath(int)` parameter becomes the `number: int` input. This makes the argument passing look more natural: `number=42` instead of `number_file_path=42`.\n",
+    "\n",
+    "Notes: As we used 'workspaces' in tekton pipelines to handle the bigger data processing, the complier will generator the PVC definations,it needs the volume to store the data.\n",
+    "User need to create volume manually, or enable dynamic volume provisioning, refer to the link of:\n",
+    "https://kubernetes.io/docs/concepts/storage/dynamic-provisioning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "### Writing and reading bigger data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Writing bigger data\n",
+    "@func_to_container_op\n",
+    "def repeat_line(line: str, output_text_path: OutputPath(str), count: int = 10):\n",
+    "    '''Repeat the line specified number of times'''\n",
+    "    with open(output_text_path, 'w') as writer:\n",
+    "        for i in range(count):\n",
+    "            writer.write(line + '\\n')\n",
+    "\n",
+    "\n",
+    "# Reading bigger data\n",
+    "@func_to_container_op\n",
+    "def print_text(text_path: InputPath()): # The \"text\" input is untyped so that any data can be printed\n",
+    "    '''Print text'''\n",
+    "    with open(text_path, 'r') as reader:\n",
+    "        for line in reader:\n",
+    "            print(line, end = '')\n",
+    "\n",
+    "def print_repeating_lines_pipeline():\n",
+    "    repeat_lines_task = repeat_line(line='Hello', count=5000)\n",
+    "    print_text(repeat_lines_task.output) # Don't forget .output !\n",
+    "\n",
+    "TektonCompiler().compile(print_repeating_lines_pipeline,\n",
+    "                         'print_repeating_lines_pipeline.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/repeat-line created\n",
+      "task.tekton.dev/print-text created\n",
+      "pipeline.tekton.dev/print-repeating-lines-pipeline created\n",
+      "pipelinerun.tekton.dev/print-repeating-lines-pipeline-run created\n",
+      "persistentvolumeclaim/print-repeating-lines-pipeline-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f print_repeating_lines_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           print-repeating-lines-pipeline-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   print-repeating-lines-pipeline\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED          DURATION     STATUS\r\n",
+      "12 seconds ago   11 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " No params\r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                                     TASK NAME     STARTED          DURATION    STATUS\r\n",
+      " ∙ print-repeating-lines-pipeline-run-print-text-xdzcj    print-text    6 seconds ago    5 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ print-repeating-lines-pipeline-run-repeat-line-lcvrf   repeat-line   12 seconds ago   6 seconds   \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe print-repeating-lines-pipeline-run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Processing bigger data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@func_to_container_op\n",
+    "def split_text_lines(source_path: InputPath(str), odd_lines_path: OutputPath(str), even_lines_path: OutputPath(str)):\n",
+    "    with open(source_path, 'r') as reader:\n",
+    "        with open(odd_lines_path, 'w') as odd_writer:\n",
+    "            with open(even_lines_path, 'w') as even_writer:\n",
+    "                while True:\n",
+    "                    line = reader.readline()\n",
+    "                    if line == \"\":\n",
+    "                        break\n",
+    "                    odd_writer.write(line)\n",
+    "                    line = reader.readline()\n",
+    "                    if line == \"\":\n",
+    "                        break\n",
+    "                    even_writer.write(line)\n",
+    "\n",
+    "def text_splitting_pipeline():\n",
+    "    text = '\\n'.join(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'])\n",
+    "    split_text_task = split_text_lines(text)\n",
+    "    print_text(split_text_task.outputs['odd_lines'])\n",
+    "    print_text(split_text_task.outputs['even_lines'])\n",
+    "\n",
+    "TektonCompiler().compile(text_splitting_pipeline,\n",
+    "                         'text_splitting_pipeline.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/split-text-lines created\n",
+      "task.tekton.dev/print-text configured\n",
+      "task.tekton.dev/print-text-2 created\n",
+      "pipeline.tekton.dev/text-splitting-pipeline created\n",
+      "pipelinerun.tekton.dev/text-splitting-pipeline-run created\n",
+      "persistentvolumeclaim/text-splitting-pipeline-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f text_splitting_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           text-splitting-pipeline-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   text-splitting-pipeline\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED        DURATION   STATUS\r\n",
+      "1 minute ago   1 minute   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " No params\r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                                   TASK NAME          STARTED          DURATION    STATUS\r\n",
+      " ∙ text-splitting-pipeline-run-print-text-2-25xs2       print-text-2       16 seconds ago   6 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ text-splitting-pipeline-run-print-text-kbq4v         print-text         16 seconds ago   6 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ text-splitting-pipeline-run-split-text-lines-dmtqx   split-text-lines   1 minute ago     1 minute    \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe text-splitting-pipeline-run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Processing bigger data with pre-opened files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@func_to_container_op\n",
+    "def split_text_lines2(source_file: InputTextFile(str), odd_lines_file: OutputTextFile(str), even_lines_file: OutputTextFile(str)):\n",
+    "    while True:\n",
+    "        line = source_file.readline()\n",
+    "        if line == \"\":\n",
+    "            break\n",
+    "        odd_lines_file.write(line)\n",
+    "        line = source_file.readline()\n",
+    "        if line == \"\":\n",
+    "            break\n",
+    "        even_lines_file.write(line)\n",
+    "\n",
+    "def text_splitting_pipeline2():\n",
+    "    text = '\\n'.join(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'])\n",
+    "    split_text_task = split_text_lines2(text)\n",
+    "    print_text(split_text_task.outputs['odd_lines']).set_display_name('Odd lines')\n",
+    "    print_text(split_text_task.outputs['even_lines']).set_display_name('Even lines')\n",
+    "\n",
+    "TektonCompiler().compile(text_splitting_pipeline2,\n",
+    "                         'text_splitting_pipeline2.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/split-text-lines2 created\n",
+      "task.tekton.dev/print-text configured\n",
+      "task.tekton.dev/print-text-2 configured\n",
+      "pipeline.tekton.dev/text-splitting-pipeline2 created\n",
+      "pipelinerun.tekton.dev/text-splitting-pipeline2-run created\n",
+      "persistentvolumeclaim/text-splitting-pipeline2-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f text_splitting_pipeline2.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           text-splitting-pipeline2-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   text-splitting-pipeline2\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED          DURATION     STATUS\r\n",
+      "48 seconds ago   48 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " No params\r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                                     TASK NAME           STARTED          DURATION     STATUS\r\n",
+      " ∙ text-splitting-pipeline2-run-print-text-2-5gfrz        print-text-2        6 seconds ago    6 seconds    \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ text-splitting-pipeline2-run-print-text-ckdcr          print-text          6 seconds ago    6 seconds    \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ text-splitting-pipeline2-run-split-text-lines2-xwlvh   split-text-lines2   48 seconds ago   42 seconds   \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe text-splitting-pipeline2-run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example: Pipeline that generates then sums many numbers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Writing many numbers\n",
+    "@func_to_container_op\n",
+    "def write_numbers(numbers_path: OutputPath(str), start: int = 0, count: int = 10):\n",
+    "    with open(numbers_path, 'w') as writer:\n",
+    "        for i in range(start, count):\n",
+    "            writer.write(str(i) + '\\n')\n",
+    "\n",
+    "\n",
+    "# Reading and summing many numbers\n",
+    "@func_to_container_op\n",
+    "def sum_numbers(numbers_path: InputPath(str)) -> int:\n",
+    "    sum = 0\n",
+    "    with open(numbers_path, 'r') as reader:\n",
+    "        for line in reader:\n",
+    "            sum = sum + int(line)\n",
+    "    return sum\n",
+    "\n",
+    "\n",
+    "\n",
+    "# Pipeline to sum 100000 numbers\n",
+    "def sum_pipeline(count: 'Integer' = 100000):\n",
+    "    numbers_task = write_numbers(count=count)\n",
+    "    print_text(numbers_task.output)\n",
+    "\n",
+    "    sum_task = sum_numbers(numbers_task.outputs['numbers'])\n",
+    "    print_text(sum_task.output)\n",
+    "\n",
+    "TektonCompiler().compile(sum_pipeline,\n",
+    "                         'sum_pipeline.yaml',\n",
+    "                         generate_pipelinerun=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task.tekton.dev/write-numbers created\n",
+      "task.tekton.dev/print-text configured\n",
+      "task.tekton.dev/sum-numbers created\n",
+      "task.tekton.dev/print-text-2 configured\n",
+      "pipeline.tekton.dev/sum-pipeline created\n",
+      "pipelinerun.tekton.dev/sum-pipeline-run created\n",
+      "persistentvolumeclaim/sum-pipeline-run created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f sum_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mName\u001b[0m:           sum-pipeline-run\r\n",
+      "\u001b[1mNamespace\u001b[0m:      kubeflow\r\n",
+      "\u001b[1mPipeline Ref\u001b[0m:   sum-pipeline\r\n",
+      "\r\n",
+      "🌡️  \u001b[4;1mStatus\r\n",
+      "\u001b[0m\r\n",
+      "STARTED          DURATION     STATUS\r\n",
+      "45 seconds ago   40 seconds   \u001b[92mSucceeded\u001b[0m\r\n",
+      "\r\n",
+      "📦 \u001b[4;1mResources\r\n",
+      "\u001b[0m\r\n",
+      " No resources\r\n",
+      "\r\n",
+      "⚓ \u001b[4;1mParams\r\n",
+      "\u001b[0m\r\n",
+      " NAME      VALUE\r\n",
+      " ∙ count   100000\r\n",
+      "\r\n",
+      "🗂  \u001b[4;1mTaskruns\r\n",
+      "\u001b[0m\r\n",
+      " NAME                                     TASK NAME       STARTED          DURATION     STATUS\r\n",
+      " ∙ sum-pipeline-run-print-text-2-k68zl    print-text-2    10 seconds ago   5 seconds    \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ sum-pipeline-run-sum-numbers-9k4s7     sum-numbers     15 seconds ago   5 seconds    \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ sum-pipeline-run-print-text-r6blr      print-text      16 seconds ago   6 seconds    \u001b[92mSucceeded\u001b[0m\r\n",
+      " ∙ sum-pipeline-run-write-numbers-9mdfq   write-numbers   45 seconds ago   29 seconds   \u001b[92mSucceeded\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tkn pr describe sum-pipeline-run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/samples/bigger_data_passing/constant_to_consumer_pipeline.yaml
+++ b/samples/bigger_data_passing/constant_to_consumer_pipeline.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print small text", "inputs":
+      [{"name": "text", "type": "String"}], "name": "Print small text"}'
+  name: print-small-text
+spec:
+  steps:
+  - args:
+    - --text
+    - Hello world
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_small_text(text ):\n    '''Print small text'''\n    print(text)\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print small text',\
+      \ description='Print small text')\n_parser.add_argument(\"--text\", dest=\"\
+      text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args =\
+      \ vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\"\
+      , [])\n\n_outputs = print_small_text(**_parsed_args)\n\n_output_serializers\
+      \ = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline that passes small
+      constant string to to consumer", "name": "Constant to consumer pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: constant-to-consumer-pipeline
+spec:
+  tasks:
+  - name: print-small-text
+    taskRef:
+      name: print-small-text
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: constant-to-consumer-pipeline-run
+spec:
+  pipelineRef:
+    name: constant-to-consumer-pipeline

--- a/samples/bigger_data_passing/pipeline_parameter_to_consumer_pipeline.yaml
+++ b/samples/bigger_data_passing/pipeline_parameter_to_consumer_pipeline.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print small text", "inputs":
+      [{"name": "text", "type": "String"}], "name": "Print small text"}'
+  name: print-small-text
+spec:
+  params:
+  - name: text
+  steps:
+  - args:
+    - --text
+    - $(inputs.params.text)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_small_text(text ):\n    '''Print small text'''\n    print(text)\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print small text',\
+      \ description='Print small text')\n_parser.add_argument(\"--text\", dest=\"\
+      text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args =\
+      \ vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\"\
+      , [])\n\n_outputs = print_small_text(**_parsed_args)\n\n_output_serializers\
+      \ = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline that passes small
+      pipeline parameter string to to consumer", "inputs": [{"name": "text", "type":
+      "String"}], "name": "Pipeline parameter to consumer pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: pipeline-parameter-to-consumer-pipeline
+spec:
+  params:
+  - name: text
+  tasks:
+  - name: print-small-text
+    params:
+    - name: text
+      value: $(params.text)
+    taskRef:
+      name: print-small-text
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline-parameter-to-consumer-pipeline-run
+spec:
+  params:
+  - name: text
+    value: ''
+  pipelineRef:
+    name: pipeline-parameter-to-consumer-pipeline

--- a/samples/bigger_data_passing/print_repeating_lines_pipeline.yaml
+++ b/samples/bigger_data_passing/print_repeating_lines_pipeline.yaml
@@ -1,0 +1,123 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Repeat the line specified
+      number of times", "inputs": [{"name": "line", "type": "String"}, {"default":
+      "10", "name": "count", "optional": true, "type": "Integer"}], "name": "Repeat
+      line", "outputs": [{"name": "output_text", "type": "String"}]}'
+  name: repeat-line
+spec:
+  steps:
+  - args:
+    - --line
+    - Hello
+    - --count
+    - '5000'
+    - --output-text
+    - $(workspaces.repeat-line.path)/repeat-line-output-text
+    command:
+    - python3
+    - -u
+    - -c
+    - "def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n   \
+      \ os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\
+      \ndef repeat_line(line , output_text_path , count  = 10):\n    '''Repeat the\
+      \ line specified number of times'''\n    with open(output_text_path, 'w') as\
+      \ writer:\n        for i in range(count):\n            writer.write(line + '\\\
+      n')\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Repeat line',\
+      \ description='Repeat the line specified number of times')\n_parser.add_argument(\"\
+      --line\", dest=\"line\", type=str, required=True, default=argparse.SUPPRESS)\n\
+      _parser.add_argument(\"--count\", dest=\"count\", type=int, required=False,\
+      \ default=argparse.SUPPRESS)\n_parser.add_argument(\"--output-text\", dest=\"\
+      output_text_path\", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)\n\
+      _parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"\
+      _output_paths\", [])\n\n_outputs = repeat_line(**_parsed_args)\n\n_output_serializers\
+      \ = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: repeat-line
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text.path)/repeat-line-output-text
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(text_path ): # The \"text\" input is untyped so that any data\
+      \ can be printed\n    '''Print text'''\n    with open(text_path, 'r') as reader:\n\
+      \        for line in reader:\n            print(line, end = '')\n\nimport argparse\n\
+      _parser = argparse.ArgumentParser(prog='Print text', description='Print text')\n\
+      _parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "Print repeating lines pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: print-repeating-lines-pipeline
+spec:
+  tasks:
+  - name: repeat-line
+    taskRef:
+      name: repeat-line
+    workspaces:
+    - name: repeat-line
+      workspace: print-repeating-lines-pipeline
+  - name: print-text
+    runAfter:
+    - repeat-line
+    taskRef:
+      name: print-text
+    workspaces:
+    - name: print-text
+      workspace: print-repeating-lines-pipeline
+  workspaces:
+  - name: print-repeating-lines-pipeline
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: print-repeating-lines-pipeline-run
+spec:
+  pipelineRef:
+    name: print-repeating-lines-pipeline
+  workspaces:
+  - name: print-repeating-lines-pipeline
+    persistentVolumeClaim:
+      claimName: print-repeating-lines-pipeline-run
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: print-repeating-lines-pipeline-run
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem

--- a/samples/bigger_data_passing/processing_pipeline.yaml
+++ b/samples/bigger_data_passing/processing_pipeline.yaml
@@ -1,0 +1,159 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "text", "type": "String"},
+      {"name": "max_length", "type": "Integer"}], "name": "Truncate text", "outputs":
+      [{"name": "Output", "type": "String"}]}'
+  name: truncate-text
+spec:
+  params:
+  - name: text
+  results:
+  - description: /tmp/outputs/Output/data
+    name: output
+  steps:
+  - args:
+    - --text
+    - $(inputs.params.text)
+    - --max-length
+    - '5'
+    - '----output-paths'
+    - $(results.output.path)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def truncate_text(text , max_length )  :\n    return text[0:max_length]\n\n\
+      def _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value,\
+      \ str):\n        raise TypeError('Value \"{}\" has type \"{}\" instead of str.'.format(str(str_value),\
+      \ str(type(str_value))))\n    return str_value\n\nimport argparse\n_parser =\
+      \ argparse.ArgumentParser(prog='Truncate text', description='')\n_parser.add_argument(\"\
+      --text\", dest=\"text\", type=str, required=True, default=argparse.SUPPRESS)\n\
+      _parser.add_argument(\"--max-length\", dest=\"max_length\", type=int, required=True,\
+      \ default=argparse.SUPPRESS)\n_parser.add_argument(\"----output-paths\", dest=\"\
+      _output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n\
+      _output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = truncate_text(**_parsed_args)\n\
+      \n_outputs = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n\
+      ]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n\
+      \        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n  \
+      \      pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "list_of_strings",
+      "type": "JsonArray"}, {"name": "index", "type": "Integer"}], "name": "Get item
+      from list", "outputs": [{"name": "Output", "type": "String"}]}'
+  name: get-item-from-list
+spec:
+  params:
+  - name: truncate-text-output
+  results:
+  - description: /tmp/outputs/Output/data
+    name: output
+  steps:
+  - args:
+    - --list-of-strings
+    - '[3, 1, "$(inputs.params.truncate-text-output)", 1, 5, 9, 2, 6, 7]'
+    - --index
+    - '2'
+    - '----output-paths'
+    - $(results.output.path)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def get_item_from_list(list_of_strings , index )  :\n    return list_of_strings[index]\n\
+      \ndef _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value,\
+      \ str):\n        raise TypeError('Value \"{}\" has type \"{}\" instead of str.'.format(str(str_value),\
+      \ str(type(str_value))))\n    return str_value\n\nimport json\nimport argparse\n\
+      _parser = argparse.ArgumentParser(prog='Get item from list', description='')\n\
+      _parser.add_argument(\"--list-of-strings\", dest=\"list_of_strings\", type=json.loads,\
+      \ required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"--index\"\
+      , dest=\"index\", type=int, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"\
+      ----output-paths\", dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args\
+      \ = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\"\
+      , [])\n\n_outputs = get_item_from_list(**_parsed_args)\n\n_outputs = [_outputs]\n\
+      \n_output_serializers = [\n    _serialize_str,\n\n]\n\nimport os\nfor idx, output_file\
+      \ in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n\
+      \    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n\
+      \        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print small text", "inputs":
+      [{"name": "text", "type": "String"}], "name": "Print small text"}'
+  name: print-small-text
+spec:
+  params:
+  - name: get-item-from-list-output
+  steps:
+  - args:
+    - --text
+    - $(inputs.params.get-item-from-list-output)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_small_text(text ):\n    '''Print small text'''\n    print(text)\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print small text',\
+      \ description='Print small text')\n_parser.add_argument(\"--text\", dest=\"\
+      text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args =\
+      \ vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\"\
+      , [])\n\n_outputs = print_small_text(**_parsed_args)\n\n_output_serializers\
+      \ = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "Hello world",
+      "name": "text", "optional": true, "type": "String"}], "name": "Processing pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: processing-pipeline
+spec:
+  params:
+  - default: Hello world
+    name: text
+  tasks:
+  - name: truncate-text
+    params:
+    - name: text
+      value: $(params.text)
+    taskRef:
+      name: truncate-text
+  - name: get-item-from-list
+    params:
+    - name: truncate-text-output
+      value: $(tasks.truncate-text.results.output)
+    taskRef:
+      name: get-item-from-list
+  - name: print-small-text
+    params:
+    - name: get-item-from-list-output
+      value: $(tasks.get-item-from-list.results.output)
+    taskRef:
+      name: print-small-text
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: processing-pipeline-run
+spec:
+  params:
+  - name: text
+    value: Hello world
+  pipelineRef:
+    name: processing-pipeline

--- a/samples/bigger_data_passing/producers_to_consumers_pipeline.yaml
+++ b/samples/bigger_data_passing/producers_to_consumers_pipeline.yaml
@@ -1,0 +1,227 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"name": "Produce one small output", "outputs":
+      [{"name": "Output", "type": "String"}]}'
+  name: produce-one-small-output
+spec:
+  results:
+  - description: /tmp/outputs/Output/data
+    name: output
+  steps:
+  - args:
+    - '----output-paths'
+    - $(results.output.path)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def produce_one_small_output()  :\n    return 'Hello world'\n\ndef _serialize_str(str_value:\
+      \ str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError('Value\
+      \ \"{}\" has type \"{}\" instead of str.'.format(str(str_value), str(type(str_value))))\n\
+      \    return str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Produce\
+      \ one small output', description='')\n_parser.add_argument(\"----output-paths\"\
+      , dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n\
+      _output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = produce_one_small_output(**_parsed_args)\n\
+      \n_outputs = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n\
+      ]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n\
+      \        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n  \
+      \      pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"name": "Produce two small outputs",
+      "outputs": [{"name": "text", "type": "String"}, {"name": "number", "type": "Integer"}]}'
+  name: produce-two-small-outputs
+spec:
+  results:
+  - description: /tmp/outputs/text/data
+    name: text
+  - description: /tmp/outputs/number/data
+    name: number
+  steps:
+  - args:
+    - '----output-paths'
+    - $(results.text.path)
+    - $(results.number.path)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def produce_two_small_outputs()      :\n    return (\"data 1\", 42)\n\ndef\
+      \ _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value, str):\n\
+      \        raise TypeError('Value \"{}\" has type \"{}\" instead of str.'.format(str(str_value),\
+      \ str(type(str_value))))\n    return str_value\n\ndef _serialize_int(int_value:\
+      \ int) -> str:\n    if isinstance(int_value, str):\n        return int_value\n\
+      \    if not isinstance(int_value, int):\n        raise TypeError('Value \"{}\"\
+      \ has type \"{}\" instead of int.'.format(str(int_value), str(type(int_value))))\n\
+      \    return str(int_value)\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Produce\
+      \ two small outputs', description='')\n_parser.add_argument(\"----output-paths\"\
+      , dest=\"_output_paths\", type=str, nargs=2)\n_parsed_args = vars(_parser.parse_args())\n\
+      _output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = produce_two_small_outputs(**_parsed_args)\n\
+      \n_output_serializers = [\n    _serialize_str,\n    _serialize_int,\n\n]\n\n\
+      import os\nfor idx, output_file in enumerate(_output_files):\n    try:\n   \
+      \     os.makedirs(os.path.dirname(output_file))\n    except OSError:\n     \
+      \   pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "text", "type": "String"},
+      {"name": "number", "type": "Integer"}], "name": "Consume two arguments"}'
+  name: consume-two-arguments
+spec:
+  params:
+  - name: produce-one-small-output-output
+  steps:
+  - args:
+    - --text
+    - $(inputs.params.produce-one-small-output-output)
+    - --number
+    - '42'
+    command:
+    - python3
+    - -u
+    - -c
+    - "def consume_two_arguments(text , number ):\n    print('Text={}'.format(text))\n\
+      \    print('Number={}'.format(str(number)))\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Consume\
+      \ two arguments', description='')\n_parser.add_argument(\"--text\", dest=\"\
+      text\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"\
+      --number\", dest=\"number\", type=int, required=True, default=argparse.SUPPRESS)\n\
+      _parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"\
+      _output_paths\", [])\n\n_outputs = consume_two_arguments(**_parsed_args)\n\n\
+      _output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "text", "type": "String"},
+      {"name": "number", "type": "Integer"}], "name": "Consume two arguments"}'
+  name: consume-two-arguments-2
+spec:
+  params:
+  - name: produce-two-small-outputs-number
+  - name: text
+  steps:
+  - args:
+    - --text
+    - $(inputs.params.text)
+    - --number
+    - $(inputs.params.produce-two-small-outputs-number)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def consume_two_arguments(text , number ):\n    print('Text={}'.format(text))\n\
+      \    print('Number={}'.format(str(number)))\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Consume\
+      \ two arguments', description='')\n_parser.add_argument(\"--text\", dest=\"\
+      text\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"\
+      --number\", dest=\"number\", type=int, required=True, default=argparse.SUPPRESS)\n\
+      _parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"\
+      _output_paths\", [])\n\n_outputs = consume_two_arguments(**_parsed_args)\n\n\
+      _output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "text", "type": "String"},
+      {"name": "number", "type": "Integer"}], "name": "Consume two arguments"}'
+  name: consume-two-arguments-3
+spec:
+  params:
+  - name: produce-two-small-outputs-number
+  - name: produce-two-small-outputs-text
+  steps:
+  - args:
+    - --text
+    - $(inputs.params.produce-two-small-outputs-text)
+    - --number
+    - $(inputs.params.produce-two-small-outputs-number)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def consume_two_arguments(text , number ):\n    print('Text={}'.format(text))\n\
+      \    print('Number={}'.format(str(number)))\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Consume\
+      \ two arguments', description='')\n_parser.add_argument(\"--text\", dest=\"\
+      text\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"\
+      --number\", dest=\"number\", type=int, required=True, default=argparse.SUPPRESS)\n\
+      _parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"\
+      _output_paths\", [])\n\n_outputs = consume_two_arguments(**_parsed_args)\n\n\
+      _output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline that passes data
+      from producer to consumer", "inputs": [{"default": "Hello world", "name": "text",
+      "optional": true, "type": "String"}], "name": "Producers to consumers pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: producers-to-consumers-pipeline
+spec:
+  params:
+  - default: Hello world
+    name: text
+  tasks:
+  - name: produce-one-small-output
+    taskRef:
+      name: produce-one-small-output
+  - name: produce-two-small-outputs
+    taskRef:
+      name: produce-two-small-outputs
+  - name: consume-two-arguments
+    params:
+    - name: produce-one-small-output-output
+      value: $(tasks.produce-one-small-output.results.output)
+    taskRef:
+      name: consume-two-arguments
+  - name: consume-two-arguments-2
+    params:
+    - name: produce-two-small-outputs-number
+      value: $(tasks.produce-two-small-outputs.results.number)
+    - name: text
+      value: $(params.text)
+    taskRef:
+      name: consume-two-arguments-2
+  - name: consume-two-arguments-3
+    params:
+    - name: produce-two-small-outputs-number
+      value: $(tasks.produce-two-small-outputs.results.number)
+    - name: produce-two-small-outputs-text
+      value: $(tasks.produce-two-small-outputs.results.text)
+    taskRef:
+      name: consume-two-arguments-3
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: producers-to-consumers-pipeline-run
+spec:
+  params:
+  - name: text
+    value: Hello world
+  pipelineRef:
+    name: producers-to-consumers-pipeline

--- a/samples/bigger_data_passing/sum_pipeline.yaml
+++ b/samples/bigger_data_passing/sum_pipeline.yaml
@@ -1,0 +1,216 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"default": "0", "name": "start",
+      "optional": true, "type": "Integer"}, {"default": "10", "name": "count", "optional":
+      true, "type": "Integer"}], "name": "Write numbers", "outputs": [{"name": "numbers",
+      "type": "String"}]}'
+  name: write-numbers
+spec:
+  params:
+  - name: count
+  steps:
+  - args:
+    - --count
+    - $(inputs.params.count)
+    - --numbers
+    - $(workspaces.write-numbers.path)/write-numbers-numbers
+    command:
+    - python3
+    - -u
+    - -c
+    - "def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n   \
+      \ os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\
+      \ndef write_numbers(numbers_path , start  = 0, count  = 10):\n    with open(numbers_path,\
+      \ 'w') as writer:\n        for i in range(start, count):\n            writer.write(str(i)\
+      \ + '\\n')\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Write\
+      \ numbers', description='')\n_parser.add_argument(\"--start\", dest=\"start\"\
+      , type=int, required=False, default=argparse.SUPPRESS)\n_parser.add_argument(\"\
+      --count\", dest=\"count\", type=int, required=False, default=argparse.SUPPRESS)\n\
+      _parser.add_argument(\"--numbers\", dest=\"numbers_path\", type=_make_parent_dirs_and_return_path,\
+      \ required=True, default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n\
+      _output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = write_numbers(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: write-numbers
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text.path)/write-numbers-numbers
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(text_path ): # The \"text\" input is untyped so that any data\
+      \ can be printed\n    '''Print text'''\n    with open(text_path, 'r') as reader:\n\
+      \        for line in reader:\n            print(line, end = '')\n\nimport argparse\n\
+      _parser = argparse.ArgumentParser(prog='Print text', description='Print text')\n\
+      _parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "numbers", "type":
+      "String"}], "name": "Sum numbers", "outputs": [{"name": "Output", "type": "Integer"}]}'
+  name: sum-numbers
+spec:
+  steps:
+  - args:
+    - --numbers
+    - $(workspaces.sum-numbers.path)/write-numbers-numbers
+    - '----output-paths'
+    - $(workspaces.sum-numbers.path)/sum-numbers-output
+    command:
+    - python3
+    - -u
+    - -c
+    - "def sum_numbers(numbers_path )  :\n    sum = 0\n    with open(numbers_path,\
+      \ 'r') as reader:\n        for line in reader:\n            sum = sum + int(line)\n\
+      \    return sum\n\ndef _serialize_int(int_value: int) -> str:\n    if isinstance(int_value,\
+      \ str):\n        return int_value\n    if not isinstance(int_value, int):\n\
+      \        raise TypeError('Value \"{}\" has type \"{}\" instead of int.'.format(str(int_value),\
+      \ str(type(int_value))))\n    return str(int_value)\n\nimport argparse\n_parser\
+      \ = argparse.ArgumentParser(prog='Sum numbers', description='')\n_parser.add_argument(\"\
+      --numbers\", dest=\"numbers_path\", type=str, required=True, default=argparse.SUPPRESS)\n\
+      _parser.add_argument(\"----output-paths\", dest=\"_output_paths\", type=str,\
+      \ nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"\
+      _output_paths\", [])\n\n_outputs = sum_numbers(**_parsed_args)\n\n_outputs =\
+      \ [_outputs]\n\n_output_serializers = [\n    _serialize_int,\n\n]\n\nimport\
+      \ os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n\
+      \    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n\
+      \        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: sum-numbers
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text-2
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text-2.path)/sum-numbers-output
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(text_path ): # The \"text\" input is untyped so that any data\
+      \ can be printed\n    '''Print text'''\n    with open(text_path, 'r') as reader:\n\
+      \        for line in reader:\n            print(line, end = '')\n\nimport argparse\n\
+      _parser = argparse.ArgumentParser(prog='Print text', description='Print text')\n\
+      _parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "100000", "name":
+      "count", "optional": true, "type": "Integer"}], "name": "Sum pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: sum-pipeline
+spec:
+  params:
+  - default: '100000'
+    name: count
+  tasks:
+  - name: write-numbers
+    params:
+    - name: count
+      value: $(params.count)
+    taskRef:
+      name: write-numbers
+    workspaces:
+    - name: write-numbers
+      workspace: sum-pipeline
+  - name: print-text
+    runAfter:
+    - write-numbers
+    taskRef:
+      name: print-text
+    workspaces:
+    - name: print-text
+      workspace: sum-pipeline
+  - name: sum-numbers
+    runAfter:
+    - write-numbers
+    taskRef:
+      name: sum-numbers
+    workspaces:
+    - name: sum-numbers
+      workspace: sum-pipeline
+  - name: print-text-2
+    runAfter:
+    - sum-numbers
+    taskRef:
+      name: print-text-2
+    workspaces:
+    - name: print-text-2
+      workspace: sum-pipeline
+  workspaces:
+  - name: sum-pipeline
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: sum-pipeline-run
+spec:
+  params:
+  - name: count
+    value: '100000'
+  pipelineRef:
+    name: sum-pipeline
+  workspaces:
+  - name: sum-pipeline
+    persistentVolumeClaim:
+      claimName: sum-pipeline-run
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sum-pipeline-run
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem

--- a/samples/bigger_data_passing/task_output_to_consumer_pipeline.yaml
+++ b/samples/bigger_data_passing/task_output_to_consumer_pipeline.yaml
@@ -1,0 +1,126 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"name": "Produce one small output", "outputs":
+      [{"name": "Output", "type": "String"}]}'
+  name: produce-one-small-output
+spec:
+  results:
+  - description: /tmp/outputs/Output/data
+    name: output
+  steps:
+  - args:
+    - '----output-paths'
+    - $(results.output.path)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def produce_one_small_output()  :\n    return 'Hello world'\n\ndef _serialize_str(str_value:\
+      \ str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError('Value\
+      \ \"{}\" has type \"{}\" instead of str.'.format(str(str_value), str(type(str_value))))\n\
+      \    return str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Produce\
+      \ one small output', description='')\n_parser.add_argument(\"----output-paths\"\
+      , dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n\
+      _output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = produce_one_small_output(**_parsed_args)\n\
+      \n_outputs = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n\
+      ]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n\
+      \        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n  \
+      \      pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print small text", "inputs":
+      [{"name": "text", "type": "String"}], "name": "Print small text"}'
+  name: print-small-text
+spec:
+  params:
+  - name: produce-one-small-output-output
+  steps:
+  - args:
+    - --text
+    - $(inputs.params.produce-one-small-output-output)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_small_text(text ):\n    '''Print small text'''\n    print(text)\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print small text',\
+      \ description='Print small text')\n_parser.add_argument(\"--text\", dest=\"\
+      text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args =\
+      \ vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\"\
+      , [])\n\n_outputs = print_small_text(**_parsed_args)\n\n_output_serializers\
+      \ = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print small text", "inputs":
+      [{"name": "text", "type": "String"}], "name": "Print small text"}'
+  name: print-small-text-2
+spec:
+  params:
+  - name: produce-one-small-output-output
+  steps:
+  - args:
+    - --text
+    - $(inputs.params.produce-one-small-output-output)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_small_text(text ):\n    '''Print small text'''\n    print(text)\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print small text',\
+      \ description='Print small text')\n_parser.add_argument(\"--text\", dest=\"\
+      text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args =\
+      \ vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\"\
+      , [])\n\n_outputs = print_small_text(**_parsed_args)\n\n_output_serializers\
+      \ = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline that passes small
+      data from producer to consumer", "name": "Task output to consumer pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: task-output-to-consumer-pipeline
+spec:
+  tasks:
+  - name: produce-one-small-output
+    taskRef:
+      name: produce-one-small-output
+  - name: print-small-text
+    params:
+    - name: produce-one-small-output-output
+      value: $(tasks.produce-one-small-output.results.output)
+    taskRef:
+      name: print-small-text
+  - name: print-small-text-2
+    params:
+    - name: produce-one-small-output-output
+      value: $(tasks.produce-one-small-output.results.output)
+    taskRef:
+      name: print-small-text-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: task-output-to-consumer-pipeline-run
+spec:
+  pipelineRef:
+    name: task-output-to-consumer-pipeline

--- a/samples/bigger_data_passing/text_splitting_pipeline.yaml
+++ b/samples/bigger_data_passing/text_splitting_pipeline.yaml
@@ -1,0 +1,199 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "source", "type":
+      "String"}], "name": "Split text lines", "outputs": [{"name": "odd_lines", "type":
+      "String"}, {"name": "even_lines", "type": "String"}]}'
+  name: split-text-lines
+spec:
+  stepTemplate:
+    volumeMounts:
+    - mountPath: /tmp/inputs/source
+      name: source
+  steps:
+  - image: busybox
+    name: copy-inputs
+    script: '#!/bin/sh
+
+      set -exo pipefail
+
+      echo -n "one
+
+      two
+
+      three
+
+      four
+
+      five
+
+      six
+
+      seven
+
+      eight
+
+      nine
+
+      ten" > /tmp/inputs/source/data
+
+      '
+  - args:
+    - --source
+    - /tmp/inputs/source/data
+    - --odd-lines
+    - $(workspaces.split-text-lines.path)/split-text-lines-odd-lines
+    - --even-lines
+    - $(workspaces.split-text-lines.path)/split-text-lines-even-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n   \
+      \ os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\
+      \ndef split_text_lines(source_path , odd_lines_path , even_lines_path ):\n \
+      \   with open(source_path, 'r') as reader:\n        with open(odd_lines_path,\
+      \ 'w') as odd_writer:\n            with open(even_lines_path, 'w') as even_writer:\n\
+      \                while True:\n                    line = reader.readline()\n\
+      \                    if line == \"\":\n                        break\n     \
+      \               odd_writer.write(line)\n                    line = reader.readline()\n\
+      \                    if line == \"\":\n                        break\n     \
+      \               even_writer.write(line)\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Split\
+      \ text lines', description='')\n_parser.add_argument(\"--source\", dest=\"source_path\"\
+      , type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"\
+      --odd-lines\", dest=\"odd_lines_path\", type=_make_parent_dirs_and_return_path,\
+      \ required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"--even-lines\"\
+      , dest=\"even_lines_path\", type=_make_parent_dirs_and_return_path, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = split_text_lines(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  volumes:
+  - emptyDir: {}
+    name: source
+  workspaces:
+  - name: split-text-lines
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text.path)/split-text-lines-odd-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(text_path ): # The \"text\" input is untyped so that any data\
+      \ can be printed\n    '''Print text'''\n    with open(text_path, 'r') as reader:\n\
+      \        for line in reader:\n            print(line, end = '')\n\nimport argparse\n\
+      _parser = argparse.ArgumentParser(prog='Print text', description='Print text')\n\
+      _parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text-2
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text-2.path)/split-text-lines-even-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(text_path ): # The \"text\" input is untyped so that any data\
+      \ can be printed\n    '''Print text'''\n    with open(text_path, 'r') as reader:\n\
+      \        for line in reader:\n            print(line, end = '')\n\nimport argparse\n\
+      _parser = argparse.ArgumentParser(prog='Print text', description='Print text')\n\
+      _parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "Text splitting pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: text-splitting-pipeline
+spec:
+  tasks:
+  - name: split-text-lines
+    taskRef:
+      name: split-text-lines
+    workspaces:
+    - name: split-text-lines
+      workspace: text-splitting-pipeline
+  - name: print-text
+    runAfter:
+    - split-text-lines
+    taskRef:
+      name: print-text
+    workspaces:
+    - name: print-text
+      workspace: text-splitting-pipeline
+  - name: print-text-2
+    runAfter:
+    - split-text-lines
+    taskRef:
+      name: print-text-2
+    workspaces:
+    - name: print-text-2
+      workspace: text-splitting-pipeline
+  workspaces:
+  - name: text-splitting-pipeline
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: text-splitting-pipeline-run
+spec:
+  pipelineRef:
+    name: text-splitting-pipeline
+  workspaces:
+  - name: text-splitting-pipeline
+    persistentVolumeClaim:
+      claimName: text-splitting-pipeline-run
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: text-splitting-pipeline-run
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem

--- a/samples/bigger_data_passing/text_splitting_pipeline2.yaml
+++ b/samples/bigger_data_passing/text_splitting_pipeline2.yaml
@@ -1,0 +1,200 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "source", "type":
+      "String"}], "name": "Split text lines2", "outputs": [{"name": "odd_lines", "type":
+      "String"}, {"name": "even_lines", "type": "String"}]}'
+  name: split-text-lines2
+spec:
+  stepTemplate:
+    volumeMounts:
+    - mountPath: /tmp/inputs/source
+      name: source
+  steps:
+  - image: busybox
+    name: copy-inputs
+    script: '#!/bin/sh
+
+      set -exo pipefail
+
+      echo -n "one
+
+      two
+
+      three
+
+      four
+
+      five
+
+      six
+
+      seven
+
+      eight
+
+      nine
+
+      ten" > /tmp/inputs/source/data
+
+      '
+  - args:
+    - --source
+    - /tmp/inputs/source/data
+    - --odd-lines
+    - $(workspaces.split-text-lines2.path)/split-text-lines2-odd-lines
+    - --even-lines
+    - $(workspaces.split-text-lines2.path)/split-text-lines2-even-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def _parent_dirs_maker_that_returns_open_file(mode: str, encoding: str = None):\n\
+      \    def make_parent_dirs_and_return_path(file_path: str):\n        import os\n\
+      \        os.makedirs(os.path.dirname(file_path), exist_ok=True)\n        return\
+      \ open(file_path, mode=mode, encoding=encoding)\n    return make_parent_dirs_and_return_path\n\
+      \ndef split_text_lines2(source_file , odd_lines_file , even_lines_file ):\n\
+      \    while True:\n        line = source_file.readline()\n        if line ==\
+      \ \"\":\n            break\n        odd_lines_file.write(line)\n        line\
+      \ = source_file.readline()\n        if line == \"\":\n            break\n  \
+      \      even_lines_file.write(line)\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Split\
+      \ text lines2', description='')\n_parser.add_argument(\"--source\", dest=\"\
+      source_file\", type=argparse.FileType('rt'), required=True, default=argparse.SUPPRESS)\n\
+      _parser.add_argument(\"--odd-lines\", dest=\"odd_lines_file\", type=_parent_dirs_maker_that_returns_open_file('wt'),\
+      \ required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"--even-lines\"\
+      , dest=\"even_lines_file\", type=_parent_dirs_maker_that_returns_open_file('wt'),\
+      \ required=True, default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n\
+      _output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = split_text_lines2(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  volumes:
+  - emptyDir: {}
+    name: source
+  workspaces:
+  - name: split-text-lines2
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+    pipelines.kubeflow.org/task_display_name: Odd lines
+  name: print-text
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text.path)/split-text-lines2-odd-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(text_path ): # The \"text\" input is untyped so that any data\
+      \ can be printed\n    '''Print text'''\n    with open(text_path, 'r') as reader:\n\
+      \        for line in reader:\n            print(line, end = '')\n\nimport argparse\n\
+      _parser = argparse.ArgumentParser(prog='Print text', description='Print text')\n\
+      _parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+    pipelines.kubeflow.org/task_display_name: Even lines
+  name: print-text-2
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text-2.path)/split-text-lines2-even-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(text_path ): # The \"text\" input is untyped so that any data\
+      \ can be printed\n    '''Print text'''\n    with open(text_path, 'r') as reader:\n\
+      \        for line in reader:\n            print(line, end = '')\n\nimport argparse\n\
+      _parser = argparse.ArgumentParser(prog='Print text', description='Print text')\n\
+      _parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "Text splitting pipeline2"}'
+    sidecar.istio.io/inject: 'false'
+  name: text-splitting-pipeline2
+spec:
+  tasks:
+  - name: split-text-lines2
+    taskRef:
+      name: split-text-lines2
+    workspaces:
+    - name: split-text-lines2
+      workspace: text-splitting-pipeline2
+  - name: print-text
+    runAfter:
+    - split-text-lines2
+    taskRef:
+      name: print-text
+    workspaces:
+    - name: print-text
+      workspace: text-splitting-pipeline2
+  - name: print-text-2
+    runAfter:
+    - split-text-lines2
+    taskRef:
+      name: print-text-2
+    workspaces:
+    - name: print-text-2
+      workspace: text-splitting-pipeline2
+  workspaces:
+  - name: text-splitting-pipeline2
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: text-splitting-pipeline2-run
+spec:
+  pipelineRef:
+    name: text-splitting-pipeline2
+  workspaces:
+  - name: text-splitting-pipeline2
+    persistentVolumeClaim:
+      claimName: text-splitting-pipeline2-run
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: text-splitting-pipeline2-run
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem

--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -13,17 +13,18 @@
 # limitations under the License.
 
 from typing import List, Text, Dict, Any
+# from kfp.compiler._data_passing_rewriter import fix_big_data_passing
+import copy
+import json
+import re
+from typing import Optional, Set
+from . import _op_to_template
 
 
-def fix_big_data_passing(workflow: List[Dict[Text, Any]]) -> List[Dict[Text, Any]]:  # Tekton change signature
+def fix_big_data_passing(
+    workflow: List[Dict[Text, Any]]
+) -> List[Dict[Text, Any]]:  # Tekton change signature
     """
-    Currently this function does not do anything.
-
-    TODO: evaluate if an implementation similar to the upstream function in KFP
-          is required
-
-    Documentation from KFP:
-
     fix_big_data_passing converts a workflow where some artifact data is passed
     as parameters and converts it to a workflow where this data is passed as
     artifacts.
@@ -35,12 +36,12 @@ def fix_big_data_passing(workflow: List[Dict[Text, Any]]) -> List[Dict[Text, Any
 
     Motivation:
 
-    DSL compiler only supports passing Argo parameters.
+    DSL compiler only supports passing Tekton parameters.
     Due to the convoluted nature of the DSL compiler, the artifact consumption
     and passing has been implemented on top of that using parameter passing.
     The artifact data is passed as parameters and the consumer template creates
     an artifact/file out of that data.
-    Due to the limitations of Kubernetes and Argo this scheme cannot pass data
+    Due to the limitations of Kubernetes and Tekton this scheme cannot pass data
     larger than few kilobytes preventing any serious use of artifacts.
 
     This function rewrites the compiled workflow so that the data consumed as
@@ -52,14 +53,622 @@ def fix_big_data_passing(workflow: List[Dict[Text, Any]]) -> List[Dict[Text, Any
 
     Implementation:
 
-    1. Index the DAGs to understand how data is being passed and which inputs/outputs
+    1. Index the pipelines to understand how data is being passed and which inputs/outputs
        are connected to each other.
     2. Search for direct data consumers in container/resource templates and some
-       DAG task attributes (e.g. conditions and loops) to find out which inputs
+       pipeline task attributes (e.g. conditions and loops) to find out which inputs
        are directly consumed as parameters/artifacts.
     3. Propagate the consumption information upstream to all inputs/outputs all
        the way up to the data producers.
-    4. Convert the inputs, outputs and arguments based on how they're consumed
-       downstream.
+    4. Convert the inputs, outputs based on how they're consumed downstream.
+    5. Use workspaces instead of result and params for bigger data passing.
+    6. Added workspaces to tasks, pipelines, pipelineruns, if the parmas is bigger data.
+    7. A PVC named with pipelinerun name will be created if bigger data passing, as workspaces need to use it.
+       User need to define proper volume or enable dynamic volume provisioning refer to the link of:
+       https://kubernetes.io/docs/concepts/storage/dynamic-provisioning
     """
+
+    workflow = copy.deepcopy(workflow)
+    resource_templates = []
+    for template in workflow:
+        resource_params = [
+            param.get('name') for param in template.get('spec', {}).get('params', [])
+            if param.get('name') == 'action'
+            or param.get('name') == 'success-condition'
+        ]
+        if 'action' in resource_params and 'success-condition' in resource_params:
+            resource_templates.append(template)
+
+    resource_template_names = set(
+        template.get('metadata', {}).get('name')
+        for template in resource_templates)
+
+    container_templates = [
+        template for template in workflow
+        if template['kind'] == 'Task' and template.get('metadata', {}).get(
+            'name') not in resource_template_names
+    ]
+
+    pipeline_templates = [
+        template for template in workflow if template['kind'] == 'Pipeline'
+    ]
+
+    pipelinerun_templates = [
+        template for template in workflow if template['kind'] == 'PipelineRun'
+    ]
+
+    # we need to make the format in tekton unified for params, artifacts, outputs.
+    container_templates = unify_container_params(container_templates)
+    pipeline_templates = unify_pipeline_params(pipeline_templates)
+    pipelinerun_templates = unify_pipelinerun_params(pipelinerun_templates)
+
+    # 1. Index the pipelines to understand how data is being passed and which
+    #  inputs/outputs are connected to each other.
+    template_input_to_parent_pipeline_inputs = {
+    }  # (task_template_name, task_input_name) -> Set[(pipeline_template_name, pipeline_input_name)]
+    template_input_to_parent_task_outputs = {
+    }  # (task_template_name, task_input_name) -> Set[(upstream_template_name, upstream_output_name)]
+    template_input_to_parent_constant_arguments = {
+    }  # (task_template_name, task_input_name) -> Set[argument_value] # Unused
+    pipeline_output_to_parent_template_outputs = {
+    }  # (pipeline_template_name, output_name) -> Set[(upstream_template_name, upstream_output_name)]
+
+    for template in pipeline_templates:
+        pipeline_template_name = template.get('metadata', {}).get('name')
+        # Indexing task arguments
+        pipeline_tasks = template.get('spec', {})['tasks']
+        task_name_to_template_name = {
+            task['name']: task['taskRef']['name']
+            for task in pipeline_tasks
+        }
+        for task in pipeline_tasks:
+            task_template_name = task['taskRef']['name']
+            parameter_arguments = task['params']
+            for parameter_argument in parameter_arguments:
+                task_input_name = parameter_argument['name']
+                argument_value = parameter_argument['value']
+
+                argument_placeholder_parts = deconstruct_tekton_single_placeholder(
+                    argument_value)
+                if not argument_placeholder_parts:  # Argument is considered to be constant string
+                    template_input_to_parent_constant_arguments.setdefault(
+                        (task_template_name, task_input_name),
+                        set()).add(argument_value)
+                else:
+                    placeholder_type = argument_placeholder_parts[0]
+                    if placeholder_type not in ('params', 'outputs', 'tasks',
+                                                'steps', 'workflow', 'pod',
+                                                'item'):
+                        # Do not fail on Jinja or other double-curly-brace templates
+                        continue
+                    if placeholder_type == 'params':
+                        pipeline_input_name = argument_placeholder_parts[1]
+                        template_input_to_parent_pipeline_inputs.setdefault(
+                            (task_template_name, task_input_name), set()).add(
+                                (pipeline_template_name, pipeline_input_name))
+                    elif placeholder_type == 'tasks':
+                        upstream_task_name = argument_placeholder_parts[1]
+                        assert argument_placeholder_parts[2] == 'results'
+                        upstream_output_name = argument_placeholder_parts[3]
+                        upstream_template_name = task_name_to_template_name[
+                            upstream_task_name]
+                        template_input_to_parent_task_outputs.setdefault(
+                            (task_template_name, task_input_name), set()).add(
+                                (upstream_template_name, upstream_output_name))
+                    elif placeholder_type == 'item' or placeholder_type == 'workflow' or placeholder_type == 'pod':
+                        # workflow.parameters.* placeholders are not supported,
+                        # but the DSL compiler does not produce those.
+                        template_input_to_parent_constant_arguments.setdefault(
+                            (task_template_name, task_input_name),
+                            set()).add(argument_value)
+                    else:
+                        raise AssertionError
+
+                pipeline_input_name = extract_tekton_input_parameter_name(
+                    argument_value)
+                if pipeline_input_name:
+                    template_input_to_parent_pipeline_inputs.setdefault(
+                        (task_template_name, task_input_name), set()).add(
+                            (pipeline_template_name, pipeline_input_name))
+                else:
+                    template_input_to_parent_constant_arguments.setdefault(
+                        (task_template_name, task_input_name),
+                        set()).add(argument_value)
+    # Finshed indexing the pipelines
+
+    # 2. Search for direct data consumers in container/resource templates and some pipeline task attributes
+    #  (e.g. conditions and loops) to find out which inputs are directly consumed as parameters/artifacts.
+    inputs_directly_consumed_as_parameters = set()
+    inputs_directly_consumed_as_artifacts = set()
+    outputs_directly_consumed_as_parameters = set()
+
+    # Searching for artifact input consumers in container template inputs
+    for template in container_templates:
+        template_name = template.get('metadata', {}).get('name')
+        for input_artifact in template.get('spec', {}).get('artifacts', {}):
+            raw_data = input_artifact['raw'][
+                'data']  # The structure must exist
+            # The raw data must be a single input parameter reference. Otherwise (e.g. it's a string
+            #  or a string with multiple inputs) we should not do the conversion to artifact passing.
+            input_name = extract_tekton_input_parameter_name(raw_data)
+            if input_name:
+                inputs_directly_consumed_as_artifacts.add(
+                    (template_name, input_name))
+                del input_artifact[
+                    'raw']  # Deleting the "default value based" data passing hack
+                # so that it's replaced by the "argument based" way of data passing.
+                input_artifact[
+                    'name'] = input_name  # The input artifact name should be the same
+                # as the original input parameter name
+
+    # Searching for parameter input consumers in pipeline templates
+    # TODO: loop params is not support for tekton yet, refer to https://github.com/kubeflow/kfp-tekton/issues/82
+    for template in pipeline_templates:
+        template_name = template.get('metadata', {}).get('name')
+        pipeline_tasks = template.get('spec', {})['tasks']
+        task_name_to_template_name = {
+            task['name']: task['taskRef']['name']
+            for task in pipeline_tasks
+        }
+        for task in pipeline_tasks:
+            # We do not care about the inputs mentioned in task arguments
+            # since we will be free to switch them from parameters to artifacts
+            task_without_arguments = task.copy()  # Shallow copy
+            task_without_arguments.pop('params', None)
+            placeholders = extract_all_tekton_placeholders(
+                task_without_arguments)
+            for placeholder in placeholders:
+                parts = placeholder.split('.')
+                placeholder_type = parts[0]
+                if placeholder_type not in ('inputs', 'outputs', 'tasks',
+                                            'steps', 'workflow', 'pod',
+                                            'item'):
+                    # Do not fail on Jinja or other double-curly-brace templates
+                    continue
+                if placeholder_type == 'inputs':
+                    if parts[1] == 'parameters':
+                        input_name = parts[2]
+                        inputs_directly_consumed_as_parameters.add(
+                            (template_name, input_name))
+                    else:
+                        raise AssertionError
+                elif placeholder_type == 'tasks':
+                    upstream_task_name = parts[1]
+                    assert parts[2] == 'results'
+                    upstream_output_name = parts[3]
+                    upstream_template_name = task_name_to_template_name[
+                        upstream_task_name]
+                    outputs_directly_consumed_as_parameters.add(
+                        (upstream_template_name, upstream_output_name))
+                elif placeholder_type == 'workflow' or placeholder_type == 'pod':
+                    pass
+                elif placeholder_type == 'item':
+                    raise AssertionError(
+                        'The "{{item}}" placeholder is not expected outside task arguments.'
+                    )
+                else:
+                    raise AssertionError(
+                        'Unexpected placeholder type "{}".'.format(
+                            placeholder_type))
+
+    # Searching for parameter input consumers in container and resource templates
+    for template in container_templates + resource_templates:
+        template_name = template.get('metadata', {}).get('name')
+        placeholders = extract_all_tekton_placeholders(template)
+        for placeholder in placeholders:
+            parts = placeholder.split('.')
+            placeholder_type = parts[0]
+            if placeholder_type not in ('inputs', 'outputs', 'tasks', 'steps',
+                                        'workflow', 'pod', 'item', 'results'):
+                # Do not fail on Jinja or other double-curly-brace templates
+                continue
+
+            if placeholder_type == 'workflow' or placeholder_type == 'pod':
+                pass
+            elif placeholder_type == 'inputs':
+                if parts[1] == 'params':
+                    input_name = parts[2]
+                    inputs_directly_consumed_as_parameters.add(
+                        (template_name, input_name))
+                elif parts[1] == 'artifacts':
+                    raise AssertionError(
+                        'Found unexpected Tekton input artifact placeholder in container template: {}'
+                        .format(placeholder))
+                else:
+                    raise AssertionError(
+                        'Found unexpected Tekton input placeholder in container template: {}'
+                        .format(placeholder))
+            elif placeholder_type == 'results':
+                input_name = parts[1]
+                outputs_directly_consumed_as_parameters.add(
+                    (template_name, input_name))
+            else:
+                raise AssertionError(
+                    'Found unexpected Tekton placeholder in container template: {}'
+                    .format(placeholder))
+
+    # Finished indexing data consumers
+
+    # 3. Propagate the consumption information upstream to all inputs/outputs all the way up to the data producers.
+    inputs_consumed_as_parameters = set()
+    inputs_consumed_as_artifacts = set()
+
+    outputs_consumed_as_parameters = set()
+    outputs_consumed_as_artifacts = set()
+
+    def mark_upstream_ios_of_input(template_input, marked_inputs,
+                                   marked_outputs):
+        # Stopping if the input has already been visited to save time and handle recursive calls
+        if template_input in marked_inputs:
+            return
+        marked_inputs.add(template_input)
+
+        upstream_inputs = template_input_to_parent_pipeline_inputs.get(
+            template_input, [])
+        for upstream_input in upstream_inputs:
+            mark_upstream_ios_of_input(upstream_input, marked_inputs,
+                                       marked_outputs)
+
+        upstream_outputs = template_input_to_parent_task_outputs.get(
+            template_input, [])
+        for upstream_output in upstream_outputs:
+            mark_upstream_ios_of_output(upstream_output, marked_inputs,
+                                        marked_outputs)
+
+    def mark_upstream_ios_of_output(template_output, marked_inputs,
+                                    marked_outputs):
+        # Stopping if the output has already been visited to save time and handle recursive calls
+        if template_output in marked_outputs:
+            return
+        marked_outputs.add(template_output)
+
+        upstream_outputs = pipeline_output_to_parent_template_outputs.get(
+            template_output, [])
+        for upstream_output in upstream_outputs:
+            mark_upstream_ios_of_output(upstream_output, marked_inputs,
+                                        marked_outputs)
+
+    for input in inputs_directly_consumed_as_parameters:
+        mark_upstream_ios_of_input(input, inputs_consumed_as_parameters,
+                                   outputs_consumed_as_parameters)
+    for input in inputs_directly_consumed_as_artifacts:
+        mark_upstream_ios_of_input(input, inputs_consumed_as_artifacts,
+                                   outputs_consumed_as_artifacts)
+    for output in outputs_directly_consumed_as_parameters:
+        mark_upstream_ios_of_output(output, inputs_consumed_as_parameters,
+                                    outputs_consumed_as_parameters)
+
+    # 4. Convert the inputs, outputs and arguments based on how they're consumed downstream.
+    # Add workspaces to pipeline and pipeline task_ref if bigger data passing
+    pipeline_workspaces = set()
+    pipelinerun_workspaces = set()
+    output_tasks_consumed_as_artifacts = {
+        output[0]
+        for output in outputs_consumed_as_artifacts
+    }
+    # task_workspaces = set()
+    for pipeline in pipeline_templates:
+        # Converting pipeline inputs
+        pipeline, pipeline_workspaces = big_data_passing_pipeline(
+            pipeline, inputs_consumed_as_artifacts,
+            output_tasks_consumed_as_artifacts)
+
+    # Add workspaces to pipelinerun if bigger data passing
+    # Check whether pipelinerun was generated, through error if not.
+    if pipeline_workspaces:
+        if not pipelinerun_templates:
+            raise AssertionError(
+                'Found bigger data passing, please enable generate_pipelinerun for your complier'
+            )
+        for pipelinerun in pipelinerun_templates:
+            pipeline, pipelinerun_workspaces = big_data_passing_pipelinerun(
+                pipelinerun, pipeline_workspaces)
+
+    # Use workspaces to tasks if bigger data passing instead of 'results', 'copy-inputs'
+    for task_template in container_templates:
+        task_template = big_data_passing_tasks(
+            task_template, inputs_consumed_as_artifacts,
+            outputs_consumed_as_artifacts)
+
+    # Create pvc for pipelinerun if bigger data passing.
+    # As we used workspaces in tekton pipelines which depends on it.
+    # User need to create PV manually, or enable dynamic volume provisioning, refer to the link of:
+    # https://kubernetes.io/docs/concepts/storage/dynamic-provisioning
+    # TODO: Remove PVC if Tekton version > = 0.12, use 'volumeClaimTemplate' instead
+    if pipelinerun_workspaces:
+        for pipelinerun in pipelinerun_workspaces:
+            workflow.append(create_pvc(pipelinerun))
+
+    # Remove input parameters unless they're used downstream.
+    # This also removes unused container template inputs if any.
+    for template in container_templates + pipeline_templates:
+        spec = template.get('spec', {})
+        spec['params'] = [
+            input_parameter for input_parameter in spec.get('params', [])
+            if (template.get('metadata', {}).get('name'),
+                input_parameter['name']) in inputs_consumed_as_parameters
+        ]
+
+    # Remove output parameters unless they're used downstream
+    for template in container_templates + pipeline_templates:
+        spec = template.get('spec', {})
+        spec['results'] = [
+            output_parameter for output_parameter in spec.get('results', [])
+            if (template.get('metadata', {}).get('name'),
+                output_parameter['name']) in outputs_consumed_as_parameters
+        ]
+
+    # Remove pipeline task parameters unless they're used downstream
+    for template in pipeline_templates:
+        tasks = template.get('spec', {}).get('tasks', [])
+        for task in tasks:
+            task['params'] = [
+                parameter_argument
+                for parameter_argument in task.get('params', [])
+                if (task['taskRef']['name'], parameter_argument['name']
+                    ) in inputs_consumed_as_parameters and
+                (task['taskRef']['name'], parameter_argument['name']
+                 ) not in inputs_consumed_as_artifacts
+                or task['taskRef']['name'] in resource_template_names
+            ]
+
+    # Need to confirm:
+    # I didn't find the use cases to support workflow parameter consumed as artifacts downstream in tekton.
+    # Whether this case need to be supporting?
+
+    clean_up_empty_workflow_structures(workflow)
     return workflow
+
+
+# Replaced '_' to '-' to make the format in tekton unified for params, artifacts, outputs.
+def unify_container_params(templates: list):
+    for template in templates:
+        template_params = template.get('spec', {}).get('params', [])
+        for template_param in template_params:
+            template_param['name'] = template_param.get('name').replace(
+                '_', '-')
+        template_artifacts = template.get('spec', {}).get('artifacts', [])
+        for template_artifact in template_artifacts:
+            template_artifact['raw']['data'] = template_artifact.get(
+                'raw', {}).get('data').replace('_', '-')
+    return templates
+
+
+def unify_pipeline_params(templates: list):
+    for template in templates:
+        tasks = template.get('spec', {}).get('tasks', [])
+        pipeline_params = template.get('spec', {}).get('params', [])
+        for pipeline_param in pipeline_params:
+            pipeline_param['name'] = pipeline_param.get('name').replace(
+                '_', '-')
+        for task in tasks:
+            task_params = task.get('params')
+            for task_param in task_params:
+                task_param['name'] = task_param.get('name').replace('_', '-')
+                task_param['value'] = task_param.get('value').replace('_', '-')
+    return templates
+
+
+def unify_pipelinerun_params(templates: list):
+    for template in templates:
+        pipelinerun_params = template.get('spec', {}).get('params', [])
+        for pipelinerun_param in pipelinerun_params:
+            pipelinerun_param['name'] = pipelinerun_param.get('name').replace(
+                '_', '-')
+    return templates
+
+
+def extract_all_tekton_placeholders(template: dict) -> Set[str]:
+    template_str = json.dumps(template)
+    placeholders = set(re.findall('\\$\\(([-._a-zA-Z0-9]+)\\)', template_str))
+    return placeholders
+
+
+def extract_tekton_input_parameter_name(s: str) -> Optional[str]:
+    match = re.fullmatch('\\$\\(inputs.params.([-_a-zA-Z0-9]+)\\)', s)
+    if not match:
+        return None
+    (input_name, ) = match.groups()
+    return input_name
+
+
+def deconstruct_tekton_single_placeholder(s: str) -> List[str]:
+    if not re.fullmatch('\\$\\([-._a-zA-Z0-9]+\\)', s):
+        return None
+    return s.lstrip('$(').rstrip(')').split('.')
+
+
+def replace_bigger_data_placeholder(template: dict, old_str: str,
+                                    new_str: str) -> dict:
+    template_str = json.dumps(template)
+    template_str = template_str.replace(old_str, new_str)
+    template = json.loads(template_str)
+    return template
+
+
+def big_data_passing_pipeline(template: dict, inputs_tasks: set(),
+                                 outputs_tasks: set):
+    pipeline_workspaces = set()
+    pipeline_name = template.get('metadata', {}).get('name')
+    pipeline_spec = template.get('spec', {})
+    tasks = pipeline_spec.get('tasks', [])
+    for task in tasks:
+        parameter_arguments = task.get('params', [])
+        for parameter_argument in parameter_arguments:
+            input_name = parameter_argument['name']
+            if (task.get('taskRef',
+                         {}).get('name'), input_name) in inputs_tasks:
+                pipeline_workspaces.add(pipeline_name)
+                # Add workspaces instead of parmas, for tasks of bigger data inputs
+                if not task.setdefault('workspaces', []):
+                    task['workspaces'].append({
+                        "name": task.get('name'),
+                        "workspace": pipeline_name
+                    })
+                # runAfter add to the task, which was depends on the result of the task.
+                argument_value = parameter_argument['value']
+                argument_placeholder_parts = deconstruct_tekton_single_placeholder(
+                    argument_value)
+                if argument_placeholder_parts[
+                        0] == 'tasks' and argument_placeholder_parts[
+                            2] == 'results':
+                    dependency_task = argument_placeholder_parts[1]
+                    task.setdefault('runAfter', [])
+                    task['runAfter'].append(dependency_task)
+        if task.get('taskRef', {}).get('name') in outputs_tasks:
+            # Add workspaces for tasks of bigger data outputs
+            if not task.setdefault('workspaces', []):
+                task['workspaces'].append({
+                    "name": task.get('name'),
+                    "workspace": pipeline_name
+                })
+    if pipeline_name in pipeline_workspaces:
+        # Add workspaces to pipeline
+        if not pipeline_spec.setdefault('workspaces', []):
+            pipeline_spec['workspaces'].append({"name": pipeline_name})
+    return template, pipeline_workspaces
+
+
+def big_data_passing_pipelinerun(pr: dict, pw: set):
+    prw = set()
+    pipelinerun_name = pr.get('metadata', {}).get('name')
+    pipeline_ref_name = pr.get('spec', {}).get('pipelineRef', {}).get('name')
+    if pipeline_ref_name in pw:
+        pr.get('spec', {}).setdefault('workspaces', [])
+        pr['spec']['workspaces'].append({
+            "name": pipeline_ref_name,
+            "persistentVolumeClaim": {
+                "claimName": pipelinerun_name
+            }
+        })
+        prw.add(pipelinerun_name)
+    return pr, prw
+
+
+def big_data_passing_tasks(task: dict, inputs_tasks: set,
+                              outputs_tasks: set) -> dict:
+    task_name = task.get('metadata', {}).get('name')
+    task_spec = task.get('spec', {})
+    # Data passing for the task outputs
+    task_outputs = task_spec.get('results', [])
+    for task_output in task_outputs:
+        if (task_name, task_output.get('name')) in outputs_tasks:
+            if not task_spec.setdefault('workspaces', []):
+                task_spec['workspaces'].append({"name": task_name})
+            # Replace the args for the outputs in the task_spec
+            # $(results.task_output.get('name').path)  -->
+            # $(workspaces.task_name.path)/task_name-task_output.get('name')
+            placeholder = '$(results.%s.path)' % (task_output.get('name'))
+            workspaces_parameter = '$(workspaces.%s.path)/%s-%s' % (
+                task_name, task_name, task_output.get('name'))
+            task['spec'] = replace_bigger_data_placeholder(
+                task['spec'], placeholder, workspaces_parameter)
+
+    # Remove artifacts outputs from results
+    task['spec']['results'] = [
+        result for result in task_outputs
+        if (task_name, result.get('name')) not in outputs_tasks
+    ]
+
+    # Data passing for task inputs
+    task_spec = task.get('spec', {})
+    task_parmas = task_spec.get('params', [])
+    task_artifacts = task_spec.get('artifacts', [])
+    for task_parma in task_parmas:
+        if (task_name, task_parma.get('name')) in inputs_tasks:
+            if not task_spec.setdefault('workspaces', []):
+                task_spec['workspaces'].append({"name": task_name})
+            # Replace the args for the inputs in the task_spec
+            # /tmp/inputs/text/data ---->
+            # $(workspaces.task_name.path)/task_parma.get('name')
+            placeholder = '/tmp/inputs/text/data'
+            for task_artifact in task_artifacts:
+                if task_artifact.get('name') == task_parma.get('name'):
+                    placeholder = task_artifact.get('path')
+            workspaces_parameter = '$(workspaces.%s.path)/%s' % (
+                task_name, task_parma.get('name'))
+            task['spec'] = replace_bigger_data_placeholder(
+                task_spec, placeholder, workspaces_parameter)
+    # Handle the case of input artifact without dependent the output of other tasks
+    for task_artifact in task_artifacts:
+        if (task_name, task_artifact.get('name')) not in inputs_tasks:
+            # add input artifact processes
+            task = input_artifacts_tasks(task, task_artifact)
+
+    # Remove artifacts parameter from params
+    task['spec']['params'] = [
+        parma for parma in task_parmas
+        if (task_name, parma.get('name')) not in inputs_tasks
+    ]
+
+    # Remove artifacts from task_spec
+    if 'artifacts' in task_spec:
+        del task['spec']['artifacts']
+
+    return task
+
+
+# Create pvc for pipelinerun if bigger data passing.
+# As we used workspaces in tekton pipelines which depends on it.
+# User need to create PV manually, or enable dynamic volume provisioning, refer to the link of:
+# https://kubernetes.io/docs/concepts/storage/dynamic-provisioning
+# TODO: Remove PVC if Tekton version > = 0.12, use 'volumeClaimTemplate' instead
+def create_pvc(pr: str) -> dict:
+    pvc = {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {
+            "name": pr
+        },
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {
+                "requests": {
+                    "storage": "100Mi"
+                }
+            },
+            "volumeMode": "Filesystem",
+        }
+    }
+    return pvc
+
+
+def input_artifacts_tasks(template: dict, artifact: dict) -> dict:
+    # The input artifacts in KFP is not pulling from s3, it will always be passed as a raw input.
+    # Visit https://github.com/kubeflow/pipelines/issues/336 for more details on the implementation.
+    volume_mount_step_template = []
+    volume_template = []
+    mounted_param_paths = []
+    copy_inputs_step = _op_to_template._get_base_step('copy-inputs')
+    if 'raw' in artifact:
+        copy_inputs_step['script'] += 'echo -n "%s" > %s\n' % (
+            artifact['raw']['data'], artifact['path'])
+    mount_path = artifact['path'].rsplit("/", 1)[0]
+    if mount_path not in mounted_param_paths:
+        _op_to_template._add_mount_path(artifact['name'], artifact['path'],
+                                        mount_path, volume_mount_step_template,
+                                        volume_template, mounted_param_paths)
+    template['spec']['steps'] = _op_to_template._prepend_steps(
+        [copy_inputs_step], template['spec']['steps'])
+    _op_to_template._update_volumes(template, volume_mount_step_template,
+                                    volume_template)
+    return template
+
+
+def clean_up_empty_workflow_structures(workflow: list):
+    for template in workflow:
+        template_spec = template.setdefault('spec', {})
+        if not template_spec.setdefault('params', []):
+            del template_spec['params']
+        if not template_spec.setdefault('artifacts', []):
+            del template_spec['artifacts']
+        if not template_spec.setdefault('results', []):
+            del template_spec['results']
+        if not template_spec:
+            del template['spec']
+        if template['kind'] == 'Pipeline':
+            for task in template['spec'].get('tasks', []):
+                if not task.setdefault('params', []):
+                    del task['params']
+                if not task.setdefault('artifacts', []):
+                    del task['artifacts']

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -158,8 +158,8 @@ def _add_mount_path(name: str,
     """
     Add emptyDir to the given mount_path for persisting files within the same tasks
     """
-    volume_mount_step_template.append({'name': name, 'mountPath': path.rsplit("/", 1)[0]})
-    volume_template.append({'name': name, 'emptyDir': {}})
+    volume_mount_step_template.append({'name': sanitize_k8s_name(name), 'mountPath': path.rsplit("/", 1)[0]})
+    volume_template.append({'name': sanitize_k8s_name(name), 'emptyDir': {}})
     mounted_param_paths.append(mount_path)
 
 
@@ -328,8 +328,10 @@ def _process_output_artifacts(outputs_dict: Dict[Text, Any],
                 copy_artifacts_step['script'] = copy_artifacts_step['script'] + \
                     'mc cp %s storage/%s/runs/$PIPELINERUN/$PODNAME/%s\n' % (artifact['path'], bucket, artifact['path'].rsplit("/", 1)[1])
                 if artifact['path'].rsplit("/", 1)[0] not in mounted_artifact_paths:
-                    volume_mount_step_template.append({'name': artifact['name'], 'mountPath': artifact['path'].rsplit("/", 1)[0]})
-                    volume_template.append({'name': artifact['name'], 'emptyDir': {}})
+                    volume_mount_step_template.append({
+                        'name': sanitize_k8s_name(artifact['name']), 'mountPath': artifact['path'].rsplit("/", 1)[0]
+                    })
+                    volume_template.append({'name': sanitize_k8s_name(artifact['name']), 'emptyDir': {}})
                     mounted_artifact_paths.append(artifact['path'].rsplit("/", 1)[0])
         return copy_artifacts_step
     else:
@@ -355,7 +357,7 @@ def _process_base_ops(op: BaseOp):
 
     # map param's (unsanitized pattern or serialized str pattern) -> input param var str
     map_to_tmpl_var = {
-        (param.pattern or str(param)): '$(inputs.params.%s)' % param.full_name  # Tekton change
+        (param.pattern or str(param)): '$(inputs.params.%s)' % param.full_name.replace('_', '-')  # Tekton change
         for param in op.inputs
     }
 
@@ -449,18 +451,8 @@ def _op_to_template(op: BaseOp, enable_artifacts=False):
         elif isinstance(op, dsl.ResourceOp):
             template['spec']['params'].extend(inputs['parameters'])
     if 'artifacts' in inputs:
-        # The input artifacts in KFP is not pulling from s3, it will always be passed as a raw input.
-        # Visit https://github.com/kubeflow/pipelines/issues/336 for more details on the implementation.
-        copy_inputs_step = _get_base_step('copy-inputs')
-        for artifact in inputs['artifacts']:
-            if 'raw' in artifact:
-                copy_inputs_step['script'] += 'echo -n "%s" > %s\n' % (artifact['raw']['data'], artifact['path'])
-            mount_path = artifact['path'].rsplit("/", 1)[0]
-            if mount_path not in mounted_param_paths:
-                _add_mount_path(artifact['name'], artifact['path'], mount_path,
-                                volume_mount_step_template, volume_template, mounted_param_paths)
-        template['spec']['steps'] = _prepend_steps([copy_inputs_step], template['spec']['steps'])
-        _update_volumes(template, volume_mount_step_template, volume_template)
+        # Leave artifacts for big data passing
+        template['spec']['artifacts'] = inputs['artifacts']
 
     # outputs
     if isinstance(op, dsl.ContainerOp):

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -231,6 +231,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.input_artifact_raw_value import input_artifact_pipeline
     self._test_pipeline_workflow(input_artifact_pipeline, 'input_artifact_raw_value.yaml')
 
+  def test_bigger_data_workflow(self):
+    """
+    Test compiling a big data passing workflow.
+    """
+    from .testdata.big_data_passing import file_passing_pipelines
+    self._test_pipeline_workflow(file_passing_pipelines, 'big_data_passing.yaml', generate_pipelinerun=True)
+
   def test_katib_workflow(self):
     """
     Test compiling a katib workflow.

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -32,10 +32,8 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: affinity
 spec:
-  params: []
   tasks:
   - name: sleep
-    params: []
     taskRef:
       name: sleep
 ---
@@ -44,7 +42,6 @@ kind: PipelineRun
 metadata:
   name: affinity-run
 spec:
-  params: []
   pipelineRef:
     name: affinity
   taskRunSpec:

--- a/sdk/python/tests/compiler/testdata/artifact_location.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_location.yaml
@@ -20,7 +20,7 @@ spec:
   params:
   - name: bucket
   - name: namespace
-  - name: secret_name
+  - name: secret-name
   - name: tag
   results:
   - description: /tmp/output.txt
@@ -49,12 +49,12 @@ spec:
       valueFrom:
         secretKeyRef:
           key: accesskey
-          name: $(inputs.params.secret_name)
+          name: $(inputs.params.secret-name)
     - name: AWS_SECRET_ACCESS_KEY
       valueFrom:
         secretKeyRef:
           key: secretkey
-          name: $(inputs.params.secret_name)
+          name: $(inputs.params.secret-name)
     image: minio/mc
     name: copy-artifacts
     script: '#!/usr/bin/env sh
@@ -83,7 +83,7 @@ metadata:
 spec:
   params:
   - default: mlpipeline-minio-artifact
-    name: secret_name
+    name: secret-name
   - default: 1.31.0
     name: tag
   - default: kubeflow
@@ -97,8 +97,8 @@ spec:
       value: $(params.bucket)
     - name: namespace
       value: $(params.namespace)
-    - name: secret_name
-      value: $(params.secret_name)
+    - name: secret-name
+      value: $(params.secret-name)
     - name: tag
       value: $(params.tag)
     taskRef:

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -90,7 +90,6 @@ spec:
     name: outputpath
   tasks:
   - name: exiting
-    params: []
     taskRef:
       name: exiting
   - name: get-frequent

--- a/sdk/python/tests/compiler/testdata/big_data_passing.py
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.py
@@ -1,0 +1,229 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# %% [markdown]
+# # Data passing tutorial
+# Data passing is the most important aspect of Pipelines.
+#
+# In Kubeflow Pipelines, the pipeline authors compose pipelines by creating component instances (tasks)
+# and connecting them together.
+#
+# Component have inputs and outputs. They can consume and produce arbitrary data.
+#
+# Pipeline authors establish connections between component tasks by connecting their data inputs and outputs
+# - by passing the output of one task as an argument to another task's input.
+#
+# The system takes care of storing the data produced by components and later passing that data
+# to other components for consumption as instructed by the pipeline.
+#
+# This tutorial shows how to create python components that produce, consume and transform data.
+# It shows how to create data passing pipelines by instantiating components and connecting them together.
+
+# %%
+
+from kfp.components import func_to_container_op, InputPath, OutputPath
+
+# %% [markdown]
+# ## Small data
+#
+# Small data is the data that you'll be comfortable passing as program's command-line argument.
+# Small data size should not exceed few kilobytes.
+#
+# Some examples of typical types of small data are: number, URL, small string (e.g. column name).
+#
+# Small lists, dictionaries and JSON structures are fine, but keep an eye on the size
+# and consider switching to file-based data passing methods taht are more suitable for
+# bigger data(more than several kilobytes) or binary data.
+#
+# All small data outputs will be at some point serialized to strings
+# and all small data input values will be at some point deserialized
+# from strings (passed as command-line argumants).
+# There are built-in serializers and deserializers for several common types
+# (e.g. `str`, `int`, `float`, `bool`, `list`, `dict`).
+# All other types of data need to be serialized manually before returning the data.
+# Make sure to properly specify type annotations, otherwize there would be no automatic deserialization
+# and the component function will receive strings instead of deserialized objects.
+
+# %% [markdown]
+# ## Bigger data (files)
+#
+# Bigger data should be read from files and written to files.
+#
+# The paths for the input and output files are chosen by the system and are passed into the function (as strings).
+#
+# Use the `InputPath` parameter annotation to tell the system that the function wants to
+# consume the corresponding input data as a file. The system will download the data,
+# write it to a local file and then pass the **path** of that file to the function.
+#
+# Use the `OutputPath` parameter annotation to tell the system that the function wants to produce
+# the corresponding output data as a file. The system will prepare and pass the **path** of a file
+# where the function should write the output data. After the function exits,
+# the system will upload the data to the storage system so that it can be passed to downstream components.
+#
+# You can specify the type of the consumed/produced data
+# by specifying the type argument to `InputPath` and `OutputPath`.
+# The type can be a python type or an arbitrary type name string.
+# `OutputPath('TFModel')` means that the function states that the data it has written to a file has type 'TFModel'.
+# `InputPath('TFModel')` means that the function states
+# that it expect the data it reads from a file to have type 'TFModel'.
+# When the pipeline author connects inputs to outputs the system checks whether the types match.
+#
+# Note on input/output names: When the function is converted to component,
+# the input and output names generally follow the parameter names,
+# but the "\_path" and "\_file" suffixes are stripped from file/path inputs and outputs.
+# E.g. the `number_file_path: InputPath(int)` parameter becomes the `number: int` input.
+# This makes the argument passing look more natural: `number=42` instead of `number_file_path=42`.
+# %% [markdown]
+#
+# ### Writing and reading bigger data
+
+
+# %%
+# Writing bigger data
+@func_to_container_op
+def repeat_line(line: str, output_text_path: OutputPath(str), count: int = 10):
+    '''Repeat the line specified number of times'''
+    with open(output_text_path, 'w') as writer:
+        for i in range(count):
+            writer.write(line + '\n')
+
+
+# Reading bigger data
+@func_to_container_op
+def print_text(
+        text_path: InputPath()
+):  # The "text" input is untyped so that any data can be printed
+    '''Print text'''
+    with open(text_path, 'r') as reader:
+        for line in reader:
+            print(line, end='')
+
+
+def print_repeating_lines_pipeline():
+    repeat_lines_task = repeat_line(line='Hello', count=5000)
+    print_text(repeat_lines_task.output)  # Don't forget .output !
+
+
+# %% [markdown]
+# ### Processing bigger data
+
+
+# %%
+@func_to_container_op
+def split_text_lines(source_path: InputPath(str),
+                     odd_lines_path: OutputPath(str),
+                     even_lines_path: OutputPath(str)):
+    with open(source_path, 'r') as reader:
+        with open(odd_lines_path, 'w') as odd_writer:
+            with open(even_lines_path, 'w') as even_writer:
+                while True:
+                    line = reader.readline()
+                    if line == "":
+                        break
+                    odd_writer.write(line)
+                    line = reader.readline()
+                    if line == "":
+                        break
+                    even_writer.write(line)
+
+
+def text_splitting_pipeline():
+    text = '\n'.join([
+        'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine',
+        'ten'
+    ])
+    split_text_task = split_text_lines(text)
+    print_text(split_text_task.outputs['odd_lines'])
+    print_text(split_text_task.outputs['even_lines'])
+
+
+# %% [markdown]
+# ### Example: Pipeline that generates then sums many numbers
+
+
+# %%
+# Writing many numbers
+@func_to_container_op
+def write_numbers(
+        numbers_path: OutputPath(str), start: int = 0, count: int = 10):
+    with open(numbers_path, 'w') as writer:
+        for i in range(start, count):
+            writer.write(str(i) + '\n')
+
+
+# Reading and summing many numbers
+@func_to_container_op
+def sum_numbers(numbers_path: InputPath(str)) -> int:
+    sum = 0
+    with open(numbers_path, 'r') as reader:
+        for line in reader:
+            sum = sum + int(line)
+    return sum
+
+
+# Pipeline to sum 100000 numbers
+def sum_pipeline(count: int = 100000):
+    numbers_task = write_numbers(count=count)
+    print_text(numbers_task.output)
+
+    sum_task = sum_numbers(numbers_task.outputs['numbers'])
+    print_text(sum_task.output)
+
+
+# %% [markdown]
+# ### Example: Pipeline that with samll data as input/output
+
+
+# %%
+# A samll data parameter of output, as an input paremeter of another tasks.
+@func_to_container_op
+def gen_params() -> int:
+    import random
+    num = random.randint(0, 9)
+    return num
+
+
+# print the result
+@func_to_container_op
+def print_params(numbers_parm: int):
+    print("The result number is: %d" % numbers_parm)
+
+
+# Pipeline to gen and echo the result
+def params_pipeline():
+    gen_task = gen_params()
+    print_params(gen_task.output)
+
+
+# Combining all pipelines together in a single pipeline
+def file_passing_pipelines():
+    print_repeating_lines_pipeline()
+    text_splitting_pipeline()
+    sum_pipeline()
+    params_pipeline()
+
+
+# # General by kfp
+# if __name__ == '__main__':
+#     # Compiling the pipeline
+#     import kfp
+#     kfp.compiler.Compiler().compile(file_passing_pipelines, __file__ + '.yaml')
+
+# General by kfp-tekton
+if __name__ == '__main__':
+    # don't use top-level import of TektonCompiler to prevent monkey-patching KFP compiler when using KFP's dsl-compile
+    from kfp_tekton.compiler import TektonCompiler
+    TektonCompiler().compile(file_passing_pipelines,
+                             __file__.replace('.py', '.yaml'),
+                             generate_pipelinerun=True)

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -1,0 +1,545 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Repeat the line specified
+      number of times", "inputs": [{"name": "line", "type": "String"}, {"default":
+      "10", "name": "count", "optional": true, "type": "Integer"}], "name": "Repeat
+      line", "outputs": [{"name": "output_text", "type": "String"}]}'
+  name: repeat-line
+spec:
+  steps:
+  - args:
+    - --line
+    - Hello
+    - --count
+    - '5000'
+    - --output-text
+    - $(workspaces.repeat-line.path)/repeat-line-output-text
+    command:
+    - python3
+    - -u
+    - -c
+    - "def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n   \
+      \ os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\
+      \ndef repeat_line(line , output_text_path , count  = 10):\n    '''Repeat the\
+      \ line specified number of times'''\n    with open(output_text_path, 'w') as\
+      \ writer:\n        for i in range(count):\n            writer.write(line + '\\\
+      n')\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Repeat line',\
+      \ description='Repeat the line specified number of times')\n_parser.add_argument(\"\
+      --line\", dest=\"line\", type=str, required=True, default=argparse.SUPPRESS)\n\
+      _parser.add_argument(\"--count\", dest=\"count\", type=int, required=False,\
+      \ default=argparse.SUPPRESS)\n_parser.add_argument(\"--output-text\", dest=\"\
+      output_text_path\", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)\n\
+      _parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"\
+      _output_paths\", [])\n\n_outputs = repeat_line(**_parsed_args)\n\n_output_serializers\
+      \ = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: repeat-line
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text.path)/repeat-line-output-text
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(\n        text_path \n):  # The \"text\" input is untyped so\
+      \ that any data can be printed\n    '''Print text'''\n    with open(text_path,\
+      \ 'r') as reader:\n        for line in reader:\n            print(line, end='')\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print text', description='Print\
+      \ text')\n_parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "source", "type":
+      "String"}], "name": "Split text lines", "outputs": [{"name": "odd_lines", "type":
+      "String"}, {"name": "even_lines", "type": "String"}]}'
+  name: split-text-lines
+spec:
+  stepTemplate:
+    volumeMounts:
+    - mountPath: /tmp/inputs/source
+      name: source
+  steps:
+  - image: busybox
+    name: copy-inputs
+    script: '#!/bin/sh
+
+      set -exo pipefail
+
+      echo -n "one
+
+      two
+
+      three
+
+      four
+
+      five
+
+      six
+
+      seven
+
+      eight
+
+      nine
+
+      ten" > /tmp/inputs/source/data
+
+      '
+  - args:
+    - --source
+    - /tmp/inputs/source/data
+    - --odd-lines
+    - $(workspaces.split-text-lines.path)/split-text-lines-odd-lines
+    - --even-lines
+    - $(workspaces.split-text-lines.path)/split-text-lines-even-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n   \
+      \ os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\
+      \ndef split_text_lines(source_path ,\n                     odd_lines_path ,\n\
+      \                     even_lines_path ):\n    with open(source_path, 'r') as\
+      \ reader:\n        with open(odd_lines_path, 'w') as odd_writer:\n         \
+      \   with open(even_lines_path, 'w') as even_writer:\n                while True:\n\
+      \                    line = reader.readline()\n                    if line ==\
+      \ \"\":\n                        break\n                    odd_writer.write(line)\n\
+      \                    line = reader.readline()\n                    if line ==\
+      \ \"\":\n                        break\n                    even_writer.write(line)\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Split text lines',\
+      \ description='')\n_parser.add_argument(\"--source\", dest=\"source_path\",\
+      \ type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"\
+      --odd-lines\", dest=\"odd_lines_path\", type=_make_parent_dirs_and_return_path,\
+      \ required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"--even-lines\"\
+      , dest=\"even_lines_path\", type=_make_parent_dirs_and_return_path, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = split_text_lines(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  volumes:
+  - emptyDir: {}
+    name: source
+  workspaces:
+  - name: split-text-lines
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text-2
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text-2.path)/split-text-lines-odd-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(\n        text_path \n):  # The \"text\" input is untyped so\
+      \ that any data can be printed\n    '''Print text'''\n    with open(text_path,\
+      \ 'r') as reader:\n        for line in reader:\n            print(line, end='')\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print text', description='Print\
+      \ text')\n_parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text-2
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text-3
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text-3.path)/split-text-lines-even-lines
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(\n        text_path \n):  # The \"text\" input is untyped so\
+      \ that any data can be printed\n    '''Print text'''\n    with open(text_path,\
+      \ 'r') as reader:\n        for line in reader:\n            print(line, end='')\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print text', description='Print\
+      \ text')\n_parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text-3
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"default": "0", "name": "start",
+      "optional": true, "type": "Integer"}, {"default": "10", "name": "count", "optional":
+      true, "type": "Integer"}], "name": "Write numbers", "outputs": [{"name": "numbers",
+      "type": "String"}]}'
+  name: write-numbers
+spec:
+  steps:
+  - args:
+    - --count
+    - '100000'
+    - --numbers
+    - $(workspaces.write-numbers.path)/write-numbers-numbers
+    command:
+    - python3
+    - -u
+    - -c
+    - "def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n   \
+      \ os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\
+      \ndef write_numbers(\n        numbers_path , start  = 0, count  = 10):\n   \
+      \ with open(numbers_path, 'w') as writer:\n        for i in range(start, count):\n\
+      \            writer.write(str(i) + '\\n')\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Write\
+      \ numbers', description='')\n_parser.add_argument(\"--start\", dest=\"start\"\
+      , type=int, required=False, default=argparse.SUPPRESS)\n_parser.add_argument(\"\
+      --count\", dest=\"count\", type=int, required=False, default=argparse.SUPPRESS)\n\
+      _parser.add_argument(\"--numbers\", dest=\"numbers_path\", type=_make_parent_dirs_and_return_path,\
+      \ required=True, default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n\
+      _output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = write_numbers(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: write-numbers
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text-4
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text-4.path)/write-numbers-numbers
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(\n        text_path \n):  # The \"text\" input is untyped so\
+      \ that any data can be printed\n    '''Print text'''\n    with open(text_path,\
+      \ 'r') as reader:\n        for line in reader:\n            print(line, end='')\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print text', description='Print\
+      \ text')\n_parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text-4
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "numbers", "type":
+      "String"}], "name": "Sum numbers", "outputs": [{"name": "Output", "type": "Integer"}]}'
+  name: sum-numbers
+spec:
+  steps:
+  - args:
+    - --numbers
+    - $(workspaces.sum-numbers.path)/write-numbers-numbers
+    - '----output-paths'
+    - $(workspaces.sum-numbers.path)/sum-numbers-output
+    command:
+    - python3
+    - -u
+    - -c
+    - "def sum_numbers(numbers_path )  :\n    sum = 0\n    with open(numbers_path,\
+      \ 'r') as reader:\n        for line in reader:\n            sum = sum + int(line)\n\
+      \    return sum\n\ndef _serialize_int(int_value: int) -> str:\n    if isinstance(int_value,\
+      \ str):\n        return int_value\n    if not isinstance(int_value, int):\n\
+      \        raise TypeError('Value \"{}\" has type \"{}\" instead of int.'.format(str(int_value),\
+      \ str(type(int_value))))\n    return str(int_value)\n\nimport argparse\n_parser\
+      \ = argparse.ArgumentParser(prog='Sum numbers', description='')\n_parser.add_argument(\"\
+      --numbers\", dest=\"numbers_path\", type=str, required=True, default=argparse.SUPPRESS)\n\
+      _parser.add_argument(\"----output-paths\", dest=\"_output_paths\", type=str,\
+      \ nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"\
+      _output_paths\", [])\n\n_outputs = sum_numbers(**_parsed_args)\n\n_outputs =\
+      \ [_outputs]\n\n_output_serializers = [\n    _serialize_int,\n\n]\n\nimport\
+      \ os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n\
+      \    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n\
+      \        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: sum-numbers
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"description": "Print text", "inputs":
+      [{"name": "text"}], "name": "Print text"}'
+  name: print-text-5
+spec:
+  steps:
+  - args:
+    - --text
+    - $(workspaces.print-text-5.path)/sum-numbers-output
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_text(\n        text_path \n):  # The \"text\" input is untyped so\
+      \ that any data can be printed\n    '''Print text'''\n    with open(text_path,\
+      \ 'r') as reader:\n        for line in reader:\n            print(line, end='')\n\
+      \nimport argparse\n_parser = argparse.ArgumentParser(prog='Print text', description='Print\
+      \ text')\n_parser.add_argument(\"--text\", dest=\"text_path\", type=str, required=True,\
+      \ default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n_output_files\
+      \ = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_text(**_parsed_args)\n\
+      \n_output_serializers = [\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n\
+      \    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n\
+      \        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+  workspaces:
+  - name: print-text-5
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"name": "Gen params", "outputs": [{"name":
+      "Output", "type": "Integer"}]}'
+  name: gen-params
+spec:
+  results:
+  - description: /tmp/outputs/Output/data
+    name: output
+  steps:
+  - args:
+    - '----output-paths'
+    - $(results.output.path)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def gen_params()  :\n    import random\n    num = random.randint(0, 9)\n  \
+      \  return num\n\ndef _serialize_int(int_value: int) -> str:\n    if isinstance(int_value,\
+      \ str):\n        return int_value\n    if not isinstance(int_value, int):\n\
+      \        raise TypeError('Value \"{}\" has type \"{}\" instead of int.'.format(str(int_value),\
+      \ str(type(int_value))))\n    return str(int_value)\n\nimport argparse\n_parser\
+      \ = argparse.ArgumentParser(prog='Gen params', description='')\n_parser.add_argument(\"\
+      ----output-paths\", dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args\
+      \ = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\"\
+      , [])\n\n_outputs = gen_params(**_parsed_args)\n\n_outputs = [_outputs]\n\n\
+      _output_serializers = [\n    _serialize_int,\n\n]\n\nimport os\nfor idx, output_file\
+      \ in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n\
+      \    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n\
+      \        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "numbers_parm", "type":
+      "Integer"}], "name": "Print params"}'
+  name: print-params
+spec:
+  params:
+  - name: gen-params-output
+  steps:
+  - args:
+    - --numbers-parm
+    - $(inputs.params.gen-params-output)
+    command:
+    - python3
+    - -u
+    - -c
+    - "def print_params(numbers_parm ):\n    print(\"The result number is: %d\" %\
+      \ numbers_parm)\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Print\
+      \ params', description='')\n_parser.add_argument(\"--numbers-parm\", dest=\"\
+      numbers_parm\", type=int, required=True, default=argparse.SUPPRESS)\n_parsed_args\
+      \ = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\"\
+      , [])\n\n_outputs = print_params(**_parsed_args)\n\n_output_serializers = [\n\
+      \n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n\
+      \        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n  \
+      \      pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+    image: tensorflow/tensorflow:1.13.2-py3
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "File passing pipelines"}'
+    sidecar.istio.io/inject: 'false'
+  name: file-passing-pipelines
+spec:
+  tasks:
+  - name: repeat-line
+    taskRef:
+      name: repeat-line
+    workspaces:
+    - name: repeat-line
+      workspace: file-passing-pipelines
+  - name: print-text
+    runAfter:
+    - repeat-line
+    taskRef:
+      name: print-text
+    workspaces:
+    - name: print-text
+      workspace: file-passing-pipelines
+  - name: split-text-lines
+    taskRef:
+      name: split-text-lines
+    workspaces:
+    - name: split-text-lines
+      workspace: file-passing-pipelines
+  - name: print-text-2
+    runAfter:
+    - split-text-lines
+    taskRef:
+      name: print-text-2
+    workspaces:
+    - name: print-text-2
+      workspace: file-passing-pipelines
+  - name: print-text-3
+    runAfter:
+    - split-text-lines
+    taskRef:
+      name: print-text-3
+    workspaces:
+    - name: print-text-3
+      workspace: file-passing-pipelines
+  - name: write-numbers
+    taskRef:
+      name: write-numbers
+    workspaces:
+    - name: write-numbers
+      workspace: file-passing-pipelines
+  - name: print-text-4
+    runAfter:
+    - write-numbers
+    taskRef:
+      name: print-text-4
+    workspaces:
+    - name: print-text-4
+      workspace: file-passing-pipelines
+  - name: sum-numbers
+    runAfter:
+    - write-numbers
+    taskRef:
+      name: sum-numbers
+    workspaces:
+    - name: sum-numbers
+      workspace: file-passing-pipelines
+  - name: print-text-5
+    runAfter:
+    - sum-numbers
+    taskRef:
+      name: print-text-5
+    workspaces:
+    - name: print-text-5
+      workspace: file-passing-pipelines
+  - name: gen-params
+    taskRef:
+      name: gen-params
+  - name: print-params
+    params:
+    - name: gen-params-output
+      value: $(tasks.gen-params.results.output)
+    taskRef:
+      name: print-params
+  workspaces:
+  - name: file-passing-pipelines
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: file-passing-pipelines-run
+spec:
+  pipelineRef:
+    name: file-passing-pipelines
+  workspaces:
+  - name: file-passing-pipelines
+    persistentVolumeClaim:
+      claimName: file-passing-pipelines-run
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: file-passing-pipelines-run
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem

--- a/sdk/python/tests/compiler/testdata/condition.yaml
+++ b/sdk/python/tests/compiler/testdata/condition.yaml
@@ -139,10 +139,8 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: flip-coin-example-pipeline
 spec:
-  params: []
   tasks:
   - name: flip
-    params: []
     taskRef:
       name: flip
   - conditions:
@@ -151,7 +149,6 @@ spec:
       - name: flip
         value: $(tasks.flip.results.output)
     name: flip-again
-    params: []
     taskRef:
       name: flip-again
   - conditions:

--- a/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
+++ b/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
@@ -71,10 +71,8 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: hidden-output-file-pipeline
 spec:
-  params: []
   tasks:
   - name: download-file
-    params: []
     taskRef:
       name: download-file
   - name: echo

--- a/sdk/python/tests/compiler/testdata/init_container.yaml
+++ b/sdk/python/tests/compiler/testdata/init_container.yaml
@@ -38,9 +38,7 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: initcontainer
 spec:
-  params: []
   tasks:
   - name: hello
-    params: []
     taskRef:
       name: hello

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -136,21 +136,16 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: pipeline-with-artifact-input-raw-argument-value
 spec:
-  params: []
   tasks:
   - name: component-with-inline-input-artifact
-    params: []
     taskRef:
       name: component-with-inline-input-artifact
   - name: component-with-input-artifact
-    params: []
     taskRef:
       name: component-with-input-artifact
   - name: component-with-input-artifact-2
-    params: []
     taskRef:
       name: component-with-input-artifact-2
   - name: component-with-input-artifact-3
-    params: []
     taskRef:
       name: component-with-input-artifact-3

--- a/sdk/python/tests/compiler/testdata/loop_static.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static.yaml
@@ -18,11 +18,11 @@ metadata:
   name: my-in-coop1
 spec:
   params:
-  - name: loop-item-param-subvar-A_a
-  - name: my_pipe_param
+  - name: loop-item-param-subvar-A-a
+  - name: my-pipe-param
   steps:
   - args:
-    - echo op1 $(inputs.params.loop-item-param-subvar-A_a) $(inputs.params.my_pipe_param)
+    - echo op1 $(inputs.params.loop-item-param-subvar-A-a) $(inputs.params.my-pipe-param)
     command:
     - sh
     - -c
@@ -35,10 +35,10 @@ metadata:
   name: my-in-coop2
 spec:
   params:
-  - name: loop-item-param-subvar-B_b
+  - name: loop-item-param-subvar-B-b
   steps:
   - args:
-    - echo op2 $(inputs.params.loop-item-param-subvar-B_b)
+    - echo op2 $(inputs.params.loop-item-param-subvar-B-b)
     command:
     - sh
     - -c
@@ -51,10 +51,10 @@ metadata:
   name: my-out-cop
 spec:
   params:
-  - name: my_pipe_param
+  - name: my-pipe-param
   steps:
   - args:
-    - echo $(inputs.params.my_pipe_param)
+    - echo $(inputs.params.my-pipe-param)
     command:
     - sh
     - -c
@@ -72,39 +72,39 @@ metadata:
 spec:
   params:
   - default: '10'
-    name: my_pipe_param
+    name: my-pipe-param
   tasks:
   - name: my-in-coop1-loop-item-0
     params:
-    - name: loop-item-param-subvar-A_a
+    - name: loop-item-param-subvar-A-a
       value: '1'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-in-coop1
   - name: my-in-coop1-loop-item-1
     params:
-    - name: loop-item-param-subvar-A_a
+    - name: loop-item-param-subvar-A-a
       value: '10'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-in-coop1
   - name: my-in-coop2-loop-item-0
     params:
-    - name: loop-item-param-subvar-B_b
+    - name: loop-item-param-subvar-B-b
       value: '2'
     taskRef:
       name: my-in-coop2
   - name: my-in-coop2-loop-item-1
     params:
-    - name: loop-item-param-subvar-B_b
+    - name: loop-item-param-subvar-B-b
       value: '20'
     taskRef:
       name: my-in-coop2
   - name: my-out-cop-loop-item-0
     params:
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-out-cop

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -32,10 +32,8 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: node-selector
 spec:
-  params: []
   tasks:
   - name: sleep
-    params: []
     taskRef:
       name: sleep
 ---
@@ -44,7 +42,6 @@ kind: PipelineRun
 metadata:
   name: node-selector-run
 spec:
-  params: []
   pipelineRef:
     name: node-selector
   taskRunSpec:

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
@@ -54,13 +54,10 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: pipeline-transformer
 spec:
-  params: []
   tasks:
   - name: print
-    params: []
     taskRef:
       name: print
   - name: print-2
-    params: []
     taskRef:
       name: print-2

--- a/sdk/python/tests/compiler/testdata/pipelineparams.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.yaml
@@ -18,7 +18,7 @@ metadata:
   name: download
 spec:
   params:
-  - name: sleep_ms
+  - name: sleep-ms
   - name: tag
   results:
   - description: /tmp/results.txt
@@ -30,7 +30,7 @@ spec:
     name: echo
   steps:
   - args:
-    - sleep $(inputs.params.sleep_ms); wget localhost:5678 -O $(results.downloaded.path)
+    - sleep $(inputs.params.sleep-ms); wget localhost:5678 -O $(results.downloaded.path)
     command:
     - sh
     - -c
@@ -71,12 +71,12 @@ spec:
   - default: latest
     name: tag
   - default: '10'
-    name: sleep_ms
+    name: sleep-ms
   tasks:
   - name: download
     params:
-    - name: sleep_ms
-      value: $(params.sleep_ms)
+    - name: sleep-ms
+      value: $(params.sleep-ms)
     - name: tag
       value: $(params.tag)
     taskRef:

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -76,7 +76,6 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: resourceop-basic
 spec:
-  params: []
   tasks:
   - name: test-step
     params:

--- a/sdk/python/tests/compiler/testdata/retry.yaml
+++ b/sdk/python/tests/compiler/testdata/retry.yaml
@@ -54,15 +54,12 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: retry-random-failures
 spec:
-  params: []
   tasks:
   - name: random-failure
-    params: []
     retries: 10
     taskRef:
       name: random-failure
   - name: random-failure-2
-    params: []
     retries: 5
     taskRef:
       name: random-failure-2

--- a/sdk/python/tests/compiler/testdata/sidecar.yaml
+++ b/sdk/python/tests/compiler/testdata/sidecar.yaml
@@ -59,10 +59,8 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: sidecar
 spec:
-  params: []
   tasks:
   - name: download
-    params: []
     taskRef:
       name: download
   - name: echo

--- a/sdk/python/tests/compiler/testdata/timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout.yaml
@@ -51,14 +51,11 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: pipeline-includes-two-steps-which-fail-randomly
 spec:
-  params: []
   tasks:
   - name: random-failure
-    params: []
     taskRef:
       name: random-failure
     timeout: 20s
   - name: random-failure-2
-    params: []
     taskRef:
       name: random-failure-2

--- a/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
@@ -51,15 +51,12 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: pipeline-includes-two-steps-which-fail-randomly
 spec:
-  params: []
   tasks:
   - name: random-failure
-    params: []
     taskRef:
       name: random-failure
     timeout: 20s
   - name: random-failure-2
-    params: []
     taskRef:
       name: random-failure-2
 ---
@@ -68,7 +65,6 @@ kind: PipelineRun
 metadata:
   name: pipeline-includes-two-steps-which-fail-randomly-run
 spec:
-  params: []
   pipelineRef:
     name: pipeline-includes-two-steps-which-fail-randomly
   timeout: 40s

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -38,10 +38,8 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: tolerations
 spec:
-  params: []
   tasks:
   - name: download
-    params: []
     taskRef:
       name: download
 ---
@@ -50,7 +48,6 @@ kind: PipelineRun
 metadata:
   name: tolerations-run
 spec:
-  params: []
   pipelineRef:
     name: tolerations
   taskRunSpec:

--- a/sdk/python/tests/compiler/testdata/volume.yaml
+++ b/sdk/python/tests/compiler/testdata/volume.yaml
@@ -66,10 +66,8 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: volume
 spec:
-  params: []
   tasks:
   - name: download
-    params: []
     taskRef:
       name: download
   - name: echo

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -19,10 +19,10 @@ metadata:
 spec:
   params:
   - name: loop-item-param-00000001-subvar-a
-  - name: my_pipe_param
+  - name: my-pipe-param
   steps:
   - args:
-    - echo op1 $(inputs.params.loop-item-param-00000001-subvar-a) $(inputs.params.my_pipe_param)
+    - echo op1 $(inputs.params.loop-item-param-00000001-subvar-a) $(inputs.params.my-pipe-param)
     command:
     - sh
     - -c
@@ -37,11 +37,11 @@ spec:
   params:
   - name: loop-item-param-00000001-subvar-a
   - name: loop-item-param-00000002
-  - name: my_pipe_param
+  - name: my-pipe-param
   steps:
   - args:
     - echo op1 $(inputs.params.loop-item-param-00000001-subvar-a) $(inputs.params.loop-item-param-00000002)
-      $(inputs.params.my_pipe_param)
+      $(inputs.params.my-pipe-param)
     command:
     - sh
     - -c
@@ -70,10 +70,10 @@ metadata:
   name: my-out-cop
 spec:
   params:
-  - name: my_pipe_param
+  - name: my-pipe-param
   steps:
   - args:
-    - echo $(inputs.params.my_pipe_param)
+    - echo $(inputs.params.my-pipe-param)
     command:
     - sh
     - -c
@@ -91,22 +91,22 @@ metadata:
 spec:
   params:
   - default: '10'
-    name: my_pipe_param
+    name: my-pipe-param
   tasks:
   - name: my-in-coop1-loop-item-0
     params:
     - name: loop-item-param-00000001-subvar-a
       value: '1'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-in-coop1
   - name: my-in-coop1-loop-item-1
     params:
     - name: loop-item-param-00000001-subvar-a
       value: '10'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-in-coop1
   - name: my-inner-inner-coop-loop-item-0
@@ -115,8 +115,8 @@ spec:
       value: '1'
     - name: loop-item-param-00000002
       value: '100'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-inner-inner-coop
   - name: my-inner-inner-coop-loop-item-1
@@ -125,8 +125,8 @@ spec:
       value: '1'
     - name: loop-item-param-00000002
       value: '200'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-inner-inner-coop
   - name: my-inner-inner-coop-loop-item-2
@@ -135,8 +135,8 @@ spec:
       value: '1'
     - name: loop-item-param-00000002
       value: '300'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-inner-inner-coop
   - name: my-inner-inner-coop-loop-item-3
@@ -145,8 +145,8 @@ spec:
       value: '10'
     - name: loop-item-param-00000002
       value: '100'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-inner-inner-coop
   - name: my-inner-inner-coop-loop-item-4
@@ -155,8 +155,8 @@ spec:
       value: '10'
     - name: loop-item-param-00000002
       value: '200'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-inner-inner-coop
   - name: my-inner-inner-coop-loop-item-5
@@ -165,8 +165,8 @@ spec:
       value: '10'
     - name: loop-item-param-00000002
       value: '300'
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-inner-inner-coop
   - name: my-in-coop2-loop-item-0
@@ -183,7 +183,7 @@ spec:
       name: my-in-coop2
   - name: my-out-cop-loop-item-0
     params:
-    - name: my_pipe_param
-      value: $(params.my_pipe_param)
+    - name: my-pipe-param
+      value: $(params.my-pipe-param)
     taskRef:
       name: my-out-cop


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #63
And related to #150

**Description of your changes:**

Big data should be read from files and written to files.

The paths for the input and output files are chosen by the system and are passed into the function (as strings).

Use the InputPath parameter annotation to tell the system that the function wants to consume the corresponding input data as a file. The system will download the data, write it to a local file and then pass the path of that file to the function.

Use the OutputPath parameter annotation to tell the system that the function wants to produce the corresponding output data as a file. The system will prepare and pass the path of a file where the function should write the output data. After the function exits, the system will upload the data to the storage system so that it can be passed to downstream components.

Notes: As we used 'workspaces' in tekton pipelines to handle the bigger data processing, the complier will generator the PVC definations,it needs the volume to store the data. User need to create volume manually, or enable dynamic volume provisioning, refer to the link of: https://kubernetes.io/docs/concepts/storage/dynamic-provisioning

- Implementation:

- [x] Index the PIPELINEs to understand how data is being passed and which inputs/outputs
       are connected to each other.
- [x] Search for direct data consumers in container/resource templates and some
       PIPELINE task attributes (e.g. conditions and loops) to find out which inputs
       are directly consumed as parameters/artifacts.
- [x] Propagate the consumption information upstream to all inputs/outputs all
       the way up to the data producers.
- [x] Convert the inputs, outputs based on how they're consumed downstream.
- [x] Use workspaces instead of result and params for bigger data passing.
- [x] Added workspaces to tasks, pipelines, pipelineruns, if the parmas is bigger data.
- [x] A PVC named pipelinerun name will be created if bigger data passing, as workspaces need to use it.
- [x] Document about 'How to use it'
