### PR TITLE
[test] Add trusted-ai into e2e testing

### DIFF
--- a/.tekton/listener.yaml
+++ b/.tekton/listener.yaml
@@ -53,6 +53,9 @@ spec:
     - name: publish-to-dockerhub
       description: publish images to dockerhub
       default: "0"
+    - name: extra-test-cases
+      description: publish images to dockerhub
+      default: "0"
     - name: image-tag
       description: image tag
       default: "nightly"
@@ -130,6 +133,8 @@ spec:
           value: $(params.dockerhub-namespace)
         - name: publish-to-dockerhub
           value: $(params.publish-to-dockerhub)
+        - name: extra-test-cases
+          value: $(params.extra-test-cases)
         - name: images
           value: $(params.images)
 ---

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -52,6 +52,9 @@ spec:
     - name: publish-to-dockerhub
       description: publish images to dockerhub
       default: "0"
+    - name: extra-test-cases
+      description: execute extra test cases
+      default: "0"
     - name: image-tag
       description: image tag
       default: "nightly"
@@ -478,6 +481,7 @@ spec:
         - name: task-pvc
           workspace: pipeline-pvc
     - name: deploy-pipeline-loops-e2e
+      retries: 1
       taskRef:
         name: iks-test
       runAfter:
@@ -505,6 +509,7 @@ spec:
       - name: task-pvc
         workspace: pipeline-pvc
     - name: deploy-any-sequencer-e2e
+      retries: 1
       taskRef:
         name: iks-test
       runAfter:
@@ -535,6 +540,7 @@ spec:
       - name: task-pvc
         workspace: pipeline-pvc
     - name: deploy-kubectl-wrapper-e2e
+      retries: 1
       taskRef:
         name: iks-test
       runAfter:
@@ -562,7 +568,8 @@ spec:
       workspaces:
         - name: task-pvc
           workspace: pipeline-pvc
-    - name: e2e-test
+    - name: e2e-test-flip-coin
+      retries: 1
       taskRef:
         name: e2e-test
       runAfter:
@@ -579,6 +586,36 @@ spec:
           value: $(params.slack-webhook)
         - name: slack-channel
           value: $(params.slack-channel)
+        - name: test-script
+          value: "scripts/deploy/iks/test-flip-coin.sh"
+      workspaces:
+      - name: task-pvc
+        workspace: pipeline-pvc
+    - name: e2e-test-trusted-ai
+      retries: 1
+      taskRef:
+        name: e2e-test
+      runAfter:
+        - deploy
+        - deploy-pipeline-loops-e2e
+      when:
+        - input: $(params.extra-test-cases)
+          operator: in
+          values:
+            - '1'
+      params:
+        - name: apikey
+          value: $(params.apikey)
+        - name: kubernetes-cluster
+          value: $(params.kubernetes-cluster)
+        - name: kubeflow-ns
+          value: $(params.kubeflow-ns)
+        - name: slack-webhook
+          value: $(params.slack-webhook)
+        - name: slack-channel
+          value: $(params.slack-channel)
+        - name: test-script
+          value: "scripts/deploy/iks/test-trusted-ai.sh"
       workspaces:
       - name: task-pvc
         workspace: pipeline-pvc
@@ -586,7 +623,7 @@ spec:
       taskRef:
         name: publish-images
       runAfter:
-        - e2e-test
+        - e2e-test-flip-coin
         - deploy-any-sequencer-e2e
         - deploy-kubectl-wrapper-e2e
       when:

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -392,11 +392,14 @@ spec:
     - name: slack-channel
       description: slack channel
       default: ""
+    - name: test-script
+      description: a shell script to run the test case
+      default: ""
   workspaces:
   - name: task-pvc
     mountPath: /artifacts
   steps:
-    - name: flip-coin
+    - name: run-test
       image: docker.io/aipipeline/pipeline-base-image:1.2
       env:
         - name: IBM_CLOUD_API_KEY
@@ -419,6 +422,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['devops.cloud.ibm.com/build-number']
+        - name: TEST_SCRIPT
+          value: $(params.test-script)
       command: ["/bin/bash", "-c"]
       args:
         - set -ex;

--- a/scripts/deploy/iks/tekton-catalog/deploy-any-sequencer-e2e.sh
+++ b/scripts/deploy/iks/tekton-catalog/deploy-any-sequencer-e2e.sh
@@ -45,7 +45,7 @@ echo "=============================="
 # Note - Permission to watch status required: "kubectl create clusterrolebinding pipeline-runner-extend --clusterrole=cluster-admin --serviceaccount=default:default"
 kubectl apply -f $MANIFEST
 
-wait_for_pipeline_run "any-sequencer" 20 30
+wait_for_pipeline_run "any-sequencer" 40 30
 
 kubectl delete -f $MANIFEST
 

--- a/scripts/deploy/iks/test-flip-coin.sh
+++ b/scripts/deploy/iks/test-flip-coin.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flip coin example
+run_flip_coin_example() {
+  local REV=1
+  local DURATION=$1
+  shift
+  local PIPELINE_ID
+  local RUN_ID
+
+  echo " =====   flip coin sample  ====="
+  python3 samples/flip-coin/condition.py
+  retry 3 3 kfp --endpoint http://localhost:8888 pipeline upload -p e2e-flip-coin samples/flip-coin/condition.yaml || :
+  PIPELINE_ID=$(kfp --endpoint http://localhost:8888  pipeline list | grep 'e2e-flip-coin' | awk '{print $2}')
+  if [[ -z "$PIPELINE_ID" ]]; then
+    echo "Failed to upload pipeline"
+    return "$REV"
+  fi
+
+  local RUN_NAME="e2e-flip-coin-run-$((RANDOM%10000+1))"
+  retry 3 3 kfp --endpoint http://localhost:8888 run submit -e exp-e2e-flip-coin -r "$RUN_NAME" -p "$PIPELINE_ID" || :
+  RUN_ID=$(kfp --endpoint http://localhost:8888  run list | grep "$RUN_NAME" | awk '{print $2}')
+  if [[ -z "$RUN_ID" ]]; then
+    echo "Failed to submit a run for flip coin pipeline"
+    return "$REV"
+  fi
+
+  local RUN_STATUS
+  ENDTIME=$(date -ud "$DURATION minute" +%s)
+  while [[ "$(date -u +%s)" -le "$ENDTIME" ]]; do
+    RUN_STATUS=$(kfp --endpoint http://localhost:8888 run list | grep "$RUN_NAME" | awk '{print $6}')
+    if [[ "$RUN_STATUS" == "Completed" ]]; then
+      REV=0
+      break;
+    fi
+    echo "  Status of flip coin run: $RUN_STATUS"
+    sleep 10
+  done
+
+  if [[ "$REV" -eq 0 ]]; then
+    echo " =====   flip coin sample PASSED ====="
+  else
+    echo " =====   flip coin sample FAILED ====="
+  fi
+
+  return "$REV"
+}
+
+RESULT=0
+run_flip_coin_example 20 || RESULT=$?
+
+STATUS_MSG=PASSED
+if [[ "$RESULT" -ne 0 ]]; then
+  STATUS_MSG=FAILED
+fi

--- a/scripts/deploy/iks/test-trusted-ai.sh
+++ b/scripts/deploy/iks/test-trusted-ai.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# trusted-ai example
+run_trusted_ai_example() {
+  local REV=1
+  local DURATION=$1
+  shift
+  local PIPELINE_ID
+  local RUN_ID
+
+  kubectl create clusterrolebinding pipeline-runner-extend --clusterrole \
+    cluster-admin --serviceaccount=kubeflow:pipeline-runner || true
+
+  echo " =====   trusted-ai sample  ====="
+  python3 samples/trusted-ai/trusted-ai.py
+  # use kubeflow namespace
+  yq eval --inplace '(.spec.params[] | select(.name=="namespace")) |=.value="kubeflow"' samples/trusted-ai/trusted-ai.yaml
+  retry 3 3 kfp --endpoint http://localhost:8888 pipeline upload -p e2e-trusted-ai samples/trusted-ai/trusted-ai.yaml || :
+  PIPELINE_ID=$(kfp --endpoint http://localhost:8888  pipeline list | grep 'e2e-trusted-ai' | awk '{print $2}')
+  if [[ -z "$PIPELINE_ID" ]]; then
+    echo "Failed to upload pipeline"
+    return "$REV"
+  fi
+
+  local RUN_NAME="e2e-trusted-ai-run-$((RANDOM%10000+1))"
+  retry 3 3 kfp --endpoint http://localhost:8888 run submit -e exp-e2e-trusted-ai -r "$RUN_NAME" -p "$PIPELINE_ID" || :
+  RUN_ID=$(kfp --endpoint http://localhost:8888  run list | grep "$RUN_NAME" | awk '{print $2}')
+  if [[ -z "$RUN_ID" ]]; then
+    echo "Failed to submit a run for trusted-ai pipeline"
+    return "$REV"
+  fi
+
+  local RUN_STATUS
+  ENDTIME=$(date -ud "$DURATION minute" +%s)
+  while [[ "$(date -u +%s)" -le "$ENDTIME" ]]; do
+    RUN_STATUS=$(kfp --endpoint http://localhost:8888 run list | grep "$RUN_NAME" | awk '{print $6}')
+    if [[ "$RUN_STATUS" == "Succeeded" ]]; then
+      REV=0
+      break;
+    fi
+    echo "  Status of trusted-ai run: $RUN_STATUS"
+    sleep 30
+  done
+
+  if [[ "$REV" -eq 0 ]]; then
+    echo " =====   trusted-ai sample PASSED ====="
+  else
+    echo " =====   trusted-ai sample FAILED ====="
+  fi
+
+  return "$REV"
+}
+
+RESULT=0
+run_trusted_ai_example 40 || RESULT=$?
+
+STATUS_MSG=PASSED
+if [[ "$RESULT" -ne 0 ]]; then
+  STATUS_MSG=FAILED
+fi


### PR DESCRIPTION
Add trusted-ai into the e2e testing and a flag (extra-test-cases)
to enable it. Also refactor the e2e-test task to support more test cases.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
