### PR TITLE
Add TektonClient to SDK

### DIFF
--- a/sdk/python/kfp_tekton/__init__.py
+++ b/sdk/python/kfp_tekton/__init__.py
@@ -14,4 +14,4 @@
 
 __version__ = '0.1.0'
 
-tekton_api_version = 'tekton.dev/v1beta1'
+from ._client import TektonClient  # noqa F401

--- a/sdk/python/kfp_tekton/_client.py
+++ b/sdk/python/kfp_tekton/_client.py
@@ -1,0 +1,63 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import tempfile
+
+from datetime import datetime
+from typing import Mapping, Callable
+
+import kfp
+
+from kfp_tekton.compiler import TektonCompiler
+
+
+class TektonClient(kfp.Client):
+  """Tekton API Client for Kubeflow Pipelines."""
+
+  def create_run_from_pipeline_func(self,
+                                    pipeline_func: Callable,
+                                    arguments: Mapping[str, str],
+                                    run_name=None,
+                                    experiment_name=None,
+                                    pipeline_conf: kfp.dsl.PipelineConf = None,
+                                    namespace=None):
+    """Runs pipeline on Kubernetes cluster with Kubeflow Pipelines Tekton backend.
+
+    This command compiles the pipeline function, creates or gets an experiment and
+    submits the pipeline for execution.
+
+    :param pipeline_func: A function that describes a pipeline by calling components
+        and composing them into execution graph.
+    :param arguments: Arguments to the pipeline function provided as a dict.
+    :param run_name: Optional. Name of the run to be shown in the UI.
+    :param experiment_name: Optional. Name of the experiment to add the run to.
+    :param pipeline_conf: Optional. Pipeline configuration.
+    :param namespace: kubernetes namespace where the pipeline runs are created.
+        For single user deployment, leave it as None;
+        For multi user, input a namespace where the user is authorized
+    :return: RunPipelineResult
+    """
+
+    # TODO: Check arguments against the pipeline function
+    pipeline_name = pipeline_func.__name__
+    run_name = run_name or pipeline_name + ' ' + datetime.now().strftime('%Y-%m-%d %H-%M-%S')
+    try:
+      (_, pipeline_package_path) = tempfile.mkstemp(suffix='.zip')
+      TektonCompiler().compile(pipeline_func, pipeline_package_path, pipeline_conf=pipeline_conf)
+      return self.create_run_from_pipeline_package(pipeline_package_path, arguments,
+                                                   run_name, experiment_name, namespace)
+    finally:
+      os.remove(pipeline_package_path)

--- a/sdk/python/kfp_tekton/_client.py
+++ b/sdk/python/kfp_tekton/_client.py
@@ -21,7 +21,7 @@ from typing import Mapping, Callable
 
 import kfp
 
-from kfp_tekton.compiler import TektonCompiler
+from .compiler import TektonCompiler
 
 
 class TektonClient(kfp.Client):

--- a/sdk/python/kfp_tekton/compiler/__init__.py
+++ b/sdk/python/kfp_tekton/compiler/__init__.py
@@ -12,4 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+__tekton_api_version__ = 'tekton.dev/v1beta1'
+
 from .compiler import TektonCompiler  # noqa F401

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -25,7 +25,7 @@ from kfp_tekton.compiler._k8s_helper import convert_k8s_obj_to_json, sanitize_k8
 from kfp.compiler._op_to_template import _process_obj, _inputs_to_json, _outputs_to_json
 from kfp.dsl._container_op import BaseOp
 
-from .. import tekton_api_version
+from kfp_tekton.compiler import __tekton_api_version__ as tekton_api_version
 
 
 def _get_base_step(name: str):

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -34,7 +34,7 @@ from kfp.dsl._for_loop import LoopArguments, LoopArgumentVariable
 from kfp.dsl._metadata import _extract_pipeline_metadata
 
 # KFP-Tekton imports
-from kfp_tekton import tekton_api_version
+from kfp_tekton.compiler import __tekton_api_version__ as tekton_api_version
 from kfp_tekton.compiler._data_passing_rewriter import fix_big_data_passing
 from kfp_tekton.compiler._k8s_helper import convert_k8s_obj_to_json, sanitize_k8s_name
 from kfp_tekton.compiler._op_to_template import _op_to_template


### PR DESCRIPTION
**Description of your changes:**
- add `TektonClient` to SDK (extends `kfp._client.Client`)
- override `create_run_from_pipeline_func(...)` to run pipeline on Tekton cluster

**Related:**
- #197: [Produce SDK for KFP-Tekton that includes compile, upload, run](https://github.com/kubeflow/kfp-tekton/issues/197)

/cc @Tomcli