### PR TITLE
Updating reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,8 +7,6 @@ reviewers:
  - animeshsingh
  - ckadner
  - Tomcli
- - afrittoli
- - jinchihe
  - fenglixa
  - drewbutlerbb4
- - kevinyu98
+


### PR DESCRIPTION
removing andrea, jinchi and kevin as reviewer

reviews should be directed to folks who are active to optimize.

