### PR TITLE
Address no logs achived to S3 with kubernets 1.6

### DIFF
--- a/samples/logging_s3/pipeline_log_to_s3_by_fluentd_recommend/fluent-config.yaml
+++ b/samples/logging_s3/pipeline_log_to_s3_by_fluentd_recommend/fluent-config.yaml
@@ -11,7 +11,7 @@ data:
       pos_file /var/log/fluentd-docker.pos
       time_format %Y-%m-%dT%H:%M:%S
       tag kubernetes.*
-      format json
+      format none
       read_from_head true
     </source>
 
@@ -61,3 +61,4 @@ data:
         chunk_limit_size 30m                        # The maximum size of each chunk
       </buffer>
     </match>
+    


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #276

**Description of your changes:**

**Reason:**

Log format is not json format in some k8s cluster, e.g. Kubernetes v1.16.2:

Server Version: version.Info{Major:"1", Minor:"16+", GitVersion:"v1.16.2", GitCommit:"a02f27a", GitTreeState:"clean", BuildDate:"2020-04-13T12:04:13Z", GoVersion:"go1.12.12", Compiler:"gc", Platform:"linux/amd64"}

```
cat /var/log/containers/parallel-pipeline-e2345-gcs-download-2-lgg4h-pod-vhsw2_tommy-chaoping-li_step-copy-artifacts-4eaa6e5ecad4770497b4e707b5bc6a1ef911aac2afc2ebc11ec1d16d24a850bc.log
2020-08-27T18:37:20.410919774Z stdout F Added `storage` successfully.
2020-08-27T18:37:20.419098255Z stdout F step-main.log
2020-08-27T18:37:20.477559075Z stdout F `main-log.tgz` -> `storage/mlpipeline/artifacts/parallel-pipeline-e2345/gcs-download-2/main-log.tgz`
2020-08-27T18:37:20.490472659Z stdout F Total: 0 B, Transferred: 234 B, Speed: 13.44 KiB/s
2020-08-27T18:37:20.493118281Z stdout F tekton/results/data
2020-08-27T18:37:20.493205246Z stderr F tar: removing leading '/' from member names
2020-08-27T18:37:20.540895951Z stdout F `data.tgz` -> `storage/mlpipeline/artifacts/parallel-pipeline-e2345/gcs-download-2/data.tgz`
2020-08-27T18:37:20.558809113Z stdout F Total: 0 B, Transferred: 205 B, Speed: 9.15 KiB/s
```

Log format is json format in kubernetes v1.18.6:

Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.6", GitCommit:"dff82dc0de47299ab66c83c626e08b245ab19037", GitTreeState:"clean", BuildDate:"2020-07-15T16:51:04Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}

```
cat /var/log/containers/parallel-pipeline-echo-l6wsr-pod-6ldlk_feng-test_step-main-5847929b6420760d104430bc3bde752d36495889b430a01bace9e182221261c9.log
{"log":"Text 1: With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate\n","stream":"stdout","time":"2020-08-08T04:52:23.659482371Z"}
{"log":"\n","stream":"stdout","time":"2020-08-08T04:52:23.659517904Z"}
{"log":"Text 2: I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath\n","stream":"stdout","time":"2020-08-08T04:52:23.659522652Z"}
{"log":"\n","stream":"stdout","time":"2020-08-08T04:52:23.659525984Z"}
```

**Fix solution:**
Update fluent configure file, change the format to none instead of json. To cover all of these cases.


After fixed, the logs files is in S3:

```
storage/mlpipeline/artifact/:
parallel-pipeline-378ff  parallel-pipeline-66e63  parallel-pipeline-6c103  parallel-pipeline-e2345

storage/mlpipeline/artifact/parallel-pipeline-378ff:
echo          gcs-download

storage/mlpipeline/artifact/parallel-pipeline-378ff/echo:
parallel-pipeline-378ff-echo-vjlgh-pod-f4b8s202008290632_0.gz

storage/mlpipeline/artifact/parallel-pipeline-378ff/gcs-download:
parallel-pipeline-378ff-gcs-download-xcxjc-pod-b4xsn202008290632_0.gz

storage/mlpipeline/artifact/parallel-pipeline-66e63:
gcs-download-2

storage/mlpipeline/artifact/parallel-pipeline-66e63/gcs-download-2:
parallel-pipeline-66e63-gcs-download-2-npk25-pod-lgs8r202008290632_0.gz

storage/mlpipeline/artifact/parallel-pipeline-6c103:
gcs-download

storage/mlpipeline/artifact/parallel-pipeline-6c103/gcs-download:
parallel-pipeline-6c103-gcs-download-4hbf5-pod-qm96k202008290632_0.gz

storage/mlpipeline/artifact/parallel-pipeline-e2345:
gcs-download-2

storage/mlpipeline/artifact/parallel-pipeline-e2345/gcs-download-2:
parallel-pipeline-e2345-gcs-download-2-lgg4h-pod-vhsw2202008290632_0.gz
```

