### PR TITLE
Make unit tests run with Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@
 
 matrix:
   include:
+    - name: "Unit tests, Python 3.5"
+      language: python
+      python: "3.5"
+      env: TOXENV=py35
+      install:
+        - python3 -m pip install -e sdk/python
+      script:
+        - make unit_test
     - name: "Unit tests, Python 3.6"
       language: python
       python: "3.6"

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -318,7 +318,7 @@ class TektonCompiler(Compiler):
     for arg in args:
       param = {'name': arg.name}
       if arg.value is not None:
-        if isinstance(arg.value, (list, tuple)):
+        if isinstance(arg.value, (list, tuple, dict)):
           param['default'] = json.dumps(arg.value, sort_keys=True)
         else:
           param['default'] = str(arg.value)
@@ -478,8 +478,8 @@ class TektonCompiler(Compiler):
         'name': sanitize_k8s_name(pipeline.name or 'Pipeline', suffix_space=4),
         'labels': get_default_telemetry_labels(),
         'annotations': {
-          'tekton.dev/output_artifacts': json.dumps(self.output_artifacts),
-          'tekton.dev/input_artifacts': json.dumps(self.input_artifacts),
+          'tekton.dev/output_artifacts': json.dumps(self.output_artifacts, sort_keys=True),
+          'tekton.dev/input_artifacts': json.dumps(self.input_artifacts, sort_keys=True),
           'sidecar.istio.io/inject': 'false'  # disable Istio inject since Tekton cannot run with Istio sidecar
         }
       },

--- a/sdk/python/tests/compiler/k8s_helper_tests.py
+++ b/sdk/python/tests/compiler/k8s_helper_tests.py
@@ -66,13 +66,13 @@ class TestK8sHelper(unittest.TestCase):
             "My-other-hobbies": "eating-drinking.-sleeping"
         }
         self.assertEqual(
-            list(map(lambda k: sanitize_k8s_name(k, allow_capital_underscore=True, allow_dot=True,
-                                                 allow_slash=True, max_length=253), labels.keys())),
-            list(expected_labels.keys()))
+            sorted(map(lambda k: sanitize_k8s_name(k, allow_capital_underscore=True, allow_dot=True,
+                                                   allow_slash=True, max_length=253), labels.keys())),
+            sorted(expected_labels.keys()))
         self.assertEqual(
-            list(map(lambda v: sanitize_k8s_name(v, allow_capital_underscore=True, allow_dot=True,
-                                                 allow_slash=False, max_length=63), labels.values())),
-            list(expected_labels.values()))
+            sorted(map(lambda v: sanitize_k8s_name(v, allow_capital_underscore=True, allow_dot=True,
+                                                   allow_slash=False, max_length=63), labels.values())),
+            sorted(expected_labels.values()))
 
     def test_sanitize_k8s_annotations(self):
         annotation_keys = {

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -18,21 +18,21 @@ metadata:
   annotations:
     pipelines.kubeflow.org/pipeline_spec: '{"name": "File passing pipelines"}'
     sidecar.istio.io/inject: 'false'
-    tekton.dev/input_artifacts: '{"print-text": [{"name": "repeat-line-output_text",
-      "parent_task": "repeat-line"}], "print-text-2": [{"name": "split-text-lines-odd_lines",
-      "parent_task": "split-text-lines"}], "print-text-3": [{"name": "split-text-lines-even_lines",
+    tekton.dev/input_artifacts: '{"print-params": [{"name": "gen-params-output", "parent_task":
+      "gen-params"}], "print-text": [{"name": "repeat-line-output_text", "parent_task":
+      "repeat-line"}], "print-text-2": [{"name": "split-text-lines-odd_lines", "parent_task":
+      "split-text-lines"}], "print-text-3": [{"name": "split-text-lines-even_lines",
       "parent_task": "split-text-lines"}], "print-text-4": [{"name": "write-numbers-numbers",
-      "parent_task": "write-numbers"}], "sum-numbers": [{"name": "write-numbers-numbers",
       "parent_task": "write-numbers"}], "print-text-5": [{"name": "sum-numbers-output",
-      "parent_task": "sum-numbers"}], "print-params": [{"name": "gen-params-output",
-      "parent_task": "gen-params"}]}'
-    tekton.dev/output_artifacts: '{"repeat-line": [{"name": "repeat-line-output_text",
+      "parent_task": "sum-numbers"}], "sum-numbers": [{"name": "write-numbers-numbers",
+      "parent_task": "write-numbers"}]}'
+    tekton.dev/output_artifacts: '{"gen-params": [{"name": "gen-params-output", "path":
+      "/tmp/outputs/Output/data"}], "repeat-line": [{"name": "repeat-line-output_text",
       "path": "/tmp/outputs/output_text/data"}], "split-text-lines": [{"name": "split-text-lines-even_lines",
       "path": "/tmp/outputs/even_lines/data"}, {"name": "split-text-lines-odd_lines",
-      "path": "/tmp/outputs/odd_lines/data"}], "write-numbers": [{"name": "write-numbers-numbers",
-      "path": "/tmp/outputs/numbers/data"}], "sum-numbers": [{"name": "sum-numbers-output",
-      "path": "/tmp/outputs/Output/data"}], "gen-params": [{"name": "gen-params-output",
-      "path": "/tmp/outputs/Output/data"}]}'
+      "path": "/tmp/outputs/odd_lines/data"}], "sum-numbers": [{"name": "sum-numbers-output",
+      "path": "/tmp/outputs/Output/data"}], "write-numbers": [{"name": "write-numbers-numbers",
+      "path": "/tmp/outputs/numbers/data"}]}'
   labels:
     pipelines.kubeflow.org/pipeline-sdk-type: kfp
   name: file-passing-pipelines

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -20,10 +20,9 @@ metadata:
       "optional": true, "type": "Integer"}], "name": "my-pipeline"}'
     sidecar.istio.io/inject: 'false'
     tekton.dev/input_artifacts: '{"my-in-coop1": [{"name": "loop-item-param-00000001-subvar-a",
+      "parent_task": null}], "my-in-coop2": [{"name": "loop-item-param-00000001-subvar-b",
       "parent_task": null}], "my-inner-inner-coop": [{"name": "loop-item-param-00000001-subvar-a",
-      "parent_task": null}, {"name": "loop-item-param-00000002", "parent_task": null}],
-      "my-in-coop2": [{"name": "loop-item-param-00000001-subvar-b", "parent_task":
-      null}]}'
+      "parent_task": null}, {"name": "loop-item-param-00000002", "parent_task": null}]}'
     tekton.dev/output_artifacts: '{}'
   labels:
     pipelines.kubeflow.org/pipeline-sdk-type: kfp


### PR DESCRIPTION
**Problem:**

Python before `3.6` did not preserve insert order for dictionaries, which causes the generated YAML to be equivalent, yet it can not reliably be compared to the "golden" YAML via `unittest.assertDictEqual`.

**Solution:**

* Sort `dict`s (and `list`s) in unit tests if the Python test runtime predates version 3.6.0
* Ensure string-serialized values are sorted via `json.dumps(..., sort_keys=True)` in the compiler code
* Add unit tests for Python 3.5 to Travis/CI
* Exclude Katib workflow from py35 unit tests as it uses (string-serialized) dictionaries containing `dsl.PipelineParam` objects which can't be JSON-serialized so using `json.dumps(sort..)` is not an alternative

**Environment tested:**

* Python Version (use `python --version`): `3.5`, `3.6`, `3.7` (via `tox`)

/cc @Tomcli 