### PR TITLE
Fix long param compile errors

### DIFF
--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -169,6 +169,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.tekton_custom_task import custom_task_pipeline
     self._test_pipeline_workflow(custom_task_pipeline, 'tekton_custom_task.yaml')
 
+  def test_long_param_name_workflow(self):
+    """
+    Test long parameter name workflow.
+    """
+    from .testdata.long_param_name import main_fn
+    self._test_pipeline_workflow(main_fn, 'long_param_name.yaml')
+
   def test_long_pipeline_name_workflow(self):
     """
     Test long pipeline name workflow.

--- a/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
+++ b/sdk/python/tests/compiler/testdata/artifacts_of_ops_with_long_names.py
@@ -16,6 +16,7 @@ import os
 from random import choice
 from string import ascii_lowercase
 from typing import Optional, List
+import pytest
 
 from kfp import dsl
 from kfp.components import load_component_from_text
@@ -78,8 +79,13 @@ def main(fdir: Optional[str] = None) -> List[str]:
     fname = os.path.basename(fpath)
     if fdir is not None:
       fpath = os.path.join(fdir, fname)
-    Compiler().compile(main_pipeline, fpath)
-    fpaths.append(fpath)
+    if length > 57:
+      # Op name cannot be more than 57 characters
+      with pytest.raises(ValueError):
+        Compiler().compile(main_pipeline, fpath)
+    else:
+      Compiler().compile(main_pipeline, fpath)
+      fpaths.append(fpath)
 
   return fpaths
 

--- a/sdk/python/tests/compiler/testdata/long_param_name.py
+++ b/sdk/python/tests/compiler/testdata/long_param_name.py
@@ -1,0 +1,47 @@
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import dsl
+from kfp_tekton.compiler import TektonCompiler as Compiler
+
+
+def gcs_download_op(url):
+    return dsl.ContainerOp(
+        name='GCS - Download' * 4,
+        image='google/cloud-sdk:279.0.0',
+        command=['sh', '-c'],
+        arguments=['gsutil cat $0 | tee $1', url, '/tmp/results.txt'],
+        file_outputs={
+            'data' * 10: '/tmp/results.txt',
+        }
+    )
+
+
+class PrintOp(dsl.ContainerOp):
+    def __init__(self, name, msg):
+        super(PrintOp, self).__init__(
+            name=name,
+            image='alpine:3.6',
+            command=['echo', msg])
+
+
+@dsl.pipeline(name="Some very long name with lots of words in it. " +
+                   "It should be over 63 chars long in order to observe the problem.")
+def main_fn(url1='gs://ml-pipeline-playground/shakespeare1.txt'):
+    download1_task = gcs_download_op(url1)
+    PrintOp('print' * 10, download1_task.output)
+
+
+if __name__ == '__main__':
+    Compiler().compile(main_fn, __file__.replace('.py', '.yaml'))

--- a/sdk/python/tests/compiler/testdata/long_param_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_param_name.yaml
@@ -1,0 +1,95 @@
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
+      "name": "url1", "optional": true}], "name": "Some very long name with lots of
+      words in it. It should be over 63 chars long in order to observe the problem."}'
+    sidecar.istio.io/inject: 'false'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"gcs-downloadgcs-downloadgcs-downloadgcs-download":
+      [["datadatadatadatadatadatadatadatadatadata", "$(results.datadatadatadatadatadatadatadatadatadata.path)"]],
+      "printprintprintprintprintprintprintprintprintprint": []}'
+    tekton.dev/input_artifacts: '{"printprintprintprintprintprintprintprintprintprint":
+      [{"name": "gcs-downloadgcs-downloadgcs-downloadgcs-download-datadatadatadatadatadatadatadatadatadata",
+      "parent_task": "gcs-downloadgcs-downloadgcs-downloadgcs-download"}]}'
+    tekton.dev/output_artifacts: '{"gcs-downloadgcs-downloadgcs-downloadgcs-download":
+      [{"key": "artifacts/$PIPELINERUN/gcs-downloadgcs-downloadgcs-downloadgcs-download/datadatadatadatadatadatadatadatadatadata.tgz",
+      "name": "gcs-downloadgcs-downloadgcs-downloadgcs-download-datadatadatadatadatadatadatadatadatadata",
+      "path": "/tmp/results.txt"}]}'
+  name: some-very-long-name-with-lots-of-words-in-it-it-shoul
+spec:
+  params:
+  - name: url1
+    value: gs://ml-pipeline-playground/shakespeare1.txt
+  pipelineSpec:
+    params:
+    - default: gs://ml-pipeline-playground/shakespeare1.txt
+      name: url1
+    tasks:
+    - name: gcs-downloadgcs-downloadgcs-downloadgcs-download
+      params:
+      - name: url1
+        value: $(params.url1)
+      taskSpec:
+        metadata:
+          annotations:
+            tekton.dev/template: ''
+          labels:
+            pipelines.kubeflow.org/cache_enabled: 'true'
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/pipelinename: ''
+        params:
+        - name: url1
+        results:
+        - description: /tmp/results.txt
+          name: datadatadatadatadatadatadatadatadatadata
+        steps:
+        - args:
+          - gsutil cat $0 | tee $1
+          - $(inputs.params.url1)
+          - $(results.datadatadatadatadatadatadatadatadatadata.path)
+          command:
+          - sh
+          - -c
+          image: google/cloud-sdk:279.0.0
+          name: main
+      timeout: 0s
+    - name: printprintprintprintprintprintprintprintprintprint
+      params:
+      - name: gcs-downloadgcs-downloadgcs-downloadgcs-download-datadatadatadatadatadatadatadatadatadata
+        value: $(tasks.gcs-downloadgcs-downloadgcs-downloadgcs-download.results.datadatadatadatadatadatadatadatadatadata)
+      taskSpec:
+        metadata:
+          annotations:
+            tekton.dev/template: ''
+          labels:
+            pipelines.kubeflow.org/cache_enabled: 'true'
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/pipelinename: ''
+        params:
+        - name: gcs-downloadgcs-downloadgcs-downloadgcs-download-datadatadatadatadatadatadatadatadatadata
+        steps:
+        - command:
+          - echo
+          - $(inputs.params.gcs-downloadgcs-downloadgcs-downloadgcs-download-datadatadatadatadatadatadatadatadatadata)
+          image: alpine:3.6
+          name: main
+      timeout: 0s
+  timeout: 0s


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #548

**Description of your changes:**
This PR introduced few changes:
1. Parameters at the param section are now capped at 128 characters (according to the kfp api requirements for displaying node id) https://github.com/kubeflow/pipelines/blob/master/frontend/src/apis/run/api.ts#L424-L429
2. The whole string size for Tekton parameters are capped at 253 because they have the same requirements as the annotation/label keys
3. The maximum op name for each opsgroup is 57 characters. Because in Tekton, opsgroup name is the same as Tekton task name which has to follow the K8S DNS label standard (with < 63 characters for the taskrun name) https://github.com/tektoncd/pipeline/blob/main/pkg/apis/pipeline/v1beta1/pipeline_types.go#L256-L262
4. In addition to No.3, op name is no longer sanitize the length. We will throw an error for any op name that's greater than 57 characters. This is because when multiple ops have the same name, the DSL only append `-2` to the op name to make each op have a unique name. However, the sanitize function may trimmed the unique identifier that sanitize the length which causes conflicts. Furthermore, the trimmed op name also needs to be reflected in the task param name, which can get very complicated towards the end of the compilation. In KFP Argo, it also throw an error when the op name is over the Argo limit (128 characters).

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
