### PR TITLE
Verify all Markdown links are valid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,13 @@ matrix:
       language: bash
       script:
         - make check_mdtoc
+    - name: "Verify Markdown files have valid links"
+      language: python
+      python: "3.7"
+      install:
+        - python3 -m pip install requests
+      script:
+        - make check_doc_links
 
 # =================================
 # TODO: merge with config from KFP

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,14 @@ check_mdtoc: ## Check Markdown files for valid the Table of Contents
 		done | grep . && echo "Run './tools/mdtoc.sh <md-file>' to update the 'Table of Contents' in the Markdown files reported above." && exit 1 || \
 		echo "$@: OK"
 
+.PHONY: check_doc_links
+check_doc_links: ## Check Markdown files for valid links
+	@pip3 show requests > /dev/null || pip install requests
+	@python3 tools/python/verify_doc_links.py
+	@echo "$@: OK"
+
 .PHONY: verify
-verify: check_license check_mdtoc lint unit_test report ## Run all verification targets: check_license, check_mdtoc, lint, unit_test, report
+verify: check_license check_mdtoc check_doc_links lint unit_test report ## Run all verification targets: check_license, check_mdtoc, lint, unit_test, report
 	@echo "$@: OK"
 
 .PHONY: distribution

--- a/guides/kfp_tekton_install.md
+++ b/guides/kfp_tekton_install.md
@@ -21,7 +21,7 @@ A Kubernetes cluster `v1.16` that has least 8 vCPU and 16 GB memory.
 
 ### IBM Cloud Kubernetes Service (IKS)
 
-   1. [Create an IBM Cloud cluster](https://www.kubeflow.org/docs/ibm/create-cluster/) or if you have an existing cluster, please follow the [initial setup for an existing cluster](https://www.kubeflow.org/docs/ibm/existing-cluster/)
+   1. [Create an IBM Cloud cluster](https://www.kubeflow.org/docs/ibm/create-cluster/) or if you have an existing cluster, please follow the [initial setup for an existing cluster](https://github.com/kubeflow/website/blob/master/content/en/docs/ibm/create-cluster.md#connecting-to-an-existing-cluster)
    2. **Important**: Configure the IKS cluster with [IBM Cloud Block Storage Setup](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow/#ibm-cloud-block-storage-setup)
 
 ### OpenShift

--- a/samples/kfp-tfx/tfx-taxi-on-prem/README.md
+++ b/samples/kfp-tfx/tfx-taxi-on-prem/README.md
@@ -1,6 +1,6 @@
 # TFX On-Prem Demo
 
-This Demo is based on the [TFX taxi oss example](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/parameterized_tfx_oss/parameterized_tfx_oss.py) and designed to run the TFX Chicago Taxi example on-prem without any GCS/GCP dependency.
+This Demo is based on the [TFX taxi oss example](https://github.com/kubeflow/pipelines/blob/master/samples/core/parameterized_tfx_oss/parameterized_tfx_oss.py) and designed to run the TFX Chicago Taxi example on-prem without any GCS/GCP dependency.
 
 ## Prerequisites
 1. Provision a Kubernetes or OpenShift cluster.

--- a/samples/logging_s3/pipeline_log_to_s3_by_banzaicloud/pipeline_logging_output_s3_banzaicloud.md
+++ b/samples/logging_s3/pipeline_log_to_s3_by_banzaicloud/pipeline_logging_output_s3_banzaicloud.md
@@ -179,7 +179,7 @@ The ClusterFlow above takes all logs from pods that have the app.kubernetes.io/m
 ## Submit a tekton pipelinerun for testing
 
 Running the PipelineRun should produce logs and you should see corresponding objects being added in minio as far as logs get collected and stored by the logs pipeline.
-e.g. [parallel_join.yaml](https://github.com/kubeflow/pipelines/blob/master/sdk/python/tests/compiler/testdata/parallel_join.yaml)
+e.g. [parallel_join.yaml](/sdk/python/tests/compiler/testdata/parallel_join.yaml)
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfp-tekton/master/sdk/python/tests/compiler/testdata/parallel_join.yaml

--- a/sdk/FEATURES.md
+++ b/sdk/FEATURES.md
@@ -41,7 +41,8 @@ Below are the features using Tekton's native support without any custom workarou
 
 `pod_annotations` and `pod_labels` are for assigning custom annotations or labels to a pipeline component. They are implemented with
 Tekton's [task metadata](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md#configuring-a-task) field under Tekton
-Task. The [pipeline transformers](/sdk/python/tests/compiler/testdata/pipeline_transfromers.py) example shows how to apply
+Task. The [pipeline transformers](/sdk/python/tests/compiler/testdata/pipeline_transformers.py) example shows how to
+ apply
 custom annotations and labels to one or more components in the pipeline.
 
 ### Retries

--- a/tools/python/verify_doc_links.py
+++ b/tools/python/verify_doc_links.py
@@ -46,6 +46,11 @@ url_status_cache = dict()
 
 def find_md_files() -> [str]:
 
+    print("Checking for Markdown files here:\n")
+    for path_expr in md_file_path_expressions:
+        print("  " + path_expr.lstrip("/"))
+    print("")
+
     md_files_list_of_lists = [glob(project_root_dir + path_expr, recursive=True)
                               for path_expr in md_file_path_expressions]
 
@@ -156,8 +161,11 @@ def verify_doc_links() -> [(str, int, str, str)]:
                               if s != 200]
 
     # 5. print some stats for confidence
-    print("\nChecked {} links ({} unique URLs) in {} Markdown files.\n".format(
-        len(file_line_text_url_status), len(url_status_cache), len(md_file_paths)))
+    print("{} {} links ({} unique URLs) in {} Markdown files.\n".format(
+        "Checked" if file_line_text_url_404 else "Verified",
+        len(file_line_text_url_status),
+        len(url_status_cache),
+        len(md_file_paths)))
 
     # 6. report invalid links, exit with error for CI/CD
     if file_line_text_url_404:

--- a/tools/python/verify_doc_links.py
+++ b/tools/python/verify_doc_links.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import concurrent.futures
+import itertools
+import re
+import requests
+
+from glob import glob
+from os import environ as env
+from os.path import abspath, basename, dirname, exists, join, relpath
+from random import randint
+from time import sleep
+
+
+GITHUB_REPO = env.get("GITHUB_REPO", "https://github.com/kubeflow/kfp-tekton/")
+
+md_file_path_expressions = [
+    "/guides/**/*.md",
+    "/samples/**/*.md",
+    "/sdk/**/*.md",
+    "/*.md"
+]
+
+script_folder = abspath(dirname(__file__))
+project_root_dir = abspath(dirname(dirname(script_folder)))
+github_repo_master_path = "{}/blob/master".format(GITHUB_REPO.rstrip("/"))
+
+parallel_requests = 60  # GitHub rate limiting is 60 requests per minute, then we sleep a bit
+
+url_status_cache = dict()
+
+
+def find_md_files() -> [str]:
+
+    md_files_list_of_lists = [glob(project_root_dir + path_expr, recursive=True)
+                              for path_expr in md_file_path_expressions]
+
+    return sorted(list(itertools.chain(*md_files_list_of_lists)))
+
+
+def get_links_from_md_file(md_file_path: str) -> [(int, str, str)]: # -> [(line, link_text, URL)]
+
+    with open(md_file_path, "r") as f:
+        md_file_content = f.read()
+
+    folder = relpath(dirname(md_file_path), project_root_dir)
+
+    # replace relative links that are siblings to the README, i.e. [link text](FEATURES.md)
+    md_file_content = re.sub(
+        r"\[([^]]+)\]\((?!http|#|/)([^)]+)\)",
+        r"[\1]({}/{}/\2)".format(github_repo_master_path, folder).replace("/./", "/"),
+        md_file_content)
+
+    # replace links that are relative to the project root, i.e. [link text](/sdk/FEATURES.md)
+    md_file_content = re.sub(
+        r"\[([^]]+)\]\(/([^)]+)\)",
+        r"[\1]({}/\2)".format(github_repo_master_path),
+        md_file_content)
+
+    # return completed links
+    line_text_url = []
+    for line_number, line_text in enumerate(md_file_content.splitlines()):
+        for (link_text, url) in re.findall(r"\[([^]]+)\]\((%s[^)]+)\)" % "http", line_text):
+            line_text_url.append((line_number + 1, link_text, url))
+
+    return line_text_url
+
+
+def test_url(file: str, line: int, text: str, url: str) -> (str, int, str, str, int):  # (file, line, text, url, status)
+
+    short_url = url.split("#", maxsplit=1)[0]
+
+    if short_url not in url_status_cache:
+
+        # mind GitHub rate limiting, use local files to verify link
+        if short_url.startswith(github_repo_master_path):
+            local_path = short_url.replace(github_repo_master_path, "")
+            if exists(abspath(project_root_dir + local_path)):
+                status = 200
+            else:
+                status = 404
+        else:
+            try:
+                status = requests.head(short_url, allow_redirects=True, timeout=5).status_code
+                if status == 405:  # method not allowed, use GET instead of HEAD
+                    status = requests.get(short_url, allow_redirects=True, timeout=5).status_code
+                if status == 429:  # GitHub rate limiting, try again after 1 minute
+                    sleep(randint(60, 90))
+                    status = requests.head(short_url, allow_redirects=True, timeout=5).status_code
+            except requests.exceptions.Timeout as e:
+                status = 408
+            except requests.exceptions.RequestException as e:
+                status = 500
+
+        url_status_cache[short_url] = status
+
+    status = url_status_cache[short_url]
+
+    return file, line, text, url, status
+
+
+def verify_urls_concurrently(file_line_text_url: [(str, int, str, str)]) -> [(str, int, str, str)]:
+    file_line_text_url_status = []
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallel_requests) as executor:
+        check_urls = (
+            executor.submit(test_url, file, line, text, url)
+            for (file, line, text, url) in file_line_text_url
+        )
+        for url_check in concurrent.futures.as_completed(check_urls):
+            try:
+                file, line, text, url, status = url_check.result()
+                file_line_text_url_status.append((file, line, text, url, status))
+            except Exception as e:
+                print(str(type(e)))
+                file_line_text_url_status.append((file, line, text, url, 500))
+            finally:
+                print("{}/{}".format(len(file_line_text_url_status),
+                                     len(file_line_text_url)), end="\r")
+
+    return file_line_text_url_status
+
+
+def verify_doc_links() -> [(str, int, str, str)]:
+
+    # 1. find all relevant Markdown files
+    md_file_paths = find_md_files()
+
+    # 2. extract all links with text and URL
+    file_line_text_url = [
+        (file, line, text, url)
+        for file in md_file_paths
+        for (line, text, url) in get_links_from_md_file(file)
+    ]
+
+    # 3. validate the URLs
+    file_line_text_url_status = verify_urls_concurrently(file_line_text_url)
+
+    # 4. filter for the invalid URLs (status 404: "Not Found") to be reported
+    file_line_text_url_404 = [(f, l, t, u, s)
+                              for (f, l, t, u, s) in file_line_text_url_status
+                              if s != 200]
+
+    # 5. print some stats for confidence
+    print("\nChecked {} links ({} unique URLs) in {} Markdown files.\n".format(
+        len(file_line_text_url_status), len(url_status_cache), len(md_file_paths)))
+
+    # 6. report invalid links, exit with error for CI/CD
+    if file_line_text_url_404:
+
+        for (file, line, text, url, status) in file_line_text_url_404:
+            print("{}:{}: `[{}]({})` {}".format(
+                relpath(file, project_root_dir), line, text,
+                url.replace(github_repo_master_path, ""), status))
+
+        # print a summary line for clear error discovery at the bottom of Travis job log
+        print("\nERROR: Found {} invalid Markdown links".format(
+            len(file_line_text_url_404)))
+
+        exit(1)
+
+
+if __name__ == '__main__':
+    verify_doc_links()


### PR DESCRIPTION
**Description of changes:**

* Add Python script `tools/python/`[`verify_doc_links.py`](https://github.com/kubeflow/kfp-tekton/blob/d4b1d06/tools/python/verify_doc_links.py) to verify links in Markdown files are valid
* Add [`check_doc_links`](https://github.com/kubeflow/kfp-tekton/blob/d4b1d06/Makefile#L104-L108) target to `Makefile`
* Add doc link check [job](https://github.com/kubeflow/kfp-tekton/blob/d4b1d06/.travis.yml#L56-L62) to **[Travis/CI](https://github.com/kubeflow/kfp-tekton/pull/363/checks?check_run_id=1392818301)**

**Script details:**
1. Find all Markdown files based on predefined path expressions:
   - `./guides/**/*.md`
   - `./samples/**/*.md`
   - `./sdk/**/*.md`
   - `./*.md`
2. Extract all Markdown links of form `[link text](url)`
3. Complete relative links with path to GitHub repo `https://github.com/kubeflow/kfp-tekton/blob/master`
4. Make asynchronous HEAD requests for each of the collected URLs
    `167/246`
5. Report any link that returns a 404, exit with error code `1`
   ```Bash
   Checked 246 links (177 unique URLs) in 27 Markdown files.

   sdk/FEATURES.md:44: `[pipeline transformers](/sdk/python/tests/compiler/testdata/pipeline_transfromers.py)` 404
   guides/kfp_tekton_install.md:24: `[initial setup for an existing cluster](https://www.kubeflow.org/docs/ibm/existing-cluster/)` 404
   samples/kfp-tfx/tfx-taxi-on-prem/README.md:3: `[TFX taxi oss example](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/parameterized_tfx_oss/parameterized_tfx_oss.py)` 404
   samples/logging_s3/pipeline_log_to_s3_by_banzaicloud/pipeline_logging_output_s3_banzaicloud.md:182: `[parallel_join.yaml](https://github.com/kubeflow/pipelines/blob/master/sdk/python/tests/compiler/testdata/parallel_join.yaml)` 404

   ERROR: Found 4 invalid Markdown links
   ```
**Related issues:**
- #361 Fix broken doc links