### PR TITLE
Move pytest dependency into Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
       env: TOXENV=py35
       install: &0
         - python3 -m pip install -e sdk/python
-        - python3 -m pip install pytest
       script: &1
         - make unit_test
     - name: "Unit tests, Python 3.6"

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ unit_test: venv ## Run compiler unit tests
 	@echo "Optional environment variables to configure $@, examples:"
 	@sed -n -e 's/# *\(make $@ .*\)/  \1/p' sdk/python/tests/compiler/compiler_tests.py
 	@echo "=================================================================="
+	@pip show pytest > /dev/null 2>&1 || pip install pytest
 	@sdk/python/tests/run_tests.sh
 	@echo "$@: OK"
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Resolves #288

**Description of your changes:**

Move `pytest` dependency from `.travis.yml` to `Makefile`

**Environment tested:**

* Python Version (use `python --version`): `3.7.5`
* Tekton Version (use `tkn version`): n/a
* Kubernetes Version (use `kubectl version`): n/a
* OS (e.g. from `/etc/os-release`): Mac OS

/cc @Tomcli 