### PR TITLE
Move kubernetes from SDK requirements to test requirements

### DIFF
--- a/sdk/python/requirements-test.txt
+++ b/sdk/python/requirements-test.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 mock==3.0.5
+kubernetes==11.0.0

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -1,2 +1,1 @@
-kubernetes==11.0.0
 kfp==1.3.0

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -52,9 +52,7 @@ kfp-server-api==1.2.0
 kfp==1.3.0
     # via -r sdk/python/requirements.in
 kubernetes==11.0.0
-    # via
-    #   -r sdk/python/requirements.in
-    #   kfp
+    # via kfp
 oauthlib==3.1.0
     # via requests-oauthlib
 protobuf==3.12.2

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -52,8 +52,7 @@ development stage. Contributions are welcome: {}
 """.format(HOMEPAGE)
 
 REQUIRES = [
-    'kfp==1.3.0',
-    'kubernetes==11.0.0'
+    'kfp==1.3.0'
 ]
 
 logging.basicConfig()


### PR DESCRIPTION
**Description of your changes:**

Move `kubernetes` from SDK requirements to test requirements. This became apparent during [conda-forge build](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=270749&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=619). 

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

/cc @Tomcli 