### PR TITLE
build.sh: avoid python2-incompatibility error

### DIFF
--- a/sdk/python/build.sh
+++ b/sdk/python/build.sh
@@ -25,6 +25,6 @@ target_archive_file=${1:-kfptekton.tar.gz}
 
 pushd "$(dirname "$0")"
 dist_dir=$(mktemp -d)
-python setup.py sdist --format=gztar --dist-dir "$dist_dir"
+python3 setup.py sdist --format=gztar --dist-dir "$dist_dir"
 cp "$dist_dir"/*.tar.gz "$target_archive_file"
 popd


### PR DESCRIPTION
python2-incompatible type hint is used in the called code, which makes it fail for python2

Works just well for python3. See: issue #202 

**Which issue is resolved by this Pull Request:** 
Resolves #202 

**Description of your changes:**
Call python3 instead of python (often defaulting to python2)

**Environment tested:**

* Python Version (use `python --version`):
  * python: 2.7.16
  * python3: 3.7.7