### PR TITLE
Generate long_description for PyPi from sdk/README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ $(VENV)/bin/activate: sdk/python/setup.py
 	pip install -e sdk/python
 	@touch $(VENV)/bin/activate
 
+.PHONY: install
+install: venv ## Install the kfp_tekton compiler in a virtual environment
+	@echo "Run 'source $(VENV)/bin/activate' to activate the virtual environment."
+
 .PHONY: unit_test
 unit_test: venv ## Run compiler unit tests
 	@sdk/python/tests/run_tests.sh
@@ -65,3 +69,13 @@ check_license: ## Check for license header in source files
 		grep -H -E -o -c  'Copyright 20.* kubeflow.org'  {} \; | \
 		grep -E ':0$$' | sed 's/..$$//' | \
 		grep . && echo "The files listed above are missing the license header" && exit 1 || echo "OK"
+
+.PHONY: distribution
+distribution: venv ## Create a distribution and upload to test.PyPi.org
+	@echo "NOTE: Using test.PyPi.org -- edit Makefile to target real PyPi index"
+	@twine --version > /dev/null 2>&1 || pip install twine
+	@cd sdk/python && \
+		rm -rf dist/ && \
+		python3 setup.py sdist && \
+		twine check dist/* && \
+		twine upload --repository testpypi dist/*

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -12,32 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import re
 
+# =============================================================================
+# To install the kfp_tekton project run:
+#
+#    $ pip3 install -e .
+#
+# To create a distribution for PyPi run:
+#
+#    $ export KFP_TEKTON_VERSION=0.1.2
+#    $ python3 setup.py sdist
+#    $ twine check dist/kfp-tekton-${KFP_TEKTON_VERSION}.tar.gz
+#    $ twine upload --repository pypi dist/kfp-tekton-${KFP_TEKTON_VERSION}.tar.gz
+#
+#   ... or:
+#
+#    $ make distribution KFP_TEKTON_VERSION=0.1.2
+#
+# =============================================================================
+
+import logging
+import re
+import sys
+
+from os import environ as env
+from os.path import abspath, dirname, join
 from setuptools import setup
 
 
 NAME = "kfp-tekton"
-# VERSION = .... Change the version in kfp_tekton/__init__.py
+# VERSION = ... set the version in kfp_tekton/__init__.py or use KFP_TEKTON_VERSION env var
 LICENSE = "Apache 2.0"
 HOMEPAGE = "https://github.com/kubeflow/kfp-tekton/"
-
 DESCRIPTION = "Tekton Compiler for Kubeflow Pipelines"
 LONG_DESCRIPTION = """\
 The kfp-tekton project is an extension of the Kubeflow Pipelines SDK compiler
 generating Tekton YAML instead of Argo YAML. The project is still in an early
-development stage. Contributors are welcome: {}
+development stage. Contributions are welcome: {}
 """.format(HOMEPAGE)
 
 REQUIRES = [
     'kfp==0.5.1',
 ]
 
+logging.basicConfig()
+logger = logging.getLogger("kfp_tekton/setup.py")
+
 
 def find_version(*file_path_parts):
-    here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, *file_path_parts), 'r') as fp:
+
+    if "KFP_TEKTON_VERSION" in env:
+        version = env.get("KFP_TEKTON_VERSION")
+        logger.warning("Using KFP_TEKTON_VERSION={}".format(version))
+        return version
+
+    here = abspath(dirname(__file__))
+    with open(join(here, *file_path_parts), 'r') as fp:
         version_file_text = fp.read()
 
     version_match = re.search(
@@ -51,11 +81,86 @@ def find_version(*file_path_parts):
     raise RuntimeError("Unable to find version string.")
 
 
+def get_long_description() -> str:
+    """Extract the content of the sdk/README.md and replace relative links when
+    running `python3 setup.py sdist`. Return the abbreviated LONG_DESCRIPTION when
+    running `pip install .`
+
+    :return: long_description, Github flavored Markdown from the sdk/README.md
+    """
+    if "sdist" not in sys.argv:
+        # log messages are only displayed when running `pip --verbose`
+        logger.warning("This not a distribution build. Using abbreviated "
+                       "long_description: {}".format(LONG_DESCRIPTION))
+        return LONG_DESCRIPTION
+    else:
+        logger.warning(
+            "Building a distribution. Using the sdk/README.md for the "
+            "long_description to be displayed on the PyPi landing page.")
+
+    here = abspath(dirname(__file__))
+    project_root = join(here, "..", "..")
+    sdk_readme_file = join(project_root, "sdk", "README.md")
+
+    with open(sdk_readme_file, "r") as f:
+        long_description = f.read()
+
+    # replace relative links from sdk/README.md with be absolute links to GitHub
+    github_repo_master_path = "{}/blob/master".format(HOMEPAGE.rstrip("/"))
+
+    # replace relative links that are siblings to the README, i.e. [link text](FEATURES.md)
+    long_description = re.sub(
+        r"\[([^]]+)\]\((?!http|#|/)([^)]+)\)",
+        r"[\1]({}/{}/\2)".format(github_repo_master_path, "sdk"),
+        long_description)
+
+    # replace links that are relative to the project root, i.e. [link text](/sdk/FEATURES.md)
+    long_description = re.sub(
+        r"\[([^]]+)\]\(/([^)]+)\)",
+        r"[\1]({}/\2)".format(github_repo_master_path),
+        long_description)
+
+    # add anchor link targets around headings for links from table-of-contents (TOC)
+    text = []
+    for line in long_description.splitlines():
+        matches = re.match(r'^(#+) (.*)$', line)
+        if matches:
+            line = '<h{}><a id="{}">{}</a></h{}>'.format(
+                len(matches.group(1)),
+                re.sub(r"[`.()]", "", matches.group(2).replace(" ", "-").lower()),
+                matches.group(2),
+                len(matches.group(1))
+            )
+        text.append(line)
+    long_description = "\n".join(text)
+
+    # verify all replaced links
+    import requests  # top-level import fails pip install, only required for make dist
+    for (text, link) in re.findall(r"\[([^]]+)\]\((%s[^)]+)\)" % github_repo_master_path,
+                                   long_description):
+        response = requests.head(link, allow_redirects=True, timeout=3)
+        if response.status_code >= 400:
+            # raise RuntimeError(  # don't fail the installation
+            # report errors when pip install verbose -v
+            logger.error(
+                "Invalid link in long_description: `[{}]({})`. "
+                "Please open an issue at {}/issues".format(
+                    text, link, HOMEPAGE.rstrip("/")))
+
+    # generate the README with absolute links for easy side-by-side verification
+    sdk_readme_w_abs_links = join(project_root, "sdk", "README_for_PyPi.md")
+    with open(sdk_readme_w_abs_links, 'w') as f:
+        f.write(long_description)
+
+    return long_description
+
+
 setup(
     name=NAME,
     version=find_version("kfp_tekton", "__init__.py"),
     description=DESCRIPTION,
-    long_description=LONG_DESCRIPTION,
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
     author="kubeflow.org",
     license=LICENSE,
     url=HOMEPAGE,


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #185

**Description of your changes:**
- Modify `setup.py` to read `long_description` from [`sdk/README.md`](https://github.com/kubeflow/kfp-tekton/blob/master/sdk/README.md)
- Replace relative links with absolute links to `kfp-tekton` GitHub repo
- Add anchor tags around headings for document-internal links from TOC
- Add `make distribution` target for upload to `testpypi`

**Updated SDK README:**
> [sdk/README.md](https://github.com/ckadner/kfp-tekton/blob/PyPi_description_from_Github_README/sdk/README.md)

**Result on Test-PyPi:**
> https://test.pypi.org/project/kfp-tekton/0.1.0rc5/

**Environment tested:**
* Python Version (use `python --version`): `3.7.5`
* Tekton Version (use `tkn version`): `0.13.0`
* Kubernetes Version (use `kubectl version`): `0.16`
* OS (e.g. from `/etc/os-release`): Mac OS

/cc @jinchihe @animeshsingh 