### PR TITLE
Add Parallelism support on backend.

### DIFF
--- a/tekton-catalog/pipeline-loops/README.md
+++ b/tekton-catalog/pipeline-loops/README.md
@@ -31,6 +31,8 @@
 
 - Install pipelineloop controller `kubectl apply -f config/`
 
+# Parallelism
+`Parallelism` is to define the number of pipelineruns can be created at the same time. It must be eqaul to or bigger than 1. If it's not set then the default value will be 1. If it's bigger than the total iterations in the loop then the number will be total iterations.
 
 # Verification
 - check controller and the webhook. `kubectl get po -n tekton-pipelines`

--- a/tekton-catalog/pipeline-loops/examples/loop-example-with-parallelism.yaml
+++ b/tekton-catalog/pipeline-loops/examples/loop-example-with-parallelism.yaml
@@ -1,0 +1,72 @@
+apiVersion: custom.tekton.dev/v1alpha1
+kind: PipelineLoop
+metadata:
+  name: pipelineloop
+spec:
+  pipelineSpec:
+    params:
+    - name: message
+      type: string
+    tasks:
+    - name: echo-loop-task
+      params:
+      - name: message
+        value: $(params.message)
+      taskSpec:
+        params:
+        - name: message
+          type: string
+        steps:
+          - name: echo
+            image: ubuntu
+            imagePullPolicy: IfNotPresent
+            script: |
+              #!/usr/bin/env bash
+              echo "$(params.message)"
+  iterateParam: message
+  parallelism: 2
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    tekton.dev/example-loop-pipeline: '{"spec":{"pipelineSpec":{"params":[{"name":"message","type":"string"}],"tasks":[{"name":"echo-loop-task","params":[{"name":"message","value":"$(params.message)"}],"taskSpec":{"params":[{"name":"message","type":"string"}],"steps":[{"name":"echo","image":"ubuntu","imagePullPolicy":"IfNotPresent","script":"#!/usr/bin/env bash\necho \"$(params.message)\"\n"}]}}]},"iterateParam":"message"}}'
+  name: para-loop-example
+  labels:
+    mylooplabels: mylooplabels
+spec:
+  pipelineSpec:
+    tasks:
+      - name: first-task
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              imagePullPolicy: IfNotPresent
+              script: |
+                #!/usr/bin/env bash
+                echo "I am the first task before the loop task"
+      - name: loop-task
+        runAfter:
+          - first-task
+        params:
+          - name: message
+            value:
+              - I am the first one
+              - I am the second one
+              - I am the third one
+        taskRef:
+          apiVersion: custom.tekton.dev/v1alpha1
+          kind: PipelineLoop
+          name: pipelineloop
+      - name: last-task
+        runAfter:
+          - loop-task
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              imagePullPolicy: IfNotPresent
+              script: |
+                #!/usr/bin/env bash
+                echo "I am the last task after the loop task"

--- a/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop/v1alpha1/pipelineloop_defaults.go
+++ b/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop/v1alpha1/pipelineloop_defaults.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	"context"
+	"os"
+	"strconv"
 
 	"knative.dev/pkg/apis"
 )
@@ -31,4 +33,19 @@ func (tl *PipelineLoop) SetDefaults(ctx context.Context) {
 
 // SetDefaults set any defaults for the PipelineLoop spec
 func (tls *PipelineLoopSpec) SetDefaults(ctx context.Context) {
+	if tls.Parallelism == 0 {
+		parallelism := os.Getenv("LOOP_PARALLELISM")
+		if parallelism == "" {
+			tls.Parallelism = 1
+			return
+		}
+		i, err := strconv.Atoi(parallelism)
+		if err != nil {
+			// fall back to default 1
+			tls.Parallelism = 1
+			return
+		} else {
+			tls.Parallelism = i
+		}
+	}
 }

--- a/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop/v1alpha1/pipelineloop_types.go
+++ b/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop/v1alpha1/pipelineloop_types.go
@@ -57,6 +57,10 @@ type PipelineLoopSpec struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
+	// Parallelism represents how many pipelines can be triggered simutaniously by the loop.
+	// +optional
+	Parallelism int `json:"parallelism,omitempty"`
+
 	// Retries represents how many times a task should be retried in case of task failure.
 	// +optional
 	Retries int `json:"retries,omitempty"`
@@ -113,12 +117,16 @@ func (t PipelineLoopRunReason) String() string {
 type PipelineLoopRunStatus struct {
 	// PipelineLoopSpec contains the exact spec used to instantiate the Run
 	PipelineLoopSpec *PipelineLoopSpec `json:"pipelineLoopSpec,omitempty"`
+	// current running pipelinerun number
+	// +optional
+	CurrentRunning int `json:"currentRunning,omitempty"`
 	// map of PipelineLoopPipelineRunStatus with the PipelineRun name as the key
 	// +optional
 	PipelineRuns map[string]*PipelineLoopPipelineRunStatus `json:"pipelineRuns,omitempty"`
 }
 
-// PipelineLoopPipelineRunStatus contains the iteration number for a PipelineRun and the PipelineRun's Status
+// PipelineLoopPipelineRunStatus contains the iteration number for a PipelineRun,
+// current running pipeline number, and the PipelineRun's Status
 type PipelineLoopPipelineRunStatus struct {
 	// iteration number
 	Iteration int `json:"iteration,omitempty"`

--- a/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop/v1alpha1/pipelineloop_validation.go
+++ b/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop/v1alpha1/pipelineloop_validation.go
@@ -37,6 +37,9 @@ func (tl *PipelineLoop) Validate(ctx context.Context) *apis.FieldError {
 
 // Validate PipelineLoopSpec
 func (tls *PipelineLoopSpec) Validate(ctx context.Context) *apis.FieldError {
+	if tls.Parallelism < 1 {
+		return apis.ErrInvalidValue(tls.Parallelism, "spec.Parallelism")
+	}
 	// Validate Task reference or inline task spec.
 	if err := validateTask(ctx, tls); err != nil {
 		return err

--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go
@@ -151,17 +151,18 @@ func getPipelineLoopController(t *testing.T, d test.Data, pipelineloops []*pipel
 	}, cancel
 }
 
-func getCreatedPipelinerun(t *testing.T, clients test.Clients) *v1beta1.PipelineRun {
+func getCreatedPipelinerun(t *testing.T, clients test.Clients) []*v1beta1.PipelineRun {
 	t.Log("actions", clients.Pipeline.Actions())
+	var createdPr []*v1beta1.PipelineRun
 	for _, a := range clients.Pipeline.Actions() {
 		if a.GetVerb() == "create" {
 			obj := a.(ktesting.CreateAction).GetObject()
 			if pr, ok := obj.(*v1beta1.PipelineRun); ok {
-				return pr
+				createdPr = append(createdPr, pr)
 			}
 		}
 	}
-	return nil
+	return createdPr
 }
 
 func checkEvents(fr *record.FakeRecorder, testName string, wantEvents []string) error {
@@ -298,6 +299,38 @@ var nPipeline = &v1beta1.Pipeline{
 	},
 }
 
+var paraPipeline = &v1beta1.Pipeline{
+	ObjectMeta: metav1.ObjectMeta{Name: "para-pipeline", Namespace: "foo"},
+	Spec: v1beta1.PipelineSpec{
+		Params: []v1beta1.ParamSpec{{
+			Name: "current-item",
+			Type: v1beta1.ParamTypeString,
+		}, {
+			Name: "additional-parameter",
+			Type: v1beta1.ParamTypeString,
+		}},
+		Tasks: []v1beta1.PipelineTask{{
+			Name: "mytask",
+			TaskSpec: &v1beta1.EmbeddedTask{
+				TaskSpec: v1beta1.TaskSpec{
+					Steps: []v1beta1.Step{{
+						Container: corev1.Container{Name: "foo", Image: "bar"},
+					}},
+				},
+			},
+		}},
+	},
+}
+
+var paraPipelineLoop = &pipelineloopv1alpha1.PipelineLoop{
+	ObjectMeta: metav1.ObjectMeta{Name: "para-pipelineloop", Namespace: "foo"},
+	Spec: pipelineloopv1alpha1.PipelineLoopSpec{
+		PipelineRef:  &v1beta1.PipelineRef{Name: "para-pipeline"},
+		IterateParam: "current-item",
+		Parallelism:  2,
+	},
+}
+
 var nPipelineLoop = &pipelineloopv1alpha1.PipelineLoop{
 	ObjectMeta: metav1.ObjectMeta{Name: "n-pipelineloop", Namespace: "foo"},
 	Spec: pipelineloopv1alpha1.PipelineLoopSpec{
@@ -360,6 +393,33 @@ var runPipelineLoop = &v1alpha1.Run{
 			APIVersion: pipelineloopv1alpha1.SchemeGroupVersion.String(),
 			Kind:       pipelineloop.PipelineLoopControllerName,
 			Name:       "a-pipelineloop",
+		},
+	},
+}
+
+var paraRunPipelineLoop = &v1alpha1.Run{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "run-pipelineloop",
+		Namespace: "foo",
+		Labels: map[string]string{
+			"myTestLabel": "myTestLabelValue",
+		},
+		Annotations: map[string]string{
+			"myTestAnnotation": "myTestAnnotationValue",
+		},
+	},
+	Spec: v1alpha1.RunSpec{
+		Params: []v1beta1.Param{{
+			Name:  "current-item",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"item1", "item2"}},
+		}, {
+			Name:  "additional-parameter",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "stuff"},
+		}},
+		Ref: &v1alpha1.TaskRef{
+			APIVersion: pipelineloopv1alpha1.SchemeGroupVersion.String(),
+			Kind:       pipelineloop.PipelineLoopControllerName,
+			Name:       "para-pipelineloop",
 		},
 	},
 }
@@ -616,6 +676,74 @@ var expectedPipelineRunIterationDict = &v1beta1.PipelineRun{
 		}, {
 			Name:  "current-item-subvar-b",
 			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "2"},
+		}, {
+			Name:  "additional-parameter",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "stuff"},
+		}},
+	},
+}
+
+var expectedParaPipelineRun = &v1beta1.PipelineRun{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "run-pipelineloop-00001-9l9zj",
+		Namespace: "foo",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion:         "tekton.dev/v1alpha1",
+			Kind:               "Run",
+			Name:               "run-pipelineloop",
+			Controller:         &trueB,
+			BlockOwnerDeletion: &trueB,
+		}},
+		Labels: map[string]string{
+			"custom.tekton.dev/parentPipelineRun":     "",
+			"custom.tekton.dev/pipelineLoop":          "para-pipelineloop",
+			"tekton.dev/run":                          "run-pipelineloop",
+			"custom.tekton.dev/pipelineLoopIteration": "1",
+			"myTestLabel":                             "myTestLabelValue",
+		},
+		Annotations: map[string]string{
+			"myTestAnnotation": "myTestAnnotationValue",
+		},
+	},
+	Spec: v1beta1.PipelineRunSpec{
+		PipelineRef: &v1beta1.PipelineRef{Name: "para-pipeline"},
+		Params: []v1beta1.Param{{
+			Name:  "current-item",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "item1"},
+		}, {
+			Name:  "additional-parameter",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "stuff"},
+		}},
+	},
+}
+
+var expectedParaPipelineRun1 = &v1beta1.PipelineRun{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "run-pipelineloop-00002-mz4c7",
+		Namespace: "foo",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion:         "tekton.dev/v1alpha1",
+			Kind:               "Run",
+			Name:               "run-pipelineloop",
+			Controller:         &trueB,
+			BlockOwnerDeletion: &trueB,
+		}},
+		Labels: map[string]string{
+			"custom.tekton.dev/parentPipelineRun":     "",
+			"custom.tekton.dev/pipelineLoop":          "para-pipelineloop",
+			"tekton.dev/run":                          "run-pipelineloop",
+			"custom.tekton.dev/pipelineLoopIteration": "2",
+			"myTestLabel":                             "myTestLabelValue",
+		},
+		Annotations: map[string]string{
+			"myTestAnnotation": "myTestAnnotationValue",
+		},
+	},
+	Spec: v1beta1.PipelineRunSpec{
+		PipelineRef: &v1beta1.PipelineRef{Name: "para-pipeline"},
+		Params: []v1beta1.Param{{
+			Name:  "current-item",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "item2"},
 		}, {
 			Name:  "additional-parameter",
 			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "stuff"},
@@ -940,6 +1068,16 @@ func TestReconcilePipelineLoopRun(t *testing.T) {
 		expectedReason:       pipelineloopv1alpha1.PipelineLoopRunReasonCancelled,
 		expectedPipelineruns: []*v1beta1.PipelineRun{successful(expectedPipelineRunIteration1)},
 		expectedEvents:       []string{"Warning Failed Run " + runPipelineLoop.Namespace + "/" + runPipelineLoop.Name + " was cancelled"},
+	}, {
+		name:                 "Reconcile a new run with a pipelineloop with Parallelism specified",
+		pipeline:             paraPipeline,
+		pipelineloop:         paraPipelineLoop,
+		run:                  paraRunPipelineLoop,
+		pipelineruns:         []*v1beta1.PipelineRun{},
+		expectedStatus:       corev1.ConditionUnknown,
+		expectedReason:       pipelineloopv1alpha1.PipelineLoopRunReasonRunning,
+		expectedPipelineruns: []*v1beta1.PipelineRun{expectedParaPipelineRun, expectedParaPipelineRun1},
+		expectedEvents:       []string{"Normal Started", "Normal Running Iterations completed: 0"},
 	}}
 
 	for _, tc := range testcases {
@@ -979,17 +1117,17 @@ func TestReconcilePipelineLoopRun(t *testing.T) {
 			// If the number of expected PipelineRuns is greater than the original number of PipelineRuns
 			// then the test expects a new PipelineRun to be created.  The new PipelineRun must be the
 			// last one in the list of expected PipelineRuns.
-			createdPipelinerun := getCreatedPipelinerun(t, clients)
+			createdPipelineruns := getCreatedPipelinerun(t, clients)
 			if len(tc.expectedPipelineruns) > len(tc.pipelineruns) {
-				if createdPipelinerun == nil {
+				if len(createdPipelineruns) == 0 {
 					t.Errorf("A PipelineRun should have been created but was not")
 				} else {
-					if d := cmp.Diff(tc.expectedPipelineruns[len(tc.expectedPipelineruns)-1], createdPipelinerun); d != "" {
+					if d := cmp.Diff(tc.expectedPipelineruns, createdPipelineruns); d != "" {
 						t.Errorf("Expected PipelineRun was not created. Diff %s", diff.PrintWantGot(d))
 					}
 				}
 			} else {
-				if createdPipelinerun != nil {
+				if len(createdPipelineruns) > 0 {
 					t.Errorf("A PipelineRun was created which was not expected")
 				}
 			}


### PR DESCRIPTION
- Parallelism is defaulted to 1
- if Parallelism is bigger then total iteration numbers, then start all
- normally start the same number of pipelineruns as Parallelism value

**Which issue is resolved by this Pull Request:** 
Resolves #542 
