### PR TITLE
fix(ui and sdk): Support display name annotations

### DIFF
--- a/frontend/src/lib/ParserUtils.ts
+++ b/frontend/src/lib/ParserUtils.ts
@@ -1,13 +1,13 @@
-import { Metadata } from 'third_party/argo-ui/argo_template';
-
-export function parseTaskDisplayName(metadata?: Metadata): string | undefined {
-  if (!metadata?.annotations) {
+export function parseTaskDisplayName(taskSpec?: any): string | undefined {
+  const metadata = taskSpec['metadata'] || {};
+  const annotations = metadata['annotations'] || false;
+  if (!annotations) {
     return undefined;
   }
-  const taskDisplayName = metadata.annotations['pipelines.kubeflow.org/task_display_name'];
+  const taskDisplayName = annotations['pipelines.kubeflow.org/task_display_name'];
   let componentDisplayName: string | undefined;
   try {
-    componentDisplayName = JSON.parse(metadata.annotations['pipelines.kubeflow.org/component_spec'])
+    componentDisplayName = JSON.parse(annotations['pipelines.kubeflow.org/component_spec'])
       .name;
   } catch (err) {
     // Expected error: metadata is missing or malformed

--- a/frontend/src/lib/StaticGraphParser.ts
+++ b/frontend/src/lib/StaticGraphParser.ts
@@ -17,6 +17,7 @@
 import * as dagre from 'dagre';
 import { color } from '../Css';
 import { Constants } from './Constants';
+import { parseTaskDisplayName } from './ParserUtils';
 
 export type nodeType = 'container' | 'resource' | 'dag' | 'unknown';
 
@@ -160,7 +161,7 @@ function buildTektonDag(graph: dagre.graphlib.Graph, template: any): void {
       bgColor: bgColor,
       height: Constants.NODE_HEIGHT,
       info,
-      label: label,
+      label: parseTaskDisplayName(task['taskSpec']) || label,
       width: Constants.NODE_WIDTH,
     });
   }

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -25,6 +25,7 @@ import { statusToIcon } from '../pages/Status';
 import { Constants } from './Constants';
 import { KeyValue } from './StaticGraphParser';
 import { NodePhase, statusToBgColor, statusToPhase } from './StatusUtils';
+import { parseTaskDisplayName } from './ParserUtils';
 
 export enum StorageService {
   GCS = 'gcs',
@@ -137,7 +138,7 @@ export default class WorkflowParser {
         graph.setNode(taskId, {
           height: Constants.NODE_HEIGHT,
           icon: statusToIcon(status),
-          label: task['name'],
+          label: parseTaskDisplayName(task['taskSpec']) || task['name'],
           statusColoring: statusColoring,
           width: Constants.NODE_WIDTH,
         });

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -283,7 +283,7 @@ def _process_output_artifacts(outputs_dict: Dict[Text, Any],
     Returns:
         Dict[Text, Any]
     """
-    
+
     if outputs_dict.get('artifacts'):
         mounted_artifact_paths = []
         for artifact in outputs_dict['artifacts']:
@@ -336,6 +336,10 @@ def _op_to_template(op: BaseOp,
                     pipelinerun_output_artifacts={},
                     artifact_items={}):
     """Generate template given an operator inherited from BaseOp."""
+
+    # Display name
+    if op.display_name:
+        op.add_pod_annotation('pipelines.kubeflow.org/task_display_name', op.display_name)
 
     # initial local variables for tracking volumes and artifacts
     volume_mount_step_template = []
@@ -483,11 +487,6 @@ def _op_to_template(op: BaseOp,
         template['spec']['volumes'] = template['spec'].get('volumes', []) + [convert_k8s_obj_to_json(volume)
                                                                             for volume in processed_op.volumes]
         template['spec']['volumes'].sort(key=lambda x: x['name'])
-
-    # Display name
-    if processed_op.display_name:
-        template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/task_display_name'] = \
-            processed_op.display_name
 
     if isinstance(op, dsl.ContainerOp) and op._metadata:
         template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/component_spec'] = \

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -166,6 +166,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.timeout import timeout_sample_pipeline
     self._test_pipeline_workflow(timeout_sample_pipeline, 'timeout.yaml')
 
+  def test_display_name_workflow(self):
+    """
+    Test compiling a step level timeout workflow.
+    """
+    from .testdata.set_display_name import echo_pipeline
+    self._test_pipeline_workflow(echo_pipeline, 'set_display_name.yaml')
+
   def test_resourceOp_workflow(self):
     """
     Test compiling a resourceOp basic workflow.

--- a/sdk/python/tests/compiler/testdata/set_display_name.py
+++ b/sdk/python/tests/compiler/testdata/set_display_name.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from kfp import dsl
+
+
 def echo_op():
     return dsl.ContainerOp(
         name='echo',
@@ -20,6 +22,7 @@ def echo_op():
         command=['sh', '-c'],
         arguments=['echo "Got scheduled"']
     )
+
 
 @dsl.pipeline(
     name='echo',

--- a/sdk/python/tests/compiler/testdata/set_display_name.py
+++ b/sdk/python/tests/compiler/testdata/set_display_name.py
@@ -1,0 +1,35 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import dsl
+def echo_op():
+    return dsl.ContainerOp(
+        name='echo',
+        image='busybox',
+        command=['sh', '-c'],
+        arguments=['echo "Got scheduled"']
+    )
+
+@dsl.pipeline(
+    name='echo',
+    description='echo pipeline'
+)
+def echo_pipeline(
+):
+    echo = echo_op().set_display_name('Hello World')
+
+
+if __name__ == '__main__':
+    from kfp_tekton.compiler import TektonCompiler
+    TektonCompiler().compile(echo_pipeline, 'echo_pipeline.yaml')

--- a/sdk/python/tests/compiler/testdata/set_display_name.yaml
+++ b/sdk/python/tests/compiler/testdata/set_display_name.yaml
@@ -1,0 +1,46 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "echo pipeline", "name":
+      "echo"}'
+    sidecar.istio.io/inject: 'false'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"echo": []}'
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/output_artifacts: '{}'
+  name: echo
+spec:
+  pipelineSpec:
+    tasks:
+    - name: echo
+      taskSpec:
+        metadata:
+          annotations:
+            pipelines.kubeflow.org/task_display_name: Hello World
+        steps:
+        - args:
+          - echo "Got scheduled"
+          command:
+          - sh
+          - -c
+          image: busybox
+          name: main
+      timeout: 0s
+  timeout: 0s


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #368 

**Description of your changes:**
The set_display_name creates an annotation for the ui to detect and replace the node name without changing any runtime dependency. This wasn't implemented previously because task wise metadata is introduced at Tekton 0.16.3. 

**Environment tested:**

* Python Version (use `python --version`): 3.7
* Tekton Version (use `tkn version`): 0.16.3
* Kubernetes Version (use `kubectl version`): 1.18
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
