### PR TITLE
Fix result path identifier and annotation bug

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -162,20 +162,20 @@ You should see the below outputs saying the artifacts are stored in the object s
 Pipelinerun started: parallel-pipeline-run-g87bs
 Waiting for logs to be available...
 [gcs-download : main] With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate
-[gcs-download-2 : main] I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath
 
 [gcs-download : copy-artifacts] Added `storage` successfully.
-[gcs-download : copy-artifacts] tar: removing leading '/' from member names
 [gcs-download : copy-artifacts] tekton/results/data
-[gcs-download : copy-artifacts] `gcs-download-data.tgz` -> `storage/mlpipeline/runs/parallel-pipeline-run-g87bs/gcs-download/gcs-download-data.tgz`
-[gcs-download : copy-artifacts] Total: 0 B, Transferred: 196 B, Speed: 422 B/s
+[gcs-download : copy-artifacts] tar: removing leading '/' from member names
+[gcs-download : copy-artifacts] `data.tgz` -> `storage/mlpipeline/artifacts/parallel-pipeline-run/gcs-download/data.tgz`
+[gcs-download : copy-artifacts] Total: 0 B, Transferred: 194 B, Speed: 12.07 KiB/s
+
+[gcs-download-2 : main] I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath
 
 [gcs-download-2 : copy-artifacts] Added `storage` successfully.
-[gcs-download-2 : copy-artifacts] tekton/results/data
 [gcs-download-2 : copy-artifacts] tar: removing leading '/' from member names
-[gcs-download-2 : copy-artifacts] `gcs-download-2-data.tgz` -> `storage/mlpipeline/runs/parallel-pipeline-run-g87bs/gcs-download-2/gcs-download-2-data.tgz`
-[gcs-download-2 : copy-artifacts] Total: 0 B, Transferred: 204 B, Speed: 328 B/s
-
+[gcs-download-2 : copy-artifacts] tekton/results/data
+[gcs-download-2 : copy-artifacts] `data.tgz` -> `storage/mlpipeline/artifacts/parallel-pipeline-run/gcs-download-2/data.tgz`
+[gcs-download-2 : copy-artifacts] Total: 0 B, Transferred: 204 B, Speed: 22.86 KiB/s
 
 [echo : main] Text 1: With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate
 [echo : main]

--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -542,7 +542,7 @@ def big_data_passing_tasks(task: dict, inputs_tasks: set,
             # Replace the args for the outputs in the task_spec
             # $(results.task_output.get('name').path)  -->
             # $(workspaces.task_name.path)/task_name-task_output.get('name')
-            placeholder = '$(results.%s.path)' % (task_output.get('name'))
+            placeholder = '$(results.%s.path)' % (sanitize_k8s_name(task_output.get('name')))
             workspaces_parameter = '$(workspaces.%s.path)/%s-%s' % (
                 task_name, task_name, task_output.get('name'))
             task['spec'] = replace_big_data_placeholder(

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -315,7 +315,7 @@ class TektonCompiler(Compiler):
       'kind': 'PipelineRun',
       'metadata': {
         'name': sanitize_k8s_name(pipeline_template['metadata']['name'], suffix_space=4) + '-run',
-        'annotation': {
+        'annotations': {
           'tekton.dev/output_artifacts': json.dumps(self.output_artifacts),
           'tekton.dev/input_artifacts': json.dumps(self.input_artifacts)
         }

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -45,7 +45,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: affinity-run

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -115,7 +115,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: save-most-frequent-word-run

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -545,7 +545,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: file-passing-pipelines-run

--- a/sdk/python/tests/compiler/testdata/compose.yaml
+++ b/sdk/python/tests/compiler/testdata/compose.yaml
@@ -118,7 +118,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: download-and-save-most-frequent-run

--- a/sdk/python/tests/compiler/testdata/condition.yaml
+++ b/sdk/python/tests/compiler/testdata/condition.yaml
@@ -188,7 +188,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: flip-coin-example-pipeline-run

--- a/sdk/python/tests/compiler/testdata/exit_handler.yaml
+++ b/sdk/python/tests/compiler/testdata/exit_handler.yaml
@@ -106,7 +106,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: exit-handler-run

--- a/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
+++ b/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
@@ -89,7 +89,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: hidden-output-file-pipeline-run

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -60,7 +60,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: save-most-frequent-run

--- a/sdk/python/tests/compiler/testdata/init_container.yaml
+++ b/sdk/python/tests/compiler/testdata/init_container.yaml
@@ -48,7 +48,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: initcontainer-run

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -161,7 +161,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: pipeline-with-artifact-input-raw-argument-value-run

--- a/sdk/python/tests/compiler/testdata/katib.yaml
+++ b/sdk/python/tests/compiler/testdata/katib.yaml
@@ -149,7 +149,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: launch-katib-experiment-run

--- a/sdk/python/tests/compiler/testdata/loop_static.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static.yaml
@@ -118,7 +118,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: my-loop-pipeline-run

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -45,7 +45,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: node-selector-run

--- a/sdk/python/tests/compiler/testdata/parallel_join.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join.yaml
@@ -120,7 +120,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: parallel-pipeline-run

--- a/sdk/python/tests/compiler/testdata/parallel_join_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_pipelinerun.yaml
@@ -120,7 +120,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: parallel-pipeline-run

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
@@ -121,7 +121,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: parallel-pipeline-with-argo-vars-run

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_artifacts.log
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_artifacts.log
@@ -1,21 +1,21 @@
 [gcs-download : main] With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate
 
-[gcs-download-2 : main] I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath
-
-[echo : main] Text 1: With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate
-[echo : main] 
-[echo : main] Text 2: I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath
-[echo : main] 
-
 [gcs-download : copy-artifacts] Added `storage` successfully.
-[gcs-download : copy-artifacts] tar: removing leading '/' from member names
 [gcs-download : copy-artifacts] tekton/results/data
-[gcs-download : copy-artifacts] `gcs-download-data.tgz` -> `storage/mlpipeline/runs/parallel-pipeline-run/gcs-download/gcs-download-data.tgz`
-[gcs-download : copy-artifacts] Total: 0 B, Transferred: 196 B, Speed: 20.50 KiB/s
+[gcs-download : copy-artifacts] tar: removing leading '/' from member names
+[gcs-download : copy-artifacts] `data.tgz` -> `storage/mlpipeline/artifacts/parallel-pipeline-run/gcs-download/data.tgz`
+[gcs-download : copy-artifacts] Total: 0 B, Transferred: 194 B, Speed: 12.07 KiB/s
+
+[gcs-download-2 : main] I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath
 
 [gcs-download-2 : copy-artifacts] Added `storage` successfully.
 [gcs-download-2 : copy-artifacts] tar: removing leading '/' from member names
 [gcs-download-2 : copy-artifacts] tekton/results/data
-[gcs-download-2 : copy-artifacts] `gcs-download-2-data.tgz` -> `storage/mlpipeline/runs/parallel-pipeline-run/gcs-download-2/gcs-download-2-data.tgz`
-[gcs-download-2 : copy-artifacts] Total: 0 B, Transferred: 205 B, Speed: 21.09 KiB/s
+[gcs-download-2 : copy-artifacts] `data.tgz` -> `storage/mlpipeline/artifacts/parallel-pipeline-run/gcs-download-2/data.tgz`
+[gcs-download-2 : copy-artifacts] Total: 0 B, Transferred: 204 B, Speed: 22.86 KiB/s
+
+[echo : main] Text 1: With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate
+[echo : main]
+[echo : main] Text 2: I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath
+[echo : main]
 

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_artifacts.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_artifacts.yaml
@@ -64,9 +64,9 @@ spec:
       mc config host add storage http://minio-service.$NAMESPACE:9000 $AWS_ACCESS_KEY_ID
       $AWS_SECRET_ACCESS_KEY
 
-      tar -cvzf gcs-download-data.tgz $(results.data.path)
+      tar -cvzf data.tgz $(results.data.path)
 
-      mc cp gcs-download-data.tgz storage/mlpipeline/runs/$PIPELINERUN/$PIPELINETASK/gcs-download-data.tgz
+      mc cp data.tgz storage/mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/data.tgz
 
       '
 ---
@@ -122,9 +122,9 @@ spec:
       mc config host add storage http://minio-service.$NAMESPACE:9000 $AWS_ACCESS_KEY_ID
       $AWS_SECRET_ACCESS_KEY
 
-      tar -cvzf gcs-download-2-data.tgz $(results.data.path)
+      tar -cvzf data.tgz $(results.data.path)
 
-      mc cp gcs-download-2-data.tgz storage/mlpipeline/runs/$PIPELINERUN/$PIPELINETASK/gcs-download-2-data.tgz
+      mc cp data.tgz storage/mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/data.tgz
 
       '
 ---
@@ -190,7 +190,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{"echo": [{"name": "gcs-download-2-data", "parent_task":
       "gcs-download-2"}, {"name": "gcs-download-data", "parent_task": "gcs-download"}]}'
     tekton.dev/output_artifacts: '{"gcs-download": [{"name": "gcs-download-data",

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
@@ -67,7 +67,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: pipeline-transformer-run

--- a/sdk/python/tests/compiler/testdata/pipelineparams.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.yaml
@@ -95,7 +95,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: pipelineparams-run

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -93,7 +93,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: resourceop-basic-run

--- a/sdk/python/tests/compiler/testdata/retry.yaml
+++ b/sdk/python/tests/compiler/testdata/retry.yaml
@@ -71,7 +71,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: retry-random-failures-run

--- a/sdk/python/tests/compiler/testdata/sequential.yaml
+++ b/sdk/python/tests/compiler/testdata/sequential.yaml
@@ -86,7 +86,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: sequential-pipeline-run

--- a/sdk/python/tests/compiler/testdata/sidecar.yaml
+++ b/sdk/python/tests/compiler/testdata/sidecar.yaml
@@ -77,7 +77,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: sidecar-run

--- a/sdk/python/tests/compiler/testdata/timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout.yaml
@@ -67,7 +67,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: pipeline-includes-two-steps-which-fail-randomly-run

--- a/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout_pipelinerun.yaml
@@ -67,7 +67,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: pipeline-includes-two-steps-which-fail-randomly-run

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -48,7 +48,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: tolerations-run

--- a/sdk/python/tests/compiler/testdata/volume.yaml
+++ b/sdk/python/tests/compiler/testdata/volume.yaml
@@ -84,7 +84,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: volume-run

--- a/sdk/python/tests/compiler/testdata/volume_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_op.yaml
@@ -137,7 +137,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: volumeop-basic-run

--- a/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
@@ -475,7 +475,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: volumesnapshotop-sequential-run

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -199,7 +199,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  annotation:
+  annotations:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/output_artifacts: '{}'
   name: my-pipeline-run


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
- Fix annotations with missing `s`
- Result path identifiers need to be sanitized because Tekton results don't accept underscore name.
- Update artifact name since we introduced a new pattern for capturing the metadata with the new identifier syntax.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):
