### PR TITLE
Add init tekton samples as part of the apiserver build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -61,7 +61,7 @@ COPY ./samples .
 # The "for" loop breaks on all whitespace, so we either need to override IFS or
 # use the "read" command instead.
 RUN line="import kfp;kfp.components.default_base_image_or_builder='gcr.io/google-appengine/python:2020-03-31-141326";\
-    set -e; find core tutorials -maxdepth 2 -name '*.py' -type f | while read pipeline; do \
+    set -e; find flip-coin -maxdepth 2 -name '*.py' -type f | while read pipeline; do \
     awk -v text="$line" '!/^#/ && !p {print text; p=1} 1' "$pipeline" && \
     python3 "$pipeline"; \
     done

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -62,7 +62,7 @@ def patch_pod_metadata(
 mlmd_store = connect_to_mlmd()
 print("Connected to the metadata store")
 
-PIPELINE_RUNTIME = os.getenv("PIPELINE_RUNTIME", "argo").lower()
+PIPELINE_RUNTIME = os.getenv("PIPELINE_RUNTIME", "tekton").lower()
 
 ARGO_OUTPUTS_ANNOTATION_KEY = 'workflows.argoproj.io/outputs'
 ARGO_TEMPLATE_ANNOTATION_KEY = 'workflows.argoproj.io/template'

--- a/backend/src/apiserver/config/sample_config.json
+++ b/backend/src/apiserver/config/sample_config.json
@@ -1,27 +1,7 @@
 [
   {
-    "name": "[Demo] XGBoost - Training with confusion matrix",
-    "description": "[source code](https://github.com/kubeflow/pipelines/blob/master/samples/core/xgboost_training_cm) [GCP Permission requirements](https://github.com/kubeflow/pipelines/blob/master/samples/core/xgboost_training_cm#requirements). A trainer that does end-to-end distributed training for XGBoost models.",
-    "file": "/samples/core/xgboost_training_cm/xgboost_training_cm.py.yaml"
-  },
-  {
-    "name": "[Demo] TFX - Taxi tip prediction model trainer",
-    "description": "[source code](https://github.com/kubeflow/pipelines/tree/master/samples/core/parameterized_tfx_oss) [GCP Permission requirements](https://github.com/kubeflow/pipelines/blob/master/samples/core/parameterized_tfx_oss#permission). Example pipeline that does classification with model analysis based on a public tax cab dataset.",
-    "file": "/samples/core/parameterized_tfx_oss/parameterized_tfx_oss.py.yaml"
-  },
-  {
-    "name": "[Tutorial] Data passing in python components",
-    "description": "[source code](https://github.com/kubeflow/pipelines/tree/master/samples/tutorials/Data%20passing%20in%20python%20components) Shows how to pass data between python components.",
-    "file": "/samples/tutorials/Data passing in python components/Data passing in python components - Files.py.yaml"
-  },
-  {
-    "name": "[Tutorial] DSL - Control structures",
-    "description": "[source code](https://github.com/kubeflow/pipelines/tree/master/samples/tutorials/DSL%20-%20Control%20structures) Shows how to use conditional execution and exit handlers. This pipeline will randomly fail to demonstrate that the exit handler gets executed even in case of failure.",
-    "file": "/samples/tutorials/DSL - Control structures/DSL - Control structures.py.yaml"
-  },
-  {
-    "name": "[Demo] TFX - Iris classification pipeline",
-    "description": "[source code](https://github.com/kubeflow/pipelines/tree/master/samples/core/iris). Example pipeline that classifies Iris flower subspecies and how to use native Keras within TFX.",
-    "file": "/samples/core/iris/iris.py.yaml"
+    "name": "[Demo] flip-coin",
+    "description": "[source code](https://github.com/kubeflow/kfp-tekton/tree/master/samples/flip-coin) A conditional pipeline to flip coins based on a random number generator.",
+    "file": "/samples/flip-coin/condition.yaml"
   }
 ]

--- a/backend/src/common/util/template_util.go
+++ b/backend/src/common/util/template_util.go
@@ -33,7 +33,7 @@ const (
 )
 
 func GetParameters(template []byte) (string, error) {
-	if strings.ToLower(os.Getenv("PIPELINE_RUNTIME")) == "tekton" {
+	if strings.ToLower(os.Getenv("PIPELINE_RUNTIME")) != "argo" {
 		return GetTektonParameters(template)
 	}
 	return "nil", nil


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
After the repo restructure, our Tekton examples are now located under /samples. Thus, update the sample_config.json and docker build to compile clip-coin as our init Tekton example in KFP. 

Also updating the default run time to Tekton so that it can run with the default upstream manifest for our dojo deployment.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):
