### PR TITLE
Update terminate status using the latest tekton api spec

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -446,11 +446,11 @@ func (r *ResourceManager) ListJobs(filterContext *common.FilterContext,
 	return r.jobStore.ListJobs(filterContext, opts)
 }
 
-// TerminateWorkflow terminates a workflow by setting its activeDeadlineSeconds to 0
+// TerminateWorkflow terminates a pipelinerun by setting its status to PipelineRunCancelled
 func TerminateWorkflow(wfClient workflowclient.PipelineRunInterface, name string) error {
 	patchObj := map[string]interface{}{
 		"spec": map[string]interface{}{
-			"activeDeadlineSeconds": 0,
+			"status": "PipelineRunCancelled",
 		},
 	}
 

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -278,8 +278,15 @@ func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeID string, artifactName
 // IsInFinalState whether the workflow is in a final state.
 func (w *Workflow) IsInFinalState() bool {
 	if len(w.Status.Status.Conditions) > 0 {
+		finalConditions := map[string]int{
+			"Succeeded":                1,
+			"Failed":                   1,
+			"Completed":                1,
+			"PipelineRunCancelled":     1,
+			"PipelineRunCouldntCancel": 1,
+		}
 		phase := w.Status.Status.Conditions[0].Reason
-		if phase == "Succeeded" || phase == "Failed" || phase == "Completed" {
+		if _, ok := finalConditions[phase]; ok {
 			return true
 		}
 	}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #227 

**Description of your changes:**
Update the KFP terminate status because Tekton `cancel` introduced 2 new status  `PipelineRunCancelled`, `PipelineRunCouldntCancel` some time during v0.13 and v0.14 release.

Will open another issue for the UI to handle these new status.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`): 0.14
* Kubernetes Version (use `kubectl version`): 1.16
* OS (e.g. from `/etc/os-release`):
