### PR TITLE
fix(sdk): dump "y" and "n" in enforced string mode

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -30,7 +30,6 @@ from distutils.util import strtobool
 from kfp import dsl
 from kfp.compiler._default_transformers import add_pod_env  # , add_pod_labels, get_default_telemetry_labels
 from kfp.compiler.compiler import Compiler
-# from kfp.components._yaml_utils import dump_yaml
 from kfp.components.structures import InputSpec
 from kfp.dsl._for_loop import LoopArguments, LoopArgumentVariable
 from kfp.dsl._metadata import _extract_pipeline_metadata
@@ -40,6 +39,7 @@ from kfp_tekton.compiler import __tekton_api_version__ as tekton_api_version
 from kfp_tekton.compiler._data_passing_rewriter import fix_big_data_passing
 from kfp_tekton.compiler._k8s_helper import convert_k8s_obj_to_json, sanitize_k8s_name, sanitize_k8s_object
 from kfp_tekton.compiler._op_to_template import _op_to_template
+from kfp_tekton.compiler.yaml_utils import dump_yaml
 
 
 DEFAULT_ARTIFACT_BUCKET = env.get('DEFAULT_ARTIFACT_BUCKET', 'mlpipeline')
@@ -728,9 +728,7 @@ class TektonCompiler(Compiler):
       package_path: file path to be written. If not specified, a yaml_text string
         will be returned.
     """
-    # yaml_text = dump_yaml(workflow)
-    yaml.Dumper.ignore_aliases = lambda *args: True
-    yaml_text = yaml.dump(workflow, default_flow_style=False)  # Tekton change
+    yaml_text = dump_yaml(workflow)
 
     # Use regex to replace all the Argo variables to Tekton variables. For variables that are unique to Argo,
     # we raise an Error to alert users about the unsupported variables. Here is the list of Argo variables.

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -15,7 +15,6 @@
 import inspect
 import json
 import tarfile
-import yaml
 import copy
 import itertools
 import zipfile

--- a/sdk/python/kfp_tekton/compiler/yaml_utils.py
+++ b/sdk/python/kfp_tekton/compiler/yaml_utils.py
@@ -1,0 +1,47 @@
+from typing import Any, Union, Optional, TextIO, overload, OrderedDict
+import yaml
+
+__all__ = [
+    "dump_yaml"
+]
+
+
+class _Dumper(yaml.SafeDumper):
+    def ignore_aliases(self, *args, **kwargs):
+        return True
+
+def _dict_representer(dumper, data):
+    return dumper.represent_mapping(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        data.items()
+    )
+
+_Dumper.add_representer(OrderedDict, _dict_representer)
+_Dumper.add_representer(dict, _dict_representer)
+
+# Hack to force the code (multi-line string) to be output using the '|' style.
+def represent_str_or_text(self, data):
+    style = None
+    if data.find('\n') >= 0:  # Multiple lines
+        style = '|'
+    # Fix for bool-like strings
+    if data.lower() in ['y', 'n', 'yes', 'no', 'true', 'false', 'on', 'off']:
+        style = '"'
+    return self.represent_scalar(u'tag:yaml.org,2002:str', data, style)
+
+_Dumper.add_representer(str, represent_str_or_text)
+
+
+@overload
+def dump_yaml(data: Any) -> Union[str, bytes]: ...
+@overload
+def dump_yaml(data: Any, stream: None) -> Union[str, bytes]: ...
+@overload
+def dump_yaml(data: Any, stream: TextIO) -> type(None): ...
+
+def dump_yaml(data: Any, stream: Optional[TextIO] = None, **kwargs) -> Optional[Union[str, bytes]]:
+    # PyYAML doesn't handle bool-like strings properly, so it needs to be fixed.
+    #See https://github.com/yaml/pyyaml/issues/247
+
+    return yaml.dump(data, stream, _Dumper, default_flow_style=None, **kwargs)
+

--- a/sdk/python/kfp_tekton/compiler/yaml_utils.py
+++ b/sdk/python/kfp_tekton/compiler/yaml_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2019-2020 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import OrderedDict
 from typing import Any, Union, Optional, TextIO, overload
 import yaml

--- a/sdk/python/kfp_tekton/compiler/yaml_utils.py
+++ b/sdk/python/kfp_tekton/compiler/yaml_utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Union, Optional, TextIO, overload, OrderedDict
+from collections import OrderedDict
+from typing import Any, Union, Optional, TextIO, overload
 import yaml
 
 __all__ = [

--- a/sdk/python/kfp_tekton/compiler/yaml_utils.py
+++ b/sdk/python/kfp_tekton/compiler/yaml_utils.py
@@ -11,14 +11,17 @@ class _Dumper(yaml.SafeDumper):
     def ignore_aliases(self, *args, **kwargs):
         return True
 
+
 def _dict_representer(dumper, data):
     return dumper.represent_mapping(
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
         data.items()
     )
 
+
 _Dumper.add_representer(OrderedDict, _dict_representer)
 _Dumper.add_representer(dict, _dict_representer)
+
 
 # Hack to force the code (multi-line string) to be output using the '|' style.
 def represent_str_or_text(self, data):
@@ -30,6 +33,7 @@ def represent_str_or_text(self, data):
         style = '"'
     return self.represent_scalar(u'tag:yaml.org,2002:str', data, style)
 
+
 _Dumper.add_representer(str, represent_str_or_text)
 
 
@@ -40,9 +44,10 @@ def dump_yaml(data: Any, stream: None) -> Union[str, bytes]: ...
 @overload
 def dump_yaml(data: Any, stream: TextIO) -> type(None): ...
 
+
 def dump_yaml(data: Any, stream: Optional[TextIO] = None, **kwargs) -> Optional[Union[str, bytes]]:
     # PyYAML doesn't handle bool-like strings properly, so it needs to be fixed.
-    #See https://github.com/yaml/pyyaml/issues/247
+    # See https://github.com/yaml/pyyaml/issues/247
 
     return yaml.dump(data, stream, _Dumper, default_flow_style=None, **kwargs)
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #389.

**Description of your changes:**
When dumping strings such as `y`, `n`, `Y`, `N` etc, explicit `"` should be added around them.

**Environment tested:**

* Python Version: 3.9.0
* SDK Version: 0.4.0

Seems like it can be cherry-picked.