### PR TITLE
Fix parallel_join_with_argo_vars pipeline (#470)

### DIFF
--- a/guides/kfp_tekton_install.md
+++ b/guides/kfp_tekton_install.md
@@ -17,7 +17,7 @@ A Kubernetes cluster `v1.18` that has least 8 vCPU and 16 GB memory.
 ### IBM Cloud Kubernetes Service (IKS)
 
    1. [Create an IBM Cloud cluster](https://www.kubeflow.org/docs/ibm/create-cluster/) or if you have an existing cluster, please follow the [initial setup for an existing cluster](https://github.com/kubeflow/website/blob/master/content/en/docs/ibm/create-cluster.md#connecting-to-an-existing-cluster)
-   2. **Important**: Configure the IKS cluster with [IBM Cloud Block Storage Setup](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow/#ibm-cloud-block-storage-setup)
+   2. **Important**: Configure the IKS cluster with [IBM Cloud Block Storage Setup](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow-on-iks/#ibm-cloud-block-storage-setup)
 
 ### OpenShift
 
@@ -60,7 +60,7 @@ To install the standalone Kubeflow Pipelines with Tekton, run the following step
 
 **Important: Please complete the [prerequisites](#installation-targets-and-prerequisites) before proceeding with the following instructions.**
 
-1. Follow the [Kubeflow install instructions](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow/#kubeflow-installation)
+1. Follow the [Kubeflow install instructions](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow-on-iks/#kubeflow-installation)
    to install the entire Kubeflow stack with `kfp-tekton`.
    Kubeflow `1.2.0` uses Tekton `v0.14.0` and `kfp-tekton` `v0.4.0`. <!-- TODO update-->
 
@@ -79,7 +79,7 @@ To install the standalone Kubeflow Pipelines with Tekton, run the following step
     kubectl rollout restart -n istio-system statefulset/authservice
     ```
 
-    Then, redo the [Kubeflow install](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow/#kubeflow-installation) section to redeploy Kubeflow with the [block storageclass](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow/#ibm-cloud-block-storage-setup).
+    Then, redo the [Kubeflow install](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow-on-iks/#kubeflow-installation) section to redeploy Kubeflow with the [block storageclass](https://www.kubeflow.org/docs/ibm/deploy/install-kubeflow-on-iks/#ibm-cloud-block-storage-setup).
 
 - If you redeploy Kubeflow and some components are not showing up, it was due to the [dynamic created webhook issue](https://github.com/kubeflow/manifests/issues/1379). This issue will be [fixed](https://github.com/kubeflow/pipelines/pull/4429) in the next release of KFP.
     ```shell

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.log
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.log
@@ -3,9 +3,12 @@
 [gcs-download-2 : main] I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath
 
 [echo : main] Text 1: With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate
-[echo : main] 
+[echo : main]
 [echo : main] Text 2: I find thou art no less than fame hath bruited And more than may be gatherd by thy shape Let my presumption not provoke thy wrath
-[echo : main] 
+[echo : main]
 [echo : main] With which he yoketh your rebellious necks Razeth your cities and subverts your towns And in a moment makes them desolate
-[echo : main] 
+[echo : main]
+[echo : main] parallel-pipeline-with-argo-vars
+[echo : main] kubeflow
+[echo : main] 7af44c31-799f-4651-b476-746fbe6bd095
 

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.py
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.py
@@ -1,4 +1,4 @@
-# Copyright 2020 kubeflow.org
+# Copyright 2020-2021 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ def echo2_op(text1, text2):
         image='library/bash:4.4.23',
         command=['sh', '-c'],
         arguments=['echo "Text 1: $0"; echo "Text 2: $1"; echo "{{inputs.parameters.gcs-download-data}}";\
-            echo "{{workflow.name}}; echo "{{workflow.namespace}}"; echo "{{workflow.uid}}"', text1, text2]
+            echo "{{workflow.name}}"; echo "{{workflow.namespace}}"; echo "{{workflow.uid}}"', text1, text2]
     )
 
 

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 kubeflow.org
+# Copyright 2020-2021 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -111,8 +111,8 @@ spec:
         steps:
         - args:
           - 'echo "Text 1: $0"; echo "Text 2: $1"; echo "$(inputs.params.gcs-download-data)";            echo
-            "$(params.pipelineRun-name); echo "$(params.pipelineRun-namespace)"; echo
-            "$(params.pipelineRun-uid)"'
+            "$(params.pipelineRun-name)"; echo "$(params.pipelineRun-namespace)";
+            echo "$(params.pipelineRun-uid)"'
           - $(inputs.params.gcs-download-data)
           - $(inputs.params.gcs-download-2-data)
           command:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 

Resolves #470

**Description of your changes:**

Added the missing quote character to terminate the workflow.name variable string. Regenerated the corresponding YAML and log file.

**Environment tested:**

* Python Version (use `python --version`): `3.9`
* Tekton Version (use `tkn version`): `0.20`
* Kubernetes Version (use `kubectl version`): `1.18`
