### PR TITLE
Fix /logs api and add tests

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -650,12 +650,16 @@ func (r *ResourceManager) ReadLog(runId string, nodeId string, follow bool, dst 
 	return err
 }
 
-func (r *ResourceManager) readRunLogFromPod(run *model.RunDetail, nodeId string, follow bool, dst io.Writer) error {
-	logOptions := corev1.PodLogOptions{
-		Container:  "main",
+func (r *ResourceManager) getPodLogOptions(follow bool) corev1.PodLogOptions {
+	return corev1.PodLogOptions{
+		Container:  "step-main",
 		Timestamps: false,
 		Follow:     follow,
 	}
+}
+
+func (r *ResourceManager) readRunLogFromPod(run *model.RunDetail, nodeId string, follow bool, dst io.Writer) error {
+	logOptions := r.getPodLogOptions(follow)
 
 	req := r.k8sCoreClient.PodClient(run.Namespace).GetLogs(nodeId, &logOptions)
 	podLogs, err := req.Stream(context.Background())

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"google.golang.org/grpc/codes"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -541,4 +542,17 @@ func TestCreateDefaultExperiment_MultiUser(t *testing.T) {
 		StorageState:   "STORAGESTATE_AVAILABLE",
 	}
 	assert.Equal(t, expectedExperiment, experiment)
+}
+
+func TestGetPodLogOptions(t *testing.T) {
+	initEnvVars()
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store)
+	logOptions := manager.getPodLogOptions(true)
+	expectedLogOptions := corev1.PodLogOptions{
+		Container:  "step-main",
+		Timestamps: false,
+		Follow:     true,
+	}
+	assert.Equal(t, expectedLogOptions, logOptions)
 }


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #578 

**Description of your changes:**
This PR address the API log issue with standard Tekton tasks. For standard Tekton tasks on KFP, we name the main container as "main" following the Argo convention. However, the Tekton controller will always inject the `step-` prefix to all the user steps when translating them into containers because it may inject initial containers and sidecars under certain settings. 

As for custom task, there's no concept of steps anymore because the workload is not always backed by a new single pod. Thus, currently it will return an error message to let any client know the log api for custom task is not valid rather than of panic. e.g. for CEL custom task, there's no dedicated pod backing for this task because the workload is done in the controller.
`curl 'http://<endpoint>/apis/v1beta1/runs/<run_id>/nodes/<custom_task_id>/log'`
```
{"error_message":"InternalServerError: error in opening log stream: pods \"conditional-cel\" not found","error_details":"InternalServerError: error in opening log stream: pods \"conditional-cel\" not found"}
```

Note: The correct way to use this API should be `curl 'http://<endpoint>/apis/v1beta1/runs/<run_id>/nodes/<task_podname>/log'`, custom_task_id can't be the pod name in this case.

For open source UI, we are not calling the log api for custom tasks already, so no need to update the open source UI.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`): 0.21
* Kubernetes Version (use `kubectl version`): 1.18
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
