### PR TITLE
fix(sdk): fix artifacts of ops with long names

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -289,8 +289,9 @@ def _process_output_artifacts(outputs_dict: Dict[Text, Any],
     if outputs_dict.get('artifacts'):
         mounted_artifact_paths = []
         for artifact in outputs_dict['artifacts']:
-            artifact_name = artifact_to_result_mapping.get(artifact['name'], artifact['name'])
-            if artifact['name'] in replaced_param_list:
+            parameter_name = sanitize_k8s_name(artifact['name'], allow_capital_underscore=True)
+            artifact_name = artifact_to_result_mapping.get(parameter_name, parameter_name)
+            if parameter_name in replaced_param_list:
                 artifact_items.append([artifact_name, "$(results.%s.path)" % sanitize_k8s_name(artifact_name)])
             else:
                 artifact_items.append([artifact_name, artifact['path']])
@@ -298,9 +299,9 @@ def _process_output_artifacts(outputs_dict: Dict[Text, Any],
                     if artifact['path'].rsplit("/", 1)[0] == "":
                         raise ValueError('Undefined volume path or "/" path artifacts are not allowed.')
                     volume_mount_step_template.append({
-                        'name': sanitize_k8s_name(artifact['name']), 'mountPath': artifact['path'].rsplit("/", 1)[0]
+                        'name': parameter_name, 'mountPath': artifact['path'].rsplit("/", 1)[0]
                     })
-                    volume_template.append({'name': sanitize_k8s_name(artifact['name']), 'emptyDir': {}})
+                    volume_template.append({'name': parameter_name, 'emptyDir': {}})
                     mounted_artifact_paths.append(artifact['path'].rsplit("/", 1)[0])
 
 

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -256,7 +256,7 @@ def _process_parameters(processed_op: BaseOp,
                 if mount_path not in mounted_param_paths:
                     _add_mount_path(name, path, mount_path, volume_mount_step_template, volume_template, mounted_param_paths)
             # Record what artifacts are moved to result parameters.
-            parameter_name = sanitize_k8s_name(processed_op.name + '-' + name, allow_capital_underscore=True)
+            parameter_name = sanitize_k8s_name(processed_op.name + '-' + name, allow_capital_underscore=True, max_length=float('Inf'))
             replaced_param_list.append(parameter_name)
             artifact_to_result_mapping[parameter_name] = name
         return copy_results_step
@@ -289,7 +289,7 @@ def _process_output_artifacts(outputs_dict: Dict[Text, Any],
     if outputs_dict.get('artifacts'):
         mounted_artifact_paths = []
         for artifact in outputs_dict['artifacts']:
-            parameter_name = sanitize_k8s_name(artifact['name'], allow_capital_underscore=True)
+            parameter_name = sanitize_k8s_name(artifact['name'], allow_capital_underscore=True, max_length=float('Inf'))
             artifact_name = artifact_to_result_mapping.get(parameter_name, parameter_name)
             if parameter_name in replaced_param_list:
                 artifact_items.append([artifact_name, "$(results.%s.path)" % sanitize_k8s_name(artifact_name)])

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -295,14 +295,15 @@ def _process_output_artifacts(outputs_dict: Dict[Text, Any],
                 artifact_items.append([artifact_name, "$(results.%s.path)" % sanitize_k8s_name(artifact_name)])
             else:
                 artifact_items.append([artifact_name, artifact['path']])
-                if artifact['path'].rsplit("/", 1)[0] not in mounted_artifact_paths:
-                    if artifact['path'].rsplit("/", 1)[0] == "":
+                mount_path = artifact['path'].rsplit("/", 1)[0]
+                if mount_path not in mounted_artifact_paths:
+                    if mount_path == "":
                         raise ValueError('Undefined volume path or "/" path artifacts are not allowed.')
                     volume_mount_step_template.append({
-                        'name': parameter_name, 'mountPath': artifact['path'].rsplit("/", 1)[0]
+                        'name': parameter_name, 'mountPath': mount_path
                     })
                     volume_template.append({'name': parameter_name, 'emptyDir': {}})
-                    mounted_artifact_paths.append(artifact['path'].rsplit("/", 1)[0])
+                    mounted_artifact_paths.append(mount_path)
 
 
 def _process_base_ops(op: BaseOp):

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -548,5 +548,9 @@ class TestTektonCompiler(unittest.TestCase):
           obj = yaml.safe_load(f)
         text = yaml.safe_dump(obj)
         self.assertNotRegex(text, "stepTemplate")
+        artifact_items = obj['metadata']['annotations']['tekton.dev/artifact_items']
+        items_for_op0 = list(json.loads(artifact_items).values())[0]
+        names_of_items_for_op0 = set([item[0] for item in items_for_op0])
+        self.assertSetEqual(names_of_items_for_op0, {"incr_i", "sq_i"})
     finally:
       shutil.rmtree(temp_dir)

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -533,3 +533,20 @@ class TestTektonCompiler(unittest.TestCase):
                        msg="\n===[ " + golden_yaml_file.split(os.path.sep)[-1] + " ]===\n"
                            + json.dumps(compiled_workflow, indent=2))
 
+  def test_artifacts_of_ops_with_long_names(self):
+    """
+    Test compiling a pipeline with artifacts of ops with long names.
+
+    No step-templates should be generated for either case.
+    """
+    from .testdata import artifacts_of_ops_with_long_names as py_module
+    temp_dir = tempfile.mkdtemp()
+    try:
+      temp_files = py_module.main(temp_dir)
+      for temp_file in temp_files:
+        with open(temp_file, 'r') as f:
+          obj = yaml.safe_load(f)
+        text = yaml.safe_dump(obj)
+        self.assertNotRegex(text, "stepTemplate")
+    finally:
+      shutil.rmtree(temp_dir)

--- a/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
+++ b/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
@@ -1,3 +1,17 @@
+# Copyright 2021 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from random import choice
 from string import ascii_lowercase

--- a/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
+++ b/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
@@ -61,7 +61,9 @@ def pipeline_for_len(op_name_length: int, op_name_base: str = ''):
     op(i)
   return main_pipeline
 
+
 lengths = [20, 55, 80]
+
 
 def main(fdir: Optional[str] = None) -> List[str]:
   fpaths: List[str] = list()
@@ -80,6 +82,7 @@ def main(fdir: Optional[str] = None) -> List[str]:
     fpaths.append(fpath)
 
   return fpaths
+
 
 if __name__ == '__main__':
   main()

--- a/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
+++ b/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
@@ -20,6 +20,7 @@ from typing import Optional, List
 from kfp import dsl
 from kfp.components import load_component_from_text
 
+
 def random_chars_of_len(length: int) -> str:
   return ''.join(
     (choice(ascii_lowercase) for i in range(length))

--- a/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
+++ b/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
@@ -1,0 +1,70 @@
+import os
+from random import choice
+from string import ascii_lowercase
+from typing import Optional, List
+
+from kfp import dsl
+from kfp.components import load_component_from_text
+
+def random_chars_of_len(length: int) -> str:
+  return ''.join(
+    (choice(ascii_lowercase) for i in range(length))
+  )
+
+
+def pipeline_for_len(op_name_length: int, op_name_base: str = ''):
+  len_to_add = 0
+  if len(op_name_base) < op_name_length:
+    len_to_add = op_name_length - len(op_name_base)
+  op_name_base += random_chars_of_len(len_to_add)
+
+  op_name = op_name_base[:op_name_length]
+
+  component_spec = f"""
+    name: {op_name}
+    inputs:
+    - name: i
+      type: Integer
+    outputs:
+    - name: incr_i
+      type: Integer
+    - name: sq_i
+      type: Integer
+    implementation:
+      container:
+        image: sth
+        command:
+        - whatever
+        - outputPath: sq_i
+        - outputPath: incr_i
+  """
+
+  op = load_component_from_text(component_spec)
+
+  @dsl.pipeline("main-pipeline")
+  def main_pipeline(i: int):
+    op(i)
+  return main_pipeline
+
+lengths = [20, 55, 80]
+
+def main(fdir: Optional[str] = None) -> List[str]:
+  fpaths: List[str] = list()
+
+  from kfp_tekton.compiler import TektonCompiler as Compiler
+  max_length = max(lengths)
+  op_name_base = random_chars_of_len(max_length)
+
+  for length in lengths:
+    main_pipeline = pipeline_for_len(length, op_name_base)
+    fpath = __file__.replace('.py', f'-{length}.yaml')
+    fname = os.path.basename(fpath)
+    if fdir is not None:
+      fpath = os.path.join(fdir, fname)
+    Compiler().compile(main_pipeline, fpath)
+    fpaths.append(fpath)
+
+  return fpaths
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #540

**Description of your changes:**
1. Add a test to check if the issue is fixed.
2. Sanitise artefact name before searching for it in the artefact name mapping (where it's sanitised already).
3. Remove limit on the length of sanitised artefact name.

**Environment tested:**

* Python Version (use `python --version`): 3.9
* Tekton Version (use `tkn version`): irrelevant
* Kubernetes Version (use `kubectl version`): irrelevant
* OS (e.g. from `/etc/os-release`): irrelevant

________

Please add `cherrypick-approved` label.