### PR TITLE
fix(sdk): Fix volumes bug on wrong dict key

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -559,7 +559,7 @@ def _op_to_template(op: BaseOp, pipelinerun_output_artifacts={}, enable_artifact
 
     # volumes
     if processed_op.volumes:
-        template['spec']['volumes'] = template['spec'].get('volume', []) + [convert_k8s_obj_to_json(volume)
+        template['spec']['volumes'] = template['spec'].get('volumes', []) + [convert_k8s_obj_to_json(volume)
                                                                             for volume in processed_op.volumes]
         template['spec']['volumes'].sort(key=lambda x: x['name'])
 

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -158,6 +158,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.volume import volume_pipeline
     self._test_pipeline_workflow(volume_pipeline, 'volume.yaml')
 
+  def test_volume_workflow_with_logging(self):
+    """
+    Test compiling a volume workflow.
+    """
+    from .testdata.volume import volume_pipeline
+    self._test_pipeline_workflow(volume_pipeline, 'volume_logging.yaml', enable_s3_logs=True)
+
   def test_timeout_workflow(self):
     """
     Test compiling a step level timeout workflow.

--- a/sdk/python/tests/compiler/testdata/volume_logging.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_logging.yaml
@@ -1,0 +1,225 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with volume.",
+      "name": "Volume"}'
+    sidecar.istio.io/inject: 'false'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/input_artifacts: '{"echo": [{"name": "download-downloaded", "parent_task":
+      "download"}]}'
+    tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/downloaded.tgz",
+      "name": "download-downloaded", "path": "/tmp/results.txt"}, {"key": "artifacts/$PIPELINERUN/download/download.tgz",
+      "name": "download", "path": "logs_to_S3"}], "echo": [{"key": "artifacts/$PIPELINERUN/echo/echo.tgz",
+      "name": "echo", "path": "logs_to_S3"}]}'
+  name: volume
+spec:
+  pipelineSpec:
+    tasks:
+    - name: download
+      taskSpec:
+        results:
+        - description: /tmp/results.txt
+          name: downloaded
+        stepTemplate:
+          volumeMounts:
+          - mountPath: /var/log
+            name: varlog
+          - mountPath: /var/lib/docker/containers
+            name: varlibdockercontainers
+            readOnly: true
+          - mountPath: /var/lib/kubelet/pods
+            name: varlibkubeletpods
+            readOnly: true
+          - mountPath: /var/log/pods
+            name: varlogpods
+            readOnly: true
+        steps:
+        - args:
+          - ls | tee $(results.downloaded.path)
+          command:
+          - sh
+          - -c
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /secret/gcp-credentials/user-gcp-sa.json
+          - name: Foo
+            value: bar
+          image: google/cloud-sdk
+          name: main
+          volumeMounts:
+          - mountPath: /secret/gcp-credentials
+            name: gcp-credentials
+        - env:
+          - name: PIPELINERUN
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tekton.dev/pipelineRun']
+          - name: PIPELINETASK
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tekton.dev/pipelineTask']
+          - name: ARTIFACT_ENDPOINT_SCHEME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['tekton.dev/artifact_endpoint_scheme']
+          - name: ARTIFACT_ENDPOINT
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['tekton.dev/artifact_endpoint']
+          - name: ARTIFACT_BUCKET
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['tekton.dev/artifact_bucket']
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: accesskey
+                name: mlpipeline-minio-artifact
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: secretkey
+                name: mlpipeline-minio-artifact
+          - name: TASKRUN
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tekton.dev/taskRun']
+          image: minio/mc
+          name: copy-artifacts
+          script: '#!/usr/bin/env sh
+
+            mc config host add storage ${ARTIFACT_ENDPOINT_SCHEME}${ARTIFACT_ENDPOINT}
+            $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
+
+            tar -cvzf downloaded.tgz $(results.downloaded.path)
+
+            mc cp downloaded.tgz storage/$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/downloaded.tgz
+
+            cat /var/log/containers/$TASKRUN*$NAMESPACE*step-main*.log > step-main.log
+            && tar -czf $TASKRUN-$NAMESPACE-step-main_log.tgz step-main.log
+
+            mc cp $TASKRUN-$NAMESPACE-step-main_log.tgz storage/$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/
+
+            '
+        volumes:
+        - name: gcp-credentials
+          secret:
+            secretName: user-gcp-sa
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/kubelet/pods
+          name: varlibkubeletpods
+        - hostPath:
+            path: /var/log
+          name: varlog
+        - hostPath:
+            path: /var/log/pods
+          name: varlogpods
+    - name: echo
+      params:
+      - name: download-downloaded
+        value: $(tasks.download.results.downloaded)
+      taskSpec:
+        params:
+        - name: download-downloaded
+        stepTemplate:
+          volumeMounts:
+          - mountPath: /var/log
+            name: varlog
+          - mountPath: /var/lib/docker/containers
+            name: varlibdockercontainers
+            readOnly: true
+          - mountPath: /var/lib/kubelet/pods
+            name: varlibkubeletpods
+            readOnly: true
+          - mountPath: /var/log/pods
+            name: varlogpods
+            readOnly: true
+        steps:
+        - args:
+          - echo $(inputs.params.download-downloaded)
+          command:
+          - sh
+          - -c
+          image: library/bash
+          name: main
+        - env:
+          - name: PIPELINERUN
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tekton.dev/pipelineRun']
+          - name: PIPELINETASK
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tekton.dev/pipelineTask']
+          - name: ARTIFACT_ENDPOINT_SCHEME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['tekton.dev/artifact_endpoint_scheme']
+          - name: ARTIFACT_ENDPOINT
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['tekton.dev/artifact_endpoint']
+          - name: ARTIFACT_BUCKET
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['tekton.dev/artifact_bucket']
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: accesskey
+                name: mlpipeline-minio-artifact
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: secretkey
+                name: mlpipeline-minio-artifact
+          - name: TASKRUN
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tekton.dev/taskRun']
+          image: minio/mc
+          name: copy-artifacts
+          script: '#!/usr/bin/env sh
+
+            mc config host add storage ${ARTIFACT_ENDPOINT_SCHEME}${ARTIFACT_ENDPOINT}
+            $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
+
+            cat /var/log/containers/$TASKRUN*$NAMESPACE*step-main*.log > step-main.log
+            && tar -czf $TASKRUN-$NAMESPACE-step-main_log.tgz step-main.log
+
+            mc cp $TASKRUN-$NAMESPACE-step-main_log.tgz storage/$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/
+
+            '
+        volumes:
+        - hostPath:
+            path: /var/log
+          name: varlog
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/kubelet/pods
+          name: varlibkubeletpods
+        - hostPath:
+            path: /var/log/pods
+          name: varlogpods


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
There's a typo bug when both user and artifact volumes are present, the artifact volumes such as logging are ignored due to the typo on the dictionary key. Thus, update the key to the correct value and add a test case to cover it.

**Environment tested:**

* Python Version (use `python --version`): 3.7
* Tekton Version (use `tkn version`): 1.14
* Kubernetes Version (use `kubectl version`): 1.16
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
