### PR TITLE
Remove persistentVolumeClaim by volumeClaimTemplate

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Set
 
 from kfp_tekton.compiler._k8s_helper import sanitize_k8s_name
 from kfp_tekton.compiler._op_to_template import _get_base_step, _add_mount_path, _prepend_steps
+from os import environ as env
 
 
 def fix_big_data_passing(workflow: dict) -> dict:
@@ -445,14 +446,16 @@ def big_data_passing_pipelinerun(name: str, pr: dict, pw: set):
         pr.get('spec', {}).setdefault('workspaces', [])
         # Change persistentVolumeClaim to volumeClaimTemplate which need Tekton version > 0.12
         # User could modify default size of storage in the yaml file mannually if necessary.
+        DEFAULT_ACCESSMODES = env.get('DEFAULT_ACCESSMODES', 'ReadWriteMany')
+        DEFAULT_STORAGE_SIZE = env.get('DEFAULT_STORAGE_SIZE', '2Gi')
         pr['spec']['workspaces'].append({
             "name": pipelinerun_name,
             "volumeClaimTemplate": {
                 "spec": {
-                    "accessModes": ["ReadWriteMany"],
+                    "accessModes": [DEFAULT_ACCESSMODES],
                     "resources": {
                         "requests": {
-                            "storage": "2Gi"
+                            "storage": DEFAULT_STORAGE_SIZE
                         }
                     }
                 }

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -411,5 +411,10 @@ spec:
     - name: file-passing-pipelines
   workspaces:
   - name: file-passing-pipelines
-    persistentVolumeClaim:
-      claimName: file-passing-pipelines
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteMany
+        resources:
+          requests:
+            storage: 2Gi


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #181

**Description of your changes:**
Remove persistentVolumeClaim by volumeClaimTemplate, since we already used the Tekton version > 0.12
**Environment tested:**
```
(.venv)  fengli@fenglis-MacBook-Pro  ~/go/src/github.com/kubeflow/kfp-tekton/sdk/python/tests   remove_pvc  kc get po |grep file
file-passing-pipelines-gen-params-mv8h8-pod-hqhnv         0/1     Completed   0          2d13h
file-passing-pipelines-print-params-25vkf-pod-zvpsm       0/1     Completed   0          2d13h
file-passing-pipelines-print-text-2-qsccx-pod-s5fkx       0/1     Completed   0          2d13h
file-passing-pipelines-print-text-3-xj69j-pod-mxvl8       0/1     Completed   0          2d13h
file-passing-pipelines-print-text-4-kfnr7-pod-9rfxq       0/1     Completed   0          2d13h
file-passing-pipelines-print-text-5-l9snc-pod-jtbhc       0/1     Completed   0          2d13h
file-passing-pipelines-print-text-dclrj-pod-w9lfj         0/1     Completed   0          2d13h
file-passing-pipelines-repeat-line-x45z5-pod-44lbv        0/1     Completed   0          2d13h
file-passing-pipelines-split-text-lines-crb4d-pod-hjdw7   0/2     Completed   0          2d13h
file-passing-pipelines-sum-numbers-fpdvm-pod-kq6r7        0/1     Completed   0          2d13h
file-passing-pipelines-write-numbers-6w9rb-pod-f8tx5      0/1     Completed   0          2d13h
(.venv)  fengli@fenglis-MacBook-Pro  ~/go/src/github.com/kubeflow/kfp-tekton/sdk/python/tests   remove_pvc  tkn pr describe file-passing-pipelines
Name:        file-passing-pipelines
Namespace:   feng-test
Timeout:     1h0m0s
Labels:
 tekton.dev/pipeline=file-passing-pipelines

🌡️  Status

STARTED      DURATION    STATUS
2 days ago   2 minutes   Succeeded

📦 Resources

 No resources

⚓ Params

 No params

🗂  Taskruns

 NAME                                              TASK NAME          STARTED      DURATION     STATUS
 ∙ file-passing-pipelines-print-text-5-l9snc       print-text-5       2 days ago   6 seconds    Succeeded
 ∙ file-passing-pipelines-print-text-3-xj69j       print-text-3       2 days ago   10 seconds   Succeeded
 ∙ file-passing-pipelines-print-text-2-qsccx       print-text-2       2 days ago   1 minute     Succeeded
 ∙ file-passing-pipelines-print-text-4-kfnr7       print-text-4       2 days ago   13 seconds   Succeeded
 ∙ file-passing-pipelines-sum-numbers-fpdvm        sum-numbers        2 days ago   15 seconds   Succeeded
 ∙ file-passing-pipelines-print-text-dclrj         print-text         2 days ago   1 minute     Succeeded
 ∙ file-passing-pipelines-print-params-25vkf       print-params       2 days ago   1 minute     Succeeded
 ∙ file-passing-pipelines-write-numbers-6w9rb      write-numbers      2 days ago   15 seconds   Succeeded
 ∙ file-passing-pipelines-gen-params-mv8h8         gen-params         2 days ago   11 seconds   Succeeded
 ∙ file-passing-pipelines-split-text-lines-crb4d   split-text-lines   2 days ago   22 seconds   Succeeded
 ∙ file-passing-pipelines-repeat-line-x45z5        repeat-line        2 days ago   14 seconds   Succeeded
```