### PR TITLE
Remove randomness from condition example

### DIFF
--- a/sdk/python/tests/compiler/testdata/condition.py
+++ b/sdk/python/tests/compiler/testdata/condition.py
@@ -17,13 +17,13 @@ from kfp import dsl
 
 class FlipCoinOp(dsl.ContainerOp):
 
-    def __init__(self, name):
+    def __init__(self, name, forced_result=""):
         super(FlipCoinOp, self).__init__(
             name=name,
             image='python:alpine3.6',
             command=['sh', '-c'],
-            arguments=['python -c "import random; result = \'heads\' if random.randint(0,1) == 0 '
-                       'else \'tails\'; print(result)" | tee /tmp/output'],
+            arguments=['python -c "import random; import sys; forced_result = \''+forced_result+'\'; result = \'heads\' if random.randint(0,1) == 0 '
+                       'else \'tails\'; print(forced_result) if (forced_result == \'heads\' or forced_result == \'tails\') else print(result)" | tee /tmp/output'],
             file_outputs={'output': '/tmp/output'})
 
 
@@ -40,14 +40,17 @@ class PrintOp(dsl.ContainerOp):
     name='Flip Coin Example Pipeline',
     description='Shows how to use dsl.Condition.'
 )
-def flipcoin(flip1: str = 'heads', flip2: str = 'tails'):
+def flipcoin(forced_result1: str = 'heads', forced_result2: str = 'tails'):
+    flip = FlipCoinOp('flip', str(forced_result1))
 
-    with dsl.Condition(flip1 == 'heads'):
-        with dsl.Condition(flip2 == 'tails'):
-            PrintOp('print1', flip2)
+    with dsl.Condition(flip.output == 'heads'):
+        flip2 = FlipCoinOp('flip-again', str(forced_result2))
 
-    with dsl.Condition(flip1 == 'tails'):
-        PrintOp('print2', flip1)
+        with dsl.Condition(flip2.output == 'tails'):
+            PrintOp('print1', flip2.output)
+
+    with dsl.Condition(flip.output == 'tails'):
+        PrintOp('print2', flip.output)
 
 
 if __name__ == '__main__':

--- a/sdk/python/tests/compiler/testdata/condition.py
+++ b/sdk/python/tests/compiler/testdata/condition.py
@@ -22,8 +22,10 @@ class FlipCoinOp(dsl.ContainerOp):
             name=name,
             image='python:alpine3.6',
             command=['sh', '-c'],
-            arguments=['python -c "import random; import sys; forced_result = \''+forced_result+'\'; result = \'heads\' if random.randint(0,1) == 0 '
-                       'else \'tails\'; print(forced_result) if (forced_result == \'heads\' or forced_result == \'tails\') else print(result)" | tee /tmp/output'],
+            arguments=['python -c "import random; import sys; forced_result = \''+forced_result+'\'; '
+                       'result = \'heads\' if random.randint(0,1) == 0 else \'tails\';'
+                       'print(forced_result) if (forced_result == \'heads\' or forced_result == \'tails\') else print(result)"'
+                       ' | tee /tmp/output'],
             file_outputs={'output': '/tmp/output'})
 
 

--- a/sdk/python/tests/compiler/testdata/condition.py
+++ b/sdk/python/tests/compiler/testdata/condition.py
@@ -23,7 +23,7 @@ class FlipCoinOp(dsl.ContainerOp):
             image='python:alpine3.6',
             command=['sh', '-c'],
             arguments=['python -c "import random; import sys; forced_result = \''+forced_result+'\'; '
-                       'result = \'heads\' if random.randint(0,1) == 0 else \'tails\';'
+                       'result = \'heads\' if random.randint(0,1) == 0 else \'tails\'; '
                        'print(forced_result) if (forced_result == \'heads\' or forced_result == \'tails\') else print(result)"'
                        ' | tee /tmp/output'],
             file_outputs={'output': '/tmp/output'})

--- a/sdk/python/tests/compiler/testdata/condition.py
+++ b/sdk/python/tests/compiler/testdata/condition.py
@@ -40,17 +40,14 @@ class PrintOp(dsl.ContainerOp):
     name='Flip Coin Example Pipeline',
     description='Shows how to use dsl.Condition.'
 )
-def flipcoin():
-    flip = FlipCoinOp('flip')
+def flipcoin(flip1: str = 'heads', flip2: str = 'tails'):
 
-    with dsl.Condition(flip.output == 'heads'):
-        flip2 = FlipCoinOp('flip-again')
+    with dsl.Condition(flip1 == 'heads'):
+        with dsl.Condition(flip2 == 'tails'):
+            PrintOp('print1', flip2)
 
-        with dsl.Condition(flip2.output == 'tails'):
-            PrintOp('print1', flip2.output)
-
-    with dsl.Condition(flip.output == 'tails'):
-        PrintOp('print2', flip2.output)
+    with dsl.Condition(flip1 == 'tails'):
+        PrintOp('print2', flip1)
 
 
 if __name__ == '__main__':

--- a/sdk/python/tests/compiler/testdata/condition.yaml
+++ b/sdk/python/tests/compiler/testdata/condition.yaml
@@ -31,50 +31,14 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: flip
-spec:
-  results:
-  - description: /tmp/output
-    name: output
-  steps:
-  - args:
-    - python -c "import random; result = 'heads' if random.randint(0,1) == 0 else
-      'tails'; print(result)" | tee $(results.output.path)
-    command:
-    - sh
-    - -c
-    image: python:alpine3.6
-    name: main
----
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
-  name: flip-again
-spec:
-  results:
-  - description: /tmp/output
-    name: output
-  steps:
-  - args:
-    - python -c "import random; result = 'heads' if random.randint(0,1) == 0 else
-      'tails'; print(result)" | tee $(results.output.path)
-    command:
-    - sh
-    - -c
-    image: python:alpine3.6
-    name: main
----
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
   name: print1
 spec:
   params:
-  - name: flip-again-output
+  - name: flip2
   steps:
   - command:
     - echo
-    - $(inputs.params.flip-again-output)
+    - $(inputs.params.flip2)
     image: alpine:3.6
     name: main
 ---
@@ -84,11 +48,11 @@ metadata:
   name: print2
 spec:
   params:
-  - name: flip-again-output
+  - name: flip1
   steps:
   - command:
     - echo
-    - $(inputs.params.flip-again-output)
+    - $(inputs.params.flip1)
     image: alpine:3.6
     name: main
 ---
@@ -97,31 +61,23 @@ kind: Pipeline
 metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use dsl.Condition.",
+      "inputs": [{"default": "heads", "name": "flip1", "optional": true, "type": "String"},
+      {"default": "tails", "name": "flip2", "optional": true, "type": "String"}],
       "name": "Flip Coin Example Pipeline"}'
     sidecar.istio.io/inject: 'false'
   name: flip-coin-example-pipeline
 spec:
+  params:
+  - default: heads
+    name: flip1
+  - default: tails
+    name: flip2
   tasks:
-  - name: flip
-    taskRef:
-      name: flip
   - conditions:
     - conditionRef: super-condition
       params:
       - name: operand1
-        value: $(tasks.flip.results.output)
-      - name: operand2
-        value: heads
-      - name: operator
-        value: ==
-    name: flip-again
-    taskRef:
-      name: flip-again
-  - conditions:
-    - conditionRef: super-condition
-      params:
-      - name: operand1
-        value: $(tasks.flip-again.results.output)
+        value: $(params.flip2)
       - name: operand2
         value: tails
       - name: operator
@@ -129,29 +85,29 @@ spec:
     - conditionRef: super-condition
       params:
       - name: operand1
-        value: $(tasks.flip.results.output)
+        value: $(params.flip1)
       - name: operand2
         value: heads
       - name: operator
         value: ==
     name: print1
     params:
-    - name: flip-again-output
-      value: $(tasks.flip-again.results.output)
+    - name: flip2
+      value: $(params.flip2)
     taskRef:
       name: print1
   - conditions:
     - conditionRef: super-condition
       params:
       - name: operand1
-        value: $(tasks.flip.results.output)
+        value: $(params.flip1)
       - name: operand2
         value: tails
       - name: operator
         value: ==
     name: print2
     params:
-    - name: flip-again-output
-      value: $(tasks.flip-again.results.output)
+    - name: flip1
+      value: $(params.flip1)
     taskRef:
       name: print2

--- a/sdk/python/tests/compiler/testdata/condition.yaml
+++ b/sdk/python/tests/compiler/testdata/condition.yaml
@@ -31,14 +31,58 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
+  name: flip
+spec:
+  params:
+  - name: forced-result1
+  results:
+  - description: /tmp/output
+    name: output
+  steps:
+  - args:
+    - python -c "import random; import sys; forced_result = '$(inputs.params.forced-result1)';
+      result = 'heads' if random.randint(0,1) == 0 else 'tails'; print(forced_result)
+      if (forced_result == 'heads' or forced_result == 'tails') else print(result)"
+      | tee $(results.output.path)
+    command:
+    - sh
+    - -c
+    image: python:alpine3.6
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: flip-again
+spec:
+  params:
+  - name: forced-result2
+  results:
+  - description: /tmp/output
+    name: output
+  steps:
+  - args:
+    - python -c "import random; import sys; forced_result = '$(inputs.params.forced-result2)';
+      result = 'heads' if random.randint(0,1) == 0 else 'tails'; print(forced_result)
+      if (forced_result == 'heads' or forced_result == 'tails') else print(result)"
+      | tee $(results.output.path)
+    command:
+    - sh
+    - -c
+    image: python:alpine3.6
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
   name: print1
 spec:
   params:
-  - name: flip2
+  - name: flip-again-output
   steps:
   - command:
     - echo
-    - $(inputs.params.flip2)
+    - $(inputs.params.flip-again-output)
     image: alpine:3.6
     name: main
 ---
@@ -48,11 +92,11 @@ metadata:
   name: print2
 spec:
   params:
-  - name: flip1
+  - name: flip-output
   steps:
   - command:
     - echo
-    - $(inputs.params.flip1)
+    - $(inputs.params.flip-output)
     image: alpine:3.6
     name: main
 ---
@@ -61,23 +105,44 @@ kind: Pipeline
 metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use dsl.Condition.",
-      "inputs": [{"default": "heads", "name": "flip1", "optional": true, "type": "String"},
-      {"default": "tails", "name": "flip2", "optional": true, "type": "String"}],
-      "name": "Flip Coin Example Pipeline"}'
+      "inputs": [{"default": "heads", "name": "forced_result1", "optional": true,
+      "type": "String"}, {"default": "tails", "name": "forced_result2", "optional":
+      true, "type": "String"}], "name": "Flip Coin Example Pipeline"}'
     sidecar.istio.io/inject: 'false'
   name: flip-coin-example-pipeline
 spec:
   params:
   - default: heads
-    name: flip1
+    name: forced-result1
   - default: tails
-    name: flip2
+    name: forced-result2
   tasks:
+  - name: flip
+    params:
+    - name: forced-result1
+      value: $(params.forced-result1)
+    taskRef:
+      name: flip
   - conditions:
     - conditionRef: super-condition
       params:
       - name: operand1
-        value: $(params.flip2)
+        value: $(tasks.flip.results.output)
+      - name: operand2
+        value: heads
+      - name: operator
+        value: ==
+    name: flip-again
+    params:
+    - name: forced-result2
+      value: $(params.forced-result2)
+    taskRef:
+      name: flip-again
+  - conditions:
+    - conditionRef: super-condition
+      params:
+      - name: operand1
+        value: $(tasks.flip-again.results.output)
       - name: operand2
         value: tails
       - name: operator
@@ -85,29 +150,29 @@ spec:
     - conditionRef: super-condition
       params:
       - name: operand1
-        value: $(params.flip1)
+        value: $(tasks.flip.results.output)
       - name: operand2
         value: heads
       - name: operator
         value: ==
     name: print1
     params:
-    - name: flip2
-      value: $(params.flip2)
+    - name: flip-again-output
+      value: $(tasks.flip-again.results.output)
     taskRef:
       name: print1
   - conditions:
     - conditionRef: super-condition
       params:
       - name: operand1
-        value: $(params.flip1)
+        value: $(tasks.flip.results.output)
       - name: operand2
         value: tails
       - name: operator
         value: ==
     name: print2
     params:
-    - name: flip1
-      value: $(params.flip1)
+    - name: flip-output
+      value: $(tasks.flip.results.output)
     taskRef:
       name: print2


### PR DESCRIPTION
The unit test for dsl.Condition previously used a random number generator to dictate which event occurred and therefore which condition would execute. This causes issues with consistent testing as there are multiple valid potential outputs. This test has been changed to be deterministic, to address this issue, by using pipeline parameters to dictate which event occurred and setting default values for the pipeline.