### PR TITLE
Upgrade E2E tests for tkn CLI version 0.11

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -51,7 +51,7 @@ SDK provides a `TektonCompiler` and a `TektonClient`:
 
  - Python: `3.5.3` or later
  - Tekton: [`0.14.0`](https://github.com/tektoncd/pipeline/releases/tag/v0.14.0)
- - Tekton CLI: [`0.10.0`](https://github.com/tektoncd/cli/releases/tag/v0.10.0)
+ - Tekton CLI: [`0.11.0`](https://github.com/tektoncd/cli/releases/tag/v0.11.0)
  - Kubeflow Pipelines: [KFP with Tekton backend](/tekton_kfp_guide.md)
 
 Follow the instructions for [installing project prerequisites](/sdk/python/README.md#development-prerequisites)

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -31,9 +31,9 @@ from kfp_tekton import compiler
 # temporarily set this flag to True in order to (re)generate new "golden" YAML
 # files after making code changes that modify the expected YAML output.
 # to (re)generate all "golden" YAML files from the command line run:
-#   GENERATE_GOLDEN_YAML=True sdk/python/tests/run_tests.sh
+#    GENERATE_GOLDEN_YAML=True sdk/python/tests/run_tests.sh
 # or:
-#   make test GENERATE_GOLDEN_YAML=True
+#    make unit_test GENERATE_GOLDEN_YAML=True
 GENERATE_GOLDEN_YAML = env.get("GENERATE_GOLDEN_YAML", "False") == "True"
 
 if GENERATE_GOLDEN_YAML:

--- a/sdk/python/tests/compiler/testdata/affinity.py
+++ b/sdk/python/tests/compiler/testdata/affinity.py
@@ -37,7 +37,7 @@ def affinity_pipeline(
             required_during_scheduling_ignored_during_execution=V1NodeSelector(
                 node_selector_terms=[V1NodeSelectorTerm(
                     match_expressions=[V1NodeSelectorRequirement(
-                        key='beta.kubernetes.io/os',
+                        key='kubernetes.io/os',
                         operator='In',
                         values=['linux'])])])))
     echo_op().add_affinity(affinity)

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -45,7 +45,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.log
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.log
@@ -1,7 +1,8 @@
 [get-frequent : main] flies
 
 [save : main] Copying file:///tmp/results.txt...
-[save : main] / [0 files][    0.0 B/    7.0 B]                                                
-/ [1 files][    7.0 B/    7.0 B]                                                
+[save : main] / [0 files][    0.0 B/    7.0 B]                                                / [1 files][    7.0 B/    7.0 B]                                                
 [save : main] Operation completed over 1 objects/7.0 B.                                        
+
+[exiting : main] exit!
 

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.py
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.py
@@ -84,9 +84,7 @@ def save_most_frequent_word():
         output_path=output_path_param)
     saver.container.set_cpu_limit('0.5')
     # saver.container.set_gpu_limit('2')
-    saver.add_node_selector_constraint(
-        'failure-domain.beta.kubernetes.io/region',
-        'us-south')
+    saver.add_node_selector_constraint('kubernetes.io/os', 'linux')
     # saver.apply(gcp.use_tpu(tpu_cores=2, tpu_resource='v2', tf_version='1.12'))
 
 

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -98,4 +98,4 @@ spec:
   - pipelineTaskName: save
     taskPodTemplate:
       nodeSelector:
-        failure-domain.beta.kubernetes.io/region: us-south
+        kubernetes.io/os: linux

--- a/sdk/python/tests/compiler/testdata/compose.log
+++ b/sdk/python/tests/compiler/testdata/compose.log
@@ -4,7 +4,7 @@
 [download : copy-artifacts] tar: removing leading '/' from member names
 [download : copy-artifacts] tekton/results/downloaded
 [download : copy-artifacts] `downloaded.tgz` -> `storage/mlpipeline/artifacts/download-and-save-most-frequent/download/downloaded.tgz`
-[download : copy-artifacts] Total: 0 B, Transferred: 200 B, Speed: 14.79 KiB/s
+[download : copy-artifacts] Total: 0 B, Transferred: 200 B, Speed: 14.17 KiB/s
 
 [get-frequent : main] your
 
@@ -12,5 +12,9 @@
 [get-frequent : copy-artifacts] tar: removing leading '/' from member names
 [get-frequent : copy-artifacts] tekton/results/word
 [get-frequent : copy-artifacts] `word.tgz` -> `storage/mlpipeline/artifacts/download-and-save-most-frequent/get-frequent/word.tgz`
-[get-frequent : copy-artifacts] Total: 0 B, Transferred: 116 B, Speed: 9.30 KiB/s
+[get-frequent : copy-artifacts] Total: 0 B, Transferred: 117 B, Speed: 2.90 KiB/s
+
+[save : main] Copying file:///tmp/results.txt...
+[save : main] / [0 files][    0.0 B/    6.0 B]                                                / [1 files][    6.0 B/    6.0 B]                                                
+[save : main] Operation completed over 1 objects/6.0 B.                                        
 

--- a/sdk/python/tests/compiler/testdata/exit_handler.log
+++ b/sdk/python/tests/compiler/testdata/exit_handler.log
@@ -4,8 +4,10 @@
 [gcs-download : copy-artifacts] tar: removing leading '/' from member names
 [gcs-download : copy-artifacts] tekton/results/data
 [gcs-download : copy-artifacts] `data.tgz` -> `storage/mlpipeline/artifacts/exit-handler/gcs-download/data.tgz`
-[gcs-download : copy-artifacts] Total: 0 B, Transferred: 195 B, Speed: 16.39 KiB/s
+[gcs-download : copy-artifacts] Total: 0 B, Transferred: 195 B, Speed: 14.59 KiB/s
 
 [echo-2 : main] With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate
 [echo-2 : main] 
+
+[echo : main] exit!
 

--- a/sdk/python/tests/compiler/testdata/node_selector.py
+++ b/sdk/python/tests/compiler/testdata/node_selector.py
@@ -32,8 +32,8 @@ def node_selector_pipeline(
 ):
     """A pipeline with Node Selector"""
     echo_op().add_node_selector_constraint(
-        label_name='beta.kubernetes.io/instance-type',
-        value='b3c.4x16.encrypted')
+        label_name='kubernetes.io/os',
+        value='linux')
 
 
 if __name__ == '__main__':

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -41,4 +41,4 @@ spec:
   - pipelineTaskName: echo
     taskPodTemplate:
       nodeSelector:
-        beta.kubernetes.io/instance-type: b3c.4x16.encrypted
+        kubernetes.io/os: linux

--- a/sdk/python/tests/compiler/testdata/pipelineparams.log
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.log
@@ -4,12 +4,14 @@
 [download : main] '/tekton/results/downloaded-resultoutput' saved
 
 [download : copy-artifacts] Added `storage` successfully.
-[download : copy-artifacts] tar: removing leading '/' from member names
 [download : copy-artifacts] tekton/results/downloaded-resultoutput
+[download : copy-artifacts] tar: removing leading '/' from member names
 [download : copy-artifacts] `downloaded_resultOutput.tgz` -> `storage/mlpipeline/artifacts/pipelineparams/download/downloaded_resultOutput.tgz`
-[download : copy-artifacts] Total: 0 B, Transferred: 136 B, Speed: 12.10 KiB/s
+[download : copy-artifacts] Total: 0 B, Transferred: 138 B, Speed: 11.44 KiB/s
 
-[download : sidecar-echo] 2020/07/13 10:38:44 Server is listening on :5678
-[download : sidecar-echo] 2020/07/13 10:38:56 localhost:5678 127.0.0.1:55050 "GET / HTTP/1.1" 200 14 "Wget" 39.277µs
-[download : sidecar-echo] 2020/07/13 10:38:59 [ERR] Unknown signal terminated
+[download : sidecar-echo] 2020/07/31 09:29:31 Server is listening on :5678
+[download : sidecar-echo] 2020/07/31 09:29:43 localhost:5678 127.0.0.1:54892 "GET / HTTP/1.1" 200 14 "Wget" 15.199µs
+[download : sidecar-echo] 2020/07/31 09:29:45 [ERR] Unknown signal terminated
+
+[echo : main] pipelineParams: hello world
 

--- a/sdk/python/tests/compiler/testdata/retry.py
+++ b/sdk/python/tests/compiler/testdata/retry.py
@@ -21,7 +21,8 @@ def random_failure_op(exit_codes):
         name='random_failure',
         image='python:alpine3.6',
         command=['python', '-c'],
-        arguments=['import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]); '
+        arguments=['import random; import sys; '
+                   'exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]); '
                    'print(exit_code); sys.exit(exit_code)', exit_codes]
     )
 

--- a/sdk/python/tests/compiler/testdata/sidecar.log
+++ b/sdk/python/tests/compiler/testdata/sidecar.log
@@ -7,9 +7,11 @@
 [download : copy-artifacts] tar: removing leading '/' from member names
 [download : copy-artifacts] tekton/results/downloaded
 [download : copy-artifacts] `downloaded.tgz` -> `storage/mlpipeline/artifacts/sidecar/download/downloaded.tgz`
-[download : copy-artifacts] Total: 0 B, Transferred: 128 B, Speed: 10.89 KiB/s
+[download : copy-artifacts] Total: 0 B, Transferred: 130 B, Speed: 12.63 KiB/s
 
-[download : sidecar-echo] 2020/07/13 10:40:23 Server is listening on :5678
-[download : sidecar-echo] 2020/07/13 10:40:35 localhost:5678 127.0.0.1:38196 "GET / HTTP/1.1" 200 14 "Wget" 38.547µs
-[download : sidecar-echo] 2020/07/13 10:40:37 [ERR] Unknown signal terminated
+[download : sidecar-echo] 2020/07/31 09:31:18 Server is listening on :5678
+[download : sidecar-echo] 2020/07/31 09:31:30 localhost:5678 127.0.0.1:38090 "GET / HTTP/1.1" 200 14 "Wget" 41.526µs
+[download : sidecar-echo] 2020/07/31 09:31:33 [ERR] Unknown signal terminated
+
+[echo : main] hello world
 


### PR DESCRIPTION
**Description of your changes:**

* Upgrade `tkn` CLI version to `0.11`
* Now including logs for `finally` tasks
* Add environment variable to modify `SLEEP_BETWEEN_TEST_PHASES` on cluster
* Add `retry.yaml` to ignored test cases since it is designed to fail randomly
* Change `node_selector`s to be more generic
* Use `pipelinerun` `status.conditions[].reason` instead of `.. [].type`
* Treat `pipelinerun` status `"Completed"` as `"Succeeded"`

**Environment tested:**

* Python Version (use `python --version`): `3.7.5`
* Tekton Version (use `tkn version`):
   - Pipeline version: `0.14.2`
   - Client version: `0.11.0`
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):


**Additional information:**

- Optional environment variables to configure `e2e_test`, examples:

```
  make e2e_test TKN_PIPELINE_VERSION=0.14
  make e2e_test TKN_CLIENT_VERSION=0.11
  make e2e_test GENERATE_GOLDEN_E2E_LOGS=True
  make e2e_test USE_LOGS_FROM_PREVIOUS_RUN=True
  make e2e_test INCLUDE_TESTS=test_name1,test_name2
  make e2e_test EXCLUDE_TESTS=test_name1,test_name2
  make e2e_test SLEEP_BETWEEN_TEST_PHASES=10
  make e2e_test RERUN_FAILED_TESTS_ONLY=True
```


/cc @Tomcli 