### PR TITLE
Fix run output crash when artifacts are present

### DIFF
--- a/frontend/src/lib/CompareUtils.ts
+++ b/frontend/src/lib/CompareUtils.ts
@@ -118,7 +118,7 @@ export default class CompareUtils {
       xLabels = Array.from(namesToNodesToValues.keys());
 
       rows = Array.from(nodeIds.keys()).map(nodeId => {
-        yLabels.push((workflow && workflow.status.nodes[nodeId].displayName) || nodeId);
+        yLabels.push(nodeId);
         return xLabels.map(metricName => namesToNodesToValues.get(metricName)!.get(nodeId) || '');
       });
     }


### PR DESCRIPTION
Hotfix for a crash coming from the Run Output page when Artifacts are used.