### PR TITLE
Feature: Configurable artifact credentials and annotations

### DIFF
--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -84,6 +84,7 @@ TEKTON_TASKRUN_LABEL_KEY = 'tekton.dev/taskRun'
 TEKTON_PIPELINETASK_LABEL_KEY = 'tekton.dev/pipelineTask'
 TEKTON_INPUT_ARTIFACT_ANNOTATION_KEY = 'tekton.dev/input_artifacts'
 TEKTON_OUTPUT_ARTIFACT_ANNOTATION_KEY = 'tekton.dev/output_artifacts'
+TEKTON_BUCKET_ARTIFACT_ANNOTATION_KEY = 'tekton.dev/artifact_bucket'
 
 PIPELINE_LABEL_KEY = TEKTON_PIPELINERUN_LABEL_KEY if PIPELINE_RUNTIME == "tekton" else ARGO_WORKFLOW_LABEL_KEY
 
@@ -142,7 +143,7 @@ def get_component_template(obj):
                     {
                         "name": i["name"],
                         "s3": {
-                            "bucket": "mlpipeline",
+                            "bucket": obj.metadata.annotations.get(TEKTON_BUCKET_ARTIFACT_ANNOTATION_KEY, "mlpipeline"),
                             "key": "artifacts/%s/%s/%s.tgz" % (obj.metadata.labels[TEKTON_PIPELINERUN_LABEL_KEY],
                                                                i['parent_task'],
                                                                i["name"].replace(i['parent_task'] + '-', ''))
@@ -173,7 +174,7 @@ def get_output_template(obj):
                     "name": i["name"],
                     "path": i["path"],
                     "s3": {
-                        "bucket": "mlpipeline",
+                        "bucket": obj.metadata.annotations.get(TEKTON_BUCKET_ARTIFACT_ANNOTATION_KEY, "mlpipeline"),
                         "key": "%s/%s.tgz" % (s3_key_prefix,
                                               i["name"].replace(artifact_prefix, ''))
                     }

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -29,6 +29,9 @@ const (
 	DefaultPipelineRunnerServiceAccount string = "DefaultPipelineRunnerServiceAccount"
 	KubeflowUserIDHeader                string = "KUBEFLOW_USERID_HEADER"
 	KubeflowUserIDPrefix                string = "KUBEFLOW_USERID_PREFIX"
+	ArtifactBucket                      string = "ARTIFACT_BUCKET"
+	ArtifactEndpoint                    string = "ARTIFACT_ENDPOINT"
+	ArtifactEndpointScheme              string = "ARTIFACT_ENDPOINT_SCHEME"
 )
 
 func GetStringConfig(configName string) string {
@@ -97,4 +100,16 @@ func GetKubeflowUserIDHeader() string {
 
 func GetKubeflowUserIDPrefix() string {
 	return GetStringConfigWithDefault(KubeflowUserIDPrefix, GoogleIAPUserIdentityPrefix)
+}
+
+func GetArtifactBucket() string {
+	return GetStringConfigWithDefault(ArtifactBucket, DefaultArtifactBucket)
+}
+
+func GetArtifactEndpoint() string {
+	return GetStringConfigWithDefault(ArtifactEndpoint, DefaultArtifactEndpoint)
+}
+
+func GetArtifactEndpointScheme() string {
+	return GetStringConfigWithDefault(ArtifactEndpointScheme, DefaultArtifactEndpointScheme)
 }

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -41,6 +41,18 @@ const (
 	GoogleIAPUserIdentityPrefix string = "accounts.google.com:"
 )
 
+const (
+	DefaultArtifactBucket         string = "mlpipeline"
+	DefaultArtifactEndpoint       string = "minio-service.kubeflow:9000"
+	DefaultArtifactEndpointScheme string = "http://"
+)
+
+const (
+	ArtifactBucketAnnotation         string = "tekton.dev/artifact_bucket"
+	ArtifactEndpointAnnotation       string = "tekton.dev/artifact_endpoint"
+	ArtifactEndpointSchemeAnnotation string = "tekton.dev/artifact_endpoint_scheme"
+)
+
 func ToModelResourceType(apiType api.ResourceType) (ResourceType, error) {
 	switch apiType {
 	case api.ResourceType_EXPERIMENT:

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -348,6 +348,12 @@ func (r *ResourceManager) CreateRun(apiRun *api.Run) (*model.RunDetail, error) {
 	workflow.SetLabels(util.LabelKeyWorkflowRunId, runId)
 	// Add run name annotation to the workflow so that it can be logged by the Metadata Writer.
 	workflow.SetAnnotations(util.AnnotationKeyRunName, apiRun.Name)
+
+	// Tekton: Update artifact cred using the KFP Tekton configmap
+	workflow.SetAnnotations(common.ArtifactBucketAnnotation, common.GetArtifactBucket())
+	workflow.SetAnnotations(common.ArtifactEndpointAnnotation, common.GetArtifactEndpoint())
+	workflow.SetAnnotations(common.ArtifactEndpointSchemeAnnotation, common.GetArtifactEndpointScheme())
+
 	// Replace {{workflow.uid}} with runId
 	err = workflow.ReplaceUID(runId)
 	if err != nil {
@@ -607,6 +613,11 @@ func (r *ResourceManager) CreateJob(apiJob *api.Job) (*model.Job, error) {
 			NoCatchup: util.BoolPointer(apiJob.NoCatchup),
 		},
 	}
+
+	// Tekton: Update artifact cred using the KFP Tekton configmap
+	workflow.SetAnnotations(common.ArtifactBucketAnnotation, common.GetArtifactBucket())
+	workflow.SetAnnotations(common.ArtifactEndpointAnnotation, common.GetArtifactEndpoint())
+	workflow.SetAnnotations(common.ArtifactEndpointSchemeAnnotation, common.GetArtifactEndpointScheme())
 
 	// Marking auto-added artifacts as optional. Otherwise most older workflows will start failing after upgrade to Argo 2.3.
 

--- a/manifests/kustomize/env/platform-agnostic/apiserver-deployment.yaml
+++ b/manifests/kustomize/env/platform-agnostic/apiserver-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-api-server
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OBJECTSTORECONFIG_SECURE
+          value: "false"
+        - name: OBJECTSTORECONFIG_BUCKETNAME
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: bucketName
+        - name: DBCONFIG_USER
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: username
+        - name: DBCONFIG_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: password
+        - name: DBCONFIG_DBNAME
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: pipelineDb
+        - name: DBCONFIG_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbHost
+        - name: DBCONFIG_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbPort
+        - name: OBJECTSTORECONFIG_ACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              name: mlpipeline-minio-artifact
+              key: accesskey
+        - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              name: mlpipeline-minio-artifact
+              key: secretkey
+        - name: PIPELINE_RUNTIME
+          value: tekton
+        - name: ARTIFACT_BUCKET
+          valueFrom:
+            configMapKeyRef:
+              name: kfp-tekton-config
+              key: artifact_bucket
+        - name: ARTIFACT_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: kfp-tekton-config
+              key: artifact_endpoint
+        - name: ARTIFACT_ENDPOINT_SCHEME
+          valueFrom:
+            configMapKeyRef:
+              name: kfp-tekton-config
+              key: artifact_endpoint_scheme

--- a/manifests/kustomize/env/platform-agnostic/kfp-pipeline-install-config.yaml
+++ b/manifests/kustomize/env/platform-agnostic/kfp-pipeline-install-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kfp-tekton-config
+data:
+  artifact_bucket: "mlpipeline"
+  artifact_endpoint: "minio-service.kubeflow:9000"
+  artifact_endpoint_scheme: "http://"

--- a/manifests/kustomize/env/platform-agnostic/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic/kustomization.yaml
@@ -6,6 +6,12 @@ bases:
   - minio
   - mysql
 
+resources:
+  - kfp-pipeline-install-config.yaml
+
+patchesStrategicMerge:
+  - apiserver-deployment.yaml
+
 # Identifier for application manager to apply ownerReference.
 # The ownerReference ensures the resources get garbage collected
 # when application is deleted.


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #269 
related: #277 

**Description of your changes:**
Implement our own configmap for things that are unique to kfp-tekton. This includes configurable artifact credentials on the server side (since Tekton doesn't support it) and other flags/settings that we want to add later on.  This PR builds the foundation for the artifact refactoring where we will be moving all the SDK client side logic to the server side.

**Environment tested:**

* Python Version (use `python --version`): 3.7
* Tekton Version (use `tkn version`): 0.15
* Kubernetes Version (use `kubectl version`): 1.16
* OS (e.g. from `/etc/os-release`):
