### PR TITLE
Add artifact annotation for metadata tracking

### DIFF
--- a/sdk/FEATURES.md
+++ b/sdk/FEATURES.md
@@ -124,6 +124,9 @@ python test is an example of how to use this feature.
 ### Output Artifacts
 Output Artifacts are files that need to be persisted to the default/destination object storage. Additionally, by default, all Kubeflow pipeline 'Output Parameters' are also stored as output artifacts. Since Tekton deprecated pipelineResource and the recommended gsutil task is not capable of moving files to the minio object storage without proper DNS address, we decided to create a step based on the [minio mc](https://github.com/minio/mc) image for moving output artifacts. This feature also includes the ArtifactLocation support where users can set their own object storage credentials during execution. The [artifact_location](/sdk/python/tests/compiler/testdata/artifact_location.py) python test is an example of how to use this feature.
 
+It also includes two annontations `tekton.dev/input_artifacts` and `tekton.dev/output_artifacts` for metadata tracking. Refer to the
+[Tetkon Artifact design proposal](https://docs.google.com/document/d/1nx63yZzANk8yDAm_Cwx_UHu-SVFrg73GVeshhtaYNsM/edit?usp=sharing) for more details.
+
 However, both ArtifactLocation and explicit output artifacts are deprecated and removed in the KFP 0.5.1 release. This is probably due to a more mature multi-user support because ArtifactLocation required users to pre-define the object storage credentials as Kubernetes secret within the same namespace. 
 
 The current implementation is relying on the existing KFP's minio setup for getting the default credentials. This feature probably needs to be deprecated and merged with the output parameters once KFP finalizes the artifact management for the multi-user scenario. 

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -368,7 +368,7 @@ def _process_base_ops(op: BaseOp):
     return op
 
 
-def _op_to_template(op: BaseOp, tekton_compiler):
+def _op_to_template(op: BaseOp, pipelinerun_output_artifacts={}, enable_artifacts=False):
     """Generate template given an operator inherited from BaseOp."""
 
     # initial local variables for tracking volumes and artifacts
@@ -400,7 +400,7 @@ def _op_to_template(op: BaseOp, tekton_compiler):
                     path=path,
                     key='runs/$PIPELINERUN/$PIPELINETASK/' + name))
             for name, path in output_artifact_paths.items()
-        ] if tekton_compiler.enable_artifacts else []
+        ] if enable_artifacts else []
 
         # workflow template
         container = convert_k8s_obj_to_json(
@@ -421,16 +421,16 @@ def _op_to_template(op: BaseOp, tekton_compiler):
         }
 
         # Create output artifact tracking annotation.
-        if tekton_compiler.enable_artifacts:
+        if enable_artifacts:
             for output_artifact in output_artifacts:
-                output_annotation = tekton_compiler.output_artifacts.get(processed_op.name, [])
+                output_annotation = pipelinerun_output_artifacts.get(processed_op.name, [])
                 output_annotation.append(
                     {
                         'name': output_artifact['name'],
                         'path': output_artifact['path']
                     }
                 )
-                tekton_compiler.output_artifacts[processed_op.name] = output_annotation
+                pipelinerun_output_artifacts[processed_op.name] = output_annotation
 
     elif isinstance(op, dsl.ResourceOp):
         # no output artifacts

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -220,7 +220,7 @@ class TektonCompiler(Compiler):
       op_to_templates_handler: Handler which converts a base op into a list of argo templates.
     """
 
-    op_to_steps_handler = op_to_templates_handler or (lambda op: [_op_to_template(op, self)])
+    op_to_steps_handler = op_to_templates_handler or (lambda op: [_op_to_template(op, self.output_artifacts, self.enable_artifacts)])
     root_group = pipeline.groups[0]
 
     # Call the transformation functions before determining the inputs/outputs, otherwise

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -87,6 +87,16 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.parallel_join import download_and_join
     self._test_pipeline_workflow(download_and_join, 'parallel_join.yaml')
 
+  def test_parallel_join_workflow_with_artifacts(self):
+    """
+    Test compiling a parallel join workflow with artifacts and pipelineRun.
+    """
+    from .testdata.parallel_join import download_and_join
+    self._test_pipeline_workflow(download_and_join,
+                                 'parallel_join_with_artifacts.yaml',
+                                 generate_pipelinerun=True,
+                                 enable_artifacts=True)
+
   def test_parallel_join_with_argo_vars_workflow(self):
     """
     Test compiling a parallel join workflow.

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -42,6 +42,9 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
+  annotation:
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/output_artifacts: '{}'
   name: affinity-run
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/artifact_location.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_location.yaml
@@ -37,10 +37,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['tekton.dev/pipelineRun']
-    - name: PODNAME
+    - name: PIPELINETASK
       valueFrom:
         fieldRef:
-          fieldPath: metadata.name
+          fieldPath: metadata.labels['tekton.dev/pipelineTask']
     - name: NAMESPACE
       valueFrom:
         fieldRef:
@@ -62,7 +62,9 @@ spec:
       mc config host add storage http://minio-service.$(inputs.params.namespace):9000
       $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
-      mc cp $(results.output.path) storage/$(inputs.params.bucket)/runs/$PIPELINERUN/$PODNAME/output.txt
+      tar -cvzf generate-output-output.tgz $(results.output.path)
+
+      mc cp generate-output-output.tgz storage/$(inputs.params.bucket)/runs/$PIPELINERUN/$PIPELINETASK/generate-output-output.tgz
 
       '
 ---

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -63,6 +63,9 @@ metadata:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
+  annotation:
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/output_artifacts: '{}'
   name: save-most-frequent-run
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -42,6 +42,9 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
+  annotation:
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/output_artifacts: '{}'
   name: node-selector-run
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/parallel_join_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_pipelinerun.yaml
@@ -114,6 +114,9 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
+  annotation:
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/output_artifacts: '{}'
   name: parallel-pipeline-run
 spec:
   params:

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_artifacts.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_artifacts.yaml
@@ -1,0 +1,201 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gcs-download
+spec:
+  params:
+  - name: url1
+  results:
+  - description: /tmp/results.txt
+    name: data
+  steps:
+  - args:
+    - gsutil cat $0 | tee $1
+    - $(inputs.params.url1)
+    - $(results.data.path)
+    command:
+    - sh
+    - -c
+    image: google/cloud-sdk:279.0.0
+    name: main
+  - env:
+    - name: PIPELINERUN
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['tekton.dev/pipelineRun']
+    - name: PIPELINETASK
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['tekton.dev/pipelineTask']
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          key: accesskey
+          name: mlpipeline-minio-artifact
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          key: secretkey
+          name: mlpipeline-minio-artifact
+    image: minio/mc
+    name: copy-artifacts
+    script: '#!/usr/bin/env sh
+
+      mc config host add storage http://minio-service.$NAMESPACE:9000 $AWS_ACCESS_KEY_ID
+      $AWS_SECRET_ACCESS_KEY
+
+      tar -cvzf gcs-download-data.tgz $(results.data.path)
+
+      mc cp gcs-download-data.tgz storage/mlpipeline/runs/$PIPELINERUN/$PIPELINETASK/gcs-download-data.tgz
+
+      '
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gcs-download-2
+spec:
+  params:
+  - name: url2
+  results:
+  - description: /tmp/results.txt
+    name: data
+  steps:
+  - args:
+    - gsutil cat $0 | tee $1
+    - $(inputs.params.url2)
+    - $(results.data.path)
+    command:
+    - sh
+    - -c
+    image: google/cloud-sdk:279.0.0
+    name: main
+  - env:
+    - name: PIPELINERUN
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['tekton.dev/pipelineRun']
+    - name: PIPELINETASK
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['tekton.dev/pipelineTask']
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          key: accesskey
+          name: mlpipeline-minio-artifact
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          key: secretkey
+          name: mlpipeline-minio-artifact
+    image: minio/mc
+    name: copy-artifacts
+    script: '#!/usr/bin/env sh
+
+      mc config host add storage http://minio-service.$NAMESPACE:9000 $AWS_ACCESS_KEY_ID
+      $AWS_SECRET_ACCESS_KEY
+
+      tar -cvzf gcs-download-2-data.tgz $(results.data.path)
+
+      mc cp gcs-download-2-data.tgz storage/mlpipeline/runs/$PIPELINERUN/$PIPELINETASK/gcs-download-2-data.tgz
+
+      '
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: echo
+spec:
+  params:
+  - name: gcs-download-2-data
+  - name: gcs-download-data
+  steps:
+  - args:
+    - 'echo "Text 1: $0"; echo "Text 2: $1"'
+    - $(inputs.params.gcs-download-data)
+    - $(inputs.params.gcs-download-2-data)
+    command:
+    - sh
+    - -c
+    image: library/bash:4.4.23
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Download two messages
+      in parallel and prints the concatenated result.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
+      "name": "url1", "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
+      "name": "url2", "optional": true}], "name": "Parallel pipeline"}'
+    sidecar.istio.io/inject: 'false'
+  name: parallel-pipeline
+spec:
+  params:
+  - default: gs://ml-pipeline-playground/shakespeare1.txt
+    name: url1
+  - default: gs://ml-pipeline-playground/shakespeare2.txt
+    name: url2
+  tasks:
+  - name: gcs-download
+    params:
+    - name: url1
+      value: $(params.url1)
+    taskRef:
+      name: gcs-download
+  - name: gcs-download-2
+    params:
+    - name: url2
+      value: $(params.url2)
+    taskRef:
+      name: gcs-download-2
+  - name: echo
+    params:
+    - name: gcs-download-2-data
+      value: $(tasks.gcs-download-2.results.data)
+    - name: gcs-download-data
+      value: $(tasks.gcs-download.results.data)
+    taskRef:
+      name: echo
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotation:
+    tekton.dev/input_artifacts: '{"echo": [{"name": "gcs-download-2-data", "parent_task":
+      "gcs-download-2"}, {"name": "gcs-download-data", "parent_task": "gcs-download"}]}'
+    tekton.dev/output_artifacts: '{"gcs-download": [{"name": "gcs-download-data",
+      "path": "/tmp/results.txt"}], "gcs-download-2": [{"name": "gcs-download-2-data",
+      "path": "/tmp/results.txt"}]}'
+  name: parallel-pipeline-run
+spec:
+  params:
+  - name: url1
+    value: gs://ml-pipeline-playground/shakespeare1.txt
+  - name: url2
+    value: gs://ml-pipeline-playground/shakespeare2.txt
+  pipelineRef:
+    name: parallel-pipeline

--- a/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
@@ -66,6 +66,9 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
+  annotation:
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/output_artifacts: '{}'
   name: pipeline-includes-two-steps-which-fail-randomly-run
 spec:
   params: []

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -48,6 +48,9 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
+  annotation:
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/output_artifacts: '{}'
   name: tolerations-run
 spec:
   params: []


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #168 

**Description of your changes:**
Add annotation to support artifacts from input/output parameters. Input artifacts with big data passing is ignored because we are pending #169. 

Change the output artifact location and add annotations for metadata tracking. The design of this approach is documented in this google docs
https://docs.google.com/document/d/1nx63yZzANk8yDAm_Cwx_UHu-SVFrg73GVeshhtaYNsM/edit#heading=h.d1ddt7vobtmu

Major changes:
- Moved `PODNAME` to `PIPELINETASK` as the secondary directory for S3 artifact key.
- Follow the [Argo standard](https://github.com/argoproj/argo/blob/6e5dd2e19a3094f88e6f927f786f866eccc5f500/workflow/controller/workflowpod.go#L877-L878) to compress artifacts into tgz file
- Add default pipelineRun annotation for metadata tracking. Default to `{}` to indicate the pipeline has no artifact.

**Environment tested:**

* Python Version (use `python --version`): 3.6.4
* Tekton Version (use `tkn version`): 1.12.1
* Kubernetes Version (use `kubectl version`): 1.16
* OS (e.g. from `/etc/os-release`):
