### PR TITLE
Remove python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,24 +14,24 @@
 
 matrix:
   include:
-    - name: "Unit tests, Python 3.5"
-      language: python
-      python: "3.5"
-      env: TOXENV=py35
-      install: &0
-        - python3 -m pip install -e sdk/python
-      script: &1
-        - VENV=$VIRTUAL_ENV make unit_test
     - name: "Unit tests, Python 3.6"
       language: python
       python: "3.6"
       env: TOXENV=py36
-      install: *0
-      script: *1
+      install: &0
+        - python3 -m pip install -e sdk/python
+      script: &1
+        - VENV=$VIRTUAL_ENV make unit_test
     - name: "Unit tests, Python 3.7"
       language: python
       python: "3.7"
       env: TOXENV=py37
+      install: *0
+      script: *1
+    - name: "Unit tests, Python 3.8"
+      language: python
+      python: "3.8"
+      env: TOXENV=py38
       install: *0
       script: *1
     - name: "Progress report on compiling KFP DSL test scripts"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -56,7 +56,7 @@ adding the `TektonCompiler` and the `TektonClient`:
 
 ## Project Prerequisites
 
- - Python: `3.5.3` or later
+ - Python: `3.6` or later
  - Tekton: [`v0.16.3`](https://github.com/tektoncd/pipeline/releases/tag/v0.16.3) or [later](https://github.com/tektoncd/pipeline/releases/latest)
  - Tekton CLI: [`0.11.0`](https://github.com/tektoncd/cli/releases/tag/v0.11.0)
  - Kubeflow Pipelines: [KFP with Tekton backend](/guides/kfp_tekton_install.md)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -33,7 +33,7 @@ can be found in the [SDK README](/sdk/README.md)
 
 ## Development Prerequisites
 
-1. [`Python`](https://www.python.org/downloads/): version `3.5.3` or later (new code must maintain compatibility with `3.5`)
+1. [`Python`](https://www.python.org/downloads/): version `3.6` or later (new code must maintain compatibility with `3.6`)
 2. [`Kubernetes` Cluster](https://kubernetes.io/): version `1.18` ([required by Kubeflow](https://www.kubeflow.org/docs/started/k8s/overview/) and Tekton `0.20`)
 3. [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/): required to deploy Tekton pipelines to Kubernetes cluster
 4. [`Tekton` Deployment](https://github.com/tektoncd/pipeline/releases/tag/v0.16.3/): version `0.16.3` or greater, required for end-to-end testing


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Related https://github.com/kubeflow/pipelines/issues/4584

**Description of your changes:**
Remove python 3.5 support since it's no longer supported in kfp. Move travis test to python 3.8 instead.

**Environment tested:**

* Python Version (use `python --version`): 
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
