### PR TITLE
Support achive pipelinerun/taskrun logs to S3 storage

### DIFF
--- a/sdk/FEATURES.md
+++ b/sdk/FEATURES.md
@@ -16,6 +16,7 @@ and test pipelines found in the KFP repository.
     + [Affinity, Node Selector, and Tolerations](#affinity-node-selector-and-tolerations)
     + [ImagePullSecrets](#imagepullsecrets)
     + [Exit Handler](#exit-handler)
+    + [Log Archive](#log-archive)
 - [Pipeline DSL Features with a Custom Tekton Implementation](#pipeline-dsl-features-with-a-custom-tekton-implementation)
   * [Features with the Same Behavior as Argo](#features-with-the-same-behavior-as-argo)
     + [InitContainers](#initcontainers)
@@ -116,6 +117,12 @@ the [exit_handler](/sdk/python/tests/compiler/testdata/exit_handler.py) compiler
 
 The `finally` syntax is supported since Tekton version `0.14.0`.
 
+### Log archive
+Archive tekton pipelinerun logs to S3 storage.
+
+Install [minio](https://min.io) and [banzaicloud logging operator](https://banzaicloud.com/docs/one-eye/logging-operator/deploy/) under `tools` namespaces before using this feature.
+
+Set `enable_s3_logs=True` during complie, for example [parallel join with S3 archive logs](/sdk/python/tests/compiler/testdata/parallel_join.py) compiler test
 
 # Pipeline DSL Features with a Custom Tekton Implementation
 

--- a/sdk/python/tests/compiler/testdata/parallel_join.py
+++ b/sdk/python/tests/compiler/testdata/parallel_join.py
@@ -54,4 +54,11 @@ def download_and_join(
 
 if __name__ == '__main__':
     from kfp_tekton.compiler import TektonCompiler
-    TektonCompiler().compile(download_and_join, __file__.replace('.py', '.yaml'))
+    TektonCompiler().compile(
+        download_and_join,
+        __file__.replace('.py', '') + "_s3.yaml",
+        enable_s3_logs=True,
+        S3_ACCESSKEY='UzNfQUNDRVNTS0VZ',
+        S3_SECRETKEY='U0VDUkVUS0VZ',
+        minio_endpoint='http://minio.tools.svc.cluster.local:9000'
+    )

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_s3_archive_logs.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_s3_archive_logs.yaml
@@ -1,0 +1,146 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: logging
+spec:
+  fluentd: {}
+  fluentbit: {}
+  controlNamespace: tools
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: ClusterOutput
+metadata:
+  name: s3
+spec:
+  s3:
+    aws_key_id:
+      value: 'UzNfQUNDRVNTS0VZ'
+    aws_sec_key:
+      value: 'U0VDUkVUS0VZ'
+    s3_endpoint: http://minio.tools.svc.cluster.local:9000
+    s3_bucket: tekton-logs
+    s3_region: tekton
+    force_path_style: 'true'
+    store_as: text
+    path: \${\$.kubernetes.namespace_name}/\${\$.kubernetes.pod_name}/\${\$.kubernetes.container_name}/
+    s3_object_key_format: '%{path}%{time_slice}_%{index}.log'
+    buffer:
+      tags: time,\$.kubernetes.namespace_name,\$.kubernetes.pod_name,\$.kubernetes.container_name
+      timekey: 1m
+      timekey_wait: 1m
+      timekey_use_utc: true
+    format:
+      type: single_value
+      message_key: message
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: ClusterFlow
+metadata:
+  name: flow
+spec:
+  outputRefs:
+    - s3
+  selectors:
+    app.kubernetes.io/managed-by: tekton-pipelines
+---  
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Download two messages
+      in parallel and prints the concatenated result.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
+      "name": "url1", "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
+      "name": "url2", "optional": true}], "name": "Parallel pipeline"}'
+    sidecar.istio.io/inject: 'false'
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/output_artifacts: '{}'
+  labels:
+    pipelines.kubeflow.org/pipeline-sdk-type: kfp
+  name: parallel-pipeline
+spec:
+  params:
+  - name: url1
+    value: gs://ml-pipeline-playground/shakespeare1.txt
+  - name: url2
+    value: gs://ml-pipeline-playground/shakespeare2.txt
+  pipelineSpec:
+    params:
+    - default: gs://ml-pipeline-playground/shakespeare1.txt
+      name: url1
+    - default: gs://ml-pipeline-playground/shakespeare2.txt
+      name: url2
+    tasks:
+    - name: gcs-download
+      params:
+      - name: url1
+        value: $(params.url1)
+      taskSpec:
+        params:
+        - name: url1
+        results:
+        - description: /tmp/results.txt
+          name: data
+        steps:
+        - args:
+          - gsutil cat $0 | tee $1
+          - $(inputs.params.url1)
+          - $(results.data.path)
+          command:
+          - sh
+          - -c
+          image: google/cloud-sdk:279.0.0
+          name: main
+    - name: gcs-download-2
+      params:
+      - name: url2
+        value: $(params.url2)
+      taskSpec:
+        params:
+        - name: url2
+        results:
+        - description: /tmp/results.txt
+          name: data
+        steps:
+        - args:
+          - gsutil cat $0 | tee $1
+          - $(inputs.params.url2)
+          - $(results.data.path)
+          command:
+          - sh
+          - -c
+          image: google/cloud-sdk:279.0.0
+          name: main
+    - name: echo
+      params:
+      - name: gcs-download-2-data
+        value: $(tasks.gcs-download-2.results.data)
+      - name: gcs-download-data
+        value: $(tasks.gcs-download.results.data)
+      taskSpec:
+        params:
+        - name: gcs-download-2-data
+        - name: gcs-download-data
+        steps:
+        - args:
+          - 'echo "Text 1: $0"; echo "Text 2: $1"'
+          - $(inputs.params.gcs-download-data)
+          - $(inputs.params.gcs-download-2-data)
+          command:
+          - sh
+          - -c
+          image: library/bash:4.4.23
+          name: main


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #161 

**Description of your changes:**
Achive pipelinerun/taskrun logs to S3 by fluentd solution. 
https://github.com/eddycharly/dashboard/blob/external-logs/docs/walkthrough/walkthrough-logs.md

User need to install [minio](https://min.io) and [banzaicloud logging operator](https://banzaicloud.com/docs/one-eye/logging-operator/deploy/) under `tools` namespaces before using this feature.

Then user could set `enable_s3_logs=True` and provide parameters of "S3_ACCESSKEY, S3_SECRETKEY and minio_endpoint" to complie the pipelinerun, details see `parallel_join.py` or `compiler_tests.py` file of this PR

/cc @Tomcli 