### PR TITLE
Support Tekton PipelineRunStopping status

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -605,8 +605,8 @@ func (s *RunStore) TerminateRun(runId string) error {
 	result, err := s.db.Exec(`
 		UPDATE run_details
 		SET Conditions = ?
-		WHERE UUID = ? AND (Conditions = ? OR Conditions = ? OR Conditions = ?)`,
-		model.RunTerminatingConditions, runId, string("Running"), string("Pending"), "")
+		WHERE UUID = ? AND (Conditions = ? OR Conditions = ? OR Conditions = ? OR Conditions = ?)`,
+		model.RunTerminatingConditions, runId, string("Running"), string("Pending"), "", string("PipelineRunStopping"))
 
 	if err != nil {
 		return util.NewInternalServerError(err,

--- a/frontend/src/lib/StatusUtils.ts
+++ b/frontend/src/lib/StatusUtils.ts
@@ -42,6 +42,7 @@ export enum NodePhase {
   CONDITIONCHECKFAILED = 'ConditionCheckFailed',
   PIPELINERUNCANCELLED = 'PipelineRunCancelled',
   PIPELINERUNCOULDNTCANCEL = 'PipelineRunCouldntCancel',
+  PIPELINERUNSTOPPING = 'PipelineRunStopping',
   TASKRUNCANCELLED = 'TaskRunCancelled',
   TASKRUNCOULDNTCANCEL = 'TaskRunCouldntCancel',
   TERMINATED = 'Terminated',
@@ -131,6 +132,7 @@ export function statusToPhase(nodeStatus: string | undefined): NodePhase {
   else if (nodeStatus === 'Completed') return 'Succeeded' as NodePhase;
   else if (nodeStatus === 'ConditionCheckFailed') return 'Skipped' as NodePhase;
   else if (nodeStatus === 'CouldntGetCondition') return 'Error' as NodePhase;
+  else if (nodeStatus === 'PipelineRunStopping') return 'Running' as NodePhase;
   else if (
     nodeStatus === 'PipelineRunCancelled' ||
     nodeStatus === 'PipelineRunCouldntCancel' ||


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
Tekton introduced a new status "PipelineRunStopping" when the pipeline is still running with one or more tasks failed. This behavior used to be part of the "Running" status. Therefore, we need to update the UI and the API to treat this status as a "Running" pipeline. (e.g. terminable) 

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`): 0.23.0
* Kubernetes Version (use `kubectl version`): 1.18
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
