### PR TITLE
Make should use specified VENV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       install: &0
         - python3 -m pip install -e sdk/python
       script: &1
-        - make unit_test
+        - VENV=$VIRTUAL_ENV make unit_test
     - name: "Unit tests, Python 3.6"
       language: python
       python: "3.6"
@@ -39,12 +39,12 @@ matrix:
       python: "3.7"
       install: *0
       script:
-        - make report
+        - VENV=$VIRTUAL_ENV make report
     - name: "Lint Python code with flake8"
       language: python
       python: "3.7"
       script:
-        - make lint
+        - VENV=$VIRTUAL_ENV make lint
     - name: "Verify source files contain the license header"
       language: bash
       script:

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,12 @@ help: ## Display the Make targets
 .PHONY: venv
 venv: $(VENV)/bin/activate ## Create and activate virtual environment
 $(VENV)/bin/activate: sdk/python/setup.py
+# create/update the VENV when there was a change to setup.py
+# check if kfp-tekton is already installed (Travis/CI did during install step)
+# use pip from the specified VENV as opposed to any pip available in the shell
 	@echo "VENV=$(VENV)"
 	@test -d $(VENV) || python3 -m venv $(VENV)
-	pip install -e sdk/python
+	@$(VENV)/bin/pip show kfp-tekton >/dev/null 2>&1 || $(VENV)/bin/pip install -e sdk/python
 	@touch $(VENV)/bin/activate
 
 .PHONY: install

--- a/sdk/python/tests/compiler/compiler_tests_e2e.py
+++ b/sdk/python/tests/compiler/compiler_tests_e2e.py
@@ -30,7 +30,11 @@ from time import sleep
 #  load test settings from environment variables (passed through make)
 # =============================================================================
 
-# get the Kubernetes context from the KUBECONFIG env var
+# get the Kubernetes context from the KUBECONFIG env var, override KUBECONFIG
+# to target a different Kubernetes cluster
+#    KUBECONFIG=/path/to/kube/config sdk/python/tests/run_e2e_tests.sh
+# or:
+#    make e2e_test KUBECONFIG=/path/to/kube/config
 KUBECONFIG = env.get("KUBECONFIG")
 
 # set or override the minimum required Tekton Pipeline version, default "0.14.0":


### PR DESCRIPTION
**Description of your changes:**

Update `.travis.yml` and `Makefile` to avoid duplicate/redundant `pip install steps` by making sure that the `make` targets use the already existing Python `virtualenv` created by Travis, instead of creating a second `VENV` inside the `make` process. This should speed up Travis build times and reduce resource consumption slightly, but at the very least it makes for more readable build logs.

**Environment tested:**

* Python Version (use `python --version`): `3.5`, `3.6`, `3.7`
* Tekton Version (use `tkn version`): n/a
* Kubernetes Version (use `kubectl version`): n/a
* OS (e.g. from `/etc/os-release`): Mac OS Catalina, Linux Ubuntu 16.04.6 LTS

/cc @Tomcli 