### PR TITLE
Fix runAfter specification failing to be parsed

### DIFF
--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -81,7 +81,7 @@ export default class WorkflowParser {
         for (const condition of conditions)
           edges.push(...this.checkParams(statusMap, pipelineParams, condition, taskId));
 
-        if (task['taskSpec']['runAfter']) {
+        if (task['runAfter']) {
           task['runAfter'].forEach((parentTask: any) => {
             if (
               statusMap.get(parentTask) &&


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #208 

**Description of your changes:**
The UI expected the runAfter specification to be a child of taskSpec. The UI now expects runAfter to be a sibling of taskSpec.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):
