### PR TITLE
Support Exit Handler

### DIFF
--- a/sdk/FEATURES.md
+++ b/sdk/FEATURES.md
@@ -189,9 +189,9 @@ kubectl get pods will show a 'Completed' pod when a sidecar exits successfully b
 
 ### Exit Handler
 
-[Tracking pull request #2437][exitHandler]
-
 An exit handler is a component that always executes, irrespective of success or failure, at the end of the pipeline.
+
+The finally syntax is now supported in tekton preview mode, the final tasks can be specified but not executed yet, implementation and execution of final tasks are tracked in separate PR [Tracking pull request #2661][exitHandler]
 
 
 <!-- Issue and PR links-->
@@ -199,4 +199,4 @@ An exit handler is a component that always executes, irrespective of success or 
 [ParallelFor]: https://github.com/tektoncd/pipeline/issues/2050
 [VarSub]: https://github.com/tektoncd/pipeline/issues/1522
 [Sidecars]: https://github.com/tektoncd/pipeline/issues/1347
-[exitHandler]: https://github.com/tektoncd/pipeline/pull/2437
+[exitHandler]: https://github.com/tektoncd/pipeline/pull/2661

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -500,6 +500,14 @@ class TektonCompiler(Compiler):
     # handle resourceOp cases in pipeline
     self._process_resourceOp(task_refs, pipeline)
 
+    # handle exit handler in pipeline
+    finally_tasks = []
+    for task in task_refs:
+      op = pipeline.ops.get(task['name'])
+      if op.is_exit_handler:
+        finally_tasks.append(task)
+    task_refs = [task for task in task_refs if not pipeline.ops.get(task['name']).is_exit_handler]
+
     # process loop parameters, keep this section in the behind of other processes, ahead of gen pipeline
     root_group = pipeline.groups[0]
     op_name_to_for_loop_op = self._get_for_loop_ops(root_group)
@@ -526,7 +534,8 @@ class TektonCompiler(Compiler):
       },
       'spec': {
         'params': params,
-        'tasks': task_refs
+        'tasks': task_refs,
+        'finally': finally_tasks
       }
     }
 

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -275,6 +275,13 @@ class TestTektonCompiler(unittest.TestCase):
     }
     self._test_workflow_without_decorator('basic_no_decorator.yaml', parameter_dict)
 
+  def test_exit_handler_workflow(self):
+    """
+    Test compiling a exit handler workflow.
+    """
+    from .testdata.exit_handler import download_and_print
+    self._test_pipeline_workflow(download_and_print, 'exit_handler.yaml')
+
   def test_compose(self):
     """
     Test compiling a simple workflow, and a bigger one composed from a simple one.

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -84,14 +84,15 @@ metadata:
     sidecar.istio.io/inject: 'false'
   name: save-most-frequent
 spec:
+  finally:
+  - name: exiting
+    taskRef:
+      name: exiting
   params:
   - name: message
   - default: default_output
     name: outputpath
   tasks:
-  - name: exiting
-    taskRef:
-      name: exiting
   - name: get-frequent
     params:
     - name: message

--- a/sdk/python/tests/compiler/testdata/exit_handler.py
+++ b/sdk/python/tests/compiler/testdata/exit_handler.py
@@ -1,0 +1,64 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import dsl
+
+
+def gcs_download_op(url):
+    return dsl.ContainerOp(
+        name='GCS - Download',
+        image='google/cloud-sdk:279.0.0',
+        command=['sh', '-c'],
+        arguments=['gsutil cat $0 | tee $1', url, '/tmp/results.txt'],
+        file_outputs={
+            'data': '/tmp/results.txt',
+        }
+    )
+
+
+def echo_op(text):
+    return dsl.ContainerOp(
+        name='echo',
+        image='library/bash:4.4.23',
+        command=['sh', '-c'],
+        arguments=['echo "$0"', text],
+    )
+
+
+@dsl.pipeline(
+    name='Exit Handler',
+    description='Downloads a message and prints it. The exit handler will run after the pipeline finishes (successfully or not).'
+)
+def download_and_print(url='gs://ml-pipeline/shakespeare/shakespeare1.txt'):
+    """A sample pipeline showing exit handler."""
+
+    exit_task = echo_op('exit!')
+
+    with dsl.ExitHandler(exit_task):
+        download_task = gcs_download_op(url)
+        echo_task = echo_op(download_task.output)
+
+
+# # General by kfp
+# if __name__ == '__main__':
+#     import kfp
+#     kfp.compiler.Compiler().compile(download_and_print, __file__ + '.yaml')
+
+
+# General by kfp-tekton
+if __name__ == '__main__':
+    # don't use top-level import of TektonCompiler to prevent monkey-patching KFP compiler when using KFP's dsl-compile
+    from kfp_tekton.compiler import TektonCompiler
+    TektonCompiler().compile(download_and_print,
+                             __file__.replace('.py', '.yaml'))

--- a/sdk/python/tests/compiler/testdata/exit_handler.yaml
+++ b/sdk/python/tests/compiler/testdata/exit_handler.yaml
@@ -1,0 +1,98 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: echo
+spec:
+  steps:
+  - args:
+    - echo "$0"
+    - exit!
+    command:
+    - sh
+    - -c
+    image: library/bash:4.4.23
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gcs-download
+spec:
+  params:
+  - name: url
+  results:
+  - description: /tmp/results.txt
+    name: data
+  steps:
+  - args:
+    - gsutil cat $0 | tee $1
+    - $(inputs.params.url)
+    - $(results.data.path)
+    command:
+    - sh
+    - -c
+    image: google/cloud-sdk:279.0.0
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: echo-2
+spec:
+  params:
+  - name: gcs-download-data
+  steps:
+  - args:
+    - echo "$0"
+    - $(inputs.params.gcs-download-data)
+    command:
+    - sh
+    - -c
+    image: library/bash:4.4.23
+    name: main
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Downloads a message and
+      prints it. The exit handler will run after the pipeline finishes (successfully
+      or not).", "inputs": [{"default": "gs://ml-pipeline/shakespeare/shakespeare1.txt",
+      "name": "url", "optional": true}], "name": "Exit Handler"}'
+    sidecar.istio.io/inject: 'false'
+  name: exit-handler
+spec:
+  finally:
+  - name: echo
+    taskRef:
+      name: echo
+  params:
+  - default: gs://ml-pipeline/shakespeare/shakespeare1.txt
+    name: url
+  tasks:
+  - name: gcs-download
+    params:
+    - name: url
+      value: $(params.url)
+    taskRef:
+      name: gcs-download
+  - name: echo-2
+    params:
+    - name: gcs-download-data
+      value: $(tasks.gcs-download.results.data)
+    taskRef:
+      name: echo-2


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #85

**Description of your changes:**
Requirements from watson cases, this PR will support exit handler definiation in kfp-tekton.
The finally syntax is now supported in tekton preview mode as in the final tasks can be specified but not executed yet, implementation and execution of final tasks are tracked in separate PR in tekton are doing that

**Environment tested:**
The exit handler cases below need to be tested after PR 2661 done, issue #180 to trace it:
sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
sdk/python/tests/compiler/testdata/exit_handler.yaml
