### PR TITLE
Sanitize Tekton result parameters when passing to custom task inputs

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -728,12 +728,14 @@ class TektonCompiler(Compiler):
           for pipeline_param in pipeline_params:
             if pipeline_param in orig_params:
               if pipeline_param in pipeline_param_names + loop_args:
+                # Do not sanitize Tekton pipeline input parameters, only the output parameters need to be sanitized
                 substitute_param = '$(params.%s)' % pipeline_param
                 tp['value'] = re.sub('\$\(inputs.params.%s\)' % pipeline_param, substitute_param, tp.get('value', ''))
               else:
                 for pp in op.inputs:
                   if pipeline_param == pp.full_name:
-                    substitute_param = '$(tasks.%s.results.%s)' % (pp.op_name, pp.name)
+                    # Parameters from Tekton results need to be sanitized
+                    substitute_param = '$(tasks.%s.results.%s)' % (sanitize_k8s_name(pp.op_name), sanitize_k8s_name(pp.name))
                     tp['value'] = re.sub('\$\(inputs.params.%s\)' % pipeline_param, substitute_param, tp.get('value', ''))
                     break
         # Not necessary for Tekton execution

--- a/sdk/python/tests/compiler/testdata/tekton_custom_task.log
+++ b/sdk/python/tests/compiler/testdata/tekton_custom_task.log
@@ -1,6 +1,17 @@
 [flip-coin : main] heads
 
+[flip-coin : copy-artifacts] Added `storage` successfully.
+[flip-coin : copy-artifacts] tar: removing leading '/' from member names
+[flip-coin : copy-artifacts] tekton/results/output-result
+[flip-coin : copy-artifacts] `output_result.tgz` -> `storage/mlpipeline/artifacts/tekton-custom-task-on-kubeflow-pipeline-76b7c/flip-coin/output_result.tgz`
+[flip-coin : copy-artifacts] Total: 0 B, Transferred: 121 B, Speed: 10 B/s
+
 [flip-coin-2 : main] heads
 
-[print : main] Condition output is true
+[flip-coin-2 : copy-artifacts] Added `storage` successfully.
+[flip-coin-2 : copy-artifacts] tar: removing leading '/' from member names
+[flip-coin-2 : copy-artifacts] tekton/results/output-result
+[flip-coin-2 : copy-artifacts] `output_result.tgz` -> `storage/mlpipeline/artifacts/tekton-custom-task-on-kubeflow-pipeline-76b7c/flip-coin-2/output_result.tgz`
+[flip-coin-2 : copy-artifacts] Total: 0 B, Transferred: 120 B, Speed: 9 B/s
 
+[print : main] Condition output is true

--- a/sdk/python/tests/compiler/testdata/tekton_custom_task.py
+++ b/sdk/python/tests/compiler/testdata/tekton_custom_task.py
@@ -23,8 +23,8 @@ def flip_coin_op():
         image='python:alpine3.6',
         command=['sh', '-c'],
         arguments=['python -c "import random; result = \'heads\' if random.randint(0,1) == 0 '
-                  'else \'tails\'; print(result)" | tee /tmp/output'],
-        file_outputs={'output': '/tmp/output'}
+                  'else \'tails\'; print(result)" | tee /tmp/output_result'],
+        file_outputs={'output_result': '/tmp/output_result'}
     )
 
 

--- a/sdk/python/tests/compiler/testdata/tekton_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_custom_task.yaml
@@ -22,14 +22,15 @@ metadata:
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
     tekton.dev/artifact_endpoint_scheme: http://
-    tekton.dev/artifact_items: '{"flip-coin": [["output", "$(results.output.path)"]],
-      "flip-coin-2": [["output", "$(results.output.path)"]], "print": []}'
+    tekton.dev/artifact_items: '{"flip-coin": [["output_result", "$(results.output-result.path)"]],
+      "flip-coin-2": [["output_result", "$(results.output-result.path)"]], "print":
+      []}'
     tekton.dev/input_artifacts: '{"print": [{"name": "condition-cel-status", "parent_task":
       "condition-cel"}]}'
-    tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output.tgz",
-      "name": "flip-coin-output", "path": "/tmp/output"}], "flip-coin-2": [{"key":
-      "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
-      "path": "/tmp/output"}]}'
+    tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output_result.tgz",
+      "name": "flip-coin-output_result", "path": "/tmp/output_result"}], "flip-coin-2":
+      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output_result.tgz", "name": "flip-coin-2-output_result",
+      "path": "/tmp/output_result"}]}'
   name: tekton-custom-task-on-kubeflow-pipeline
 spec:
   pipelineSpec:
@@ -44,12 +45,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/pipelinename: ''
         results:
-        - description: /tmp/output
-          name: output
+        - description: /tmp/output_result
+          name: output-result
         steps:
         - args:
           - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output.path)
+            else 'tails'; print(result)" | tee $(results.output-result.path)
           command:
           - sh
           - -c
@@ -66,12 +67,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/pipelinename: ''
         results:
-        - description: /tmp/output
-          name: output
+        - description: /tmp/output_result
+          name: output-result
         steps:
         - args:
           - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output.path)
+            else 'tails'; print(result)" | tee $(results.output-result.path)
           command:
           - sh
           - -c
@@ -81,7 +82,7 @@ spec:
     - name: condition-cel
       params:
       - name: status
-        value: '''$(tasks.flip-coin.results.output)'' == ''$(tasks.flip-coin-2.results.output)'''
+        value: '''$(tasks.flip-coin.results.output-result)'' == ''$(tasks.flip-coin-2.results.output-result)'''
       taskRef:
         apiVersion: cel.tekton.dev/v1alpha1
         kind: CEL


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #577 

**Description of your changes:**
When passing the Tekton result parameters with underscore keys to custom tasks, the Tekton variables are not properly sanitized. Thus, this PR fix the sanitization for custom task inputs.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
