### PR TITLE
Clean up and revert cache image env on manifests

### DIFF
--- a/install/v0.8.0/kfp-tekton.yaml
+++ b/install/v0.8.0/kfp-tekton.yaml
@@ -1351,7 +1351,7 @@ data:
   autoUpdatePipelineDefaultVersion: "true"
   bucketName: mlpipeline
   cacheDb: cachedb
-  cacheImage: gcr.io/google-containers/busybox
+  cacheImage: registry.access.redhat.com/ubi8/ubi-minimal
   cronScheduleTimezone: UTC
   dbHost: mysql
   dbPort: "3306"

--- a/manifests/kustomize/base/cache/kustomization.yaml
+++ b/manifests/kustomize/base/cache/kustomization.yaml
@@ -10,4 +10,5 @@ commonLabels:
   app: cache-server
 images:
   - name: gcr.io/ml-pipeline/cache-server
-    newTag: 1.5.0
+    newName: docker.io/aipipeline/cache-server
+    newTag: 0.8.0

--- a/manifests/kustomize/base/installs/generic/kustomization.yaml
+++ b/manifests/kustomize/base/installs/generic/kustomization.yaml
@@ -11,26 +11,6 @@ resources:
   - mysql-secret.yaml
 
 
-images:
-  - name: gcr.io/ml-pipeline/api-server
-    newName: docker.io/aipipeline/api-server
-    newTag: latest
-  - name: gcr.io/ml-pipeline/persistenceagent
-    newName: docker.io/aipipeline/persistenceagent
-    newTag: latest
-  - name: gcr.io/ml-pipeline/frontend
-    newName: docker.io/aipipeline/frontend
-    newTag: latest
-  - name: gcr.io/ml-pipeline/metadata-writer
-    newName: docker.io/aipipeline/metadata-writer
-    newTag: latest
-  - name: gcr.io/ml-pipeline/scheduledworkflow
-    newName: docker.io/aipipeline/scheduledworkflow
-    newTag: latest
-  - name: gcr.io/ml-pipeline/cache-server
-    newName: docker.io/aipipeline/cache-server
-    newTag: latest
-
 # Used by Kustomize
 vars:
 - name: kfp-namespace

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -25,5 +25,5 @@ data:
   ## cacheImage is the image that the mutating webhook will use to patch
   ## cached steps with. Will be used to echo a message announcing that
   ## the cached step result will be used. If not set it will default to
-  ## 'gcr.io/google-containers/busybox'
-  cacheImage: "gcr.io/google-containers/busybox"
+  ## 'registry.access.redhat.com/ubi8/ubi-minimal'
+  cacheImage: "registry.access.redhat.com/ubi8/ubi-minimal"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
The 1.5.0 rebase overwrite our default cache image in the manifests which causes some issue on certain Kubernetes version and Openshift. Thus revert it back to the redhat UBI image we use to make it work on all platform.

Also clean up the manifests on the image patching section.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
