### PR TITLE
[test] Add pipeline-loop flag

### DIFF
--- a/.tekton/listener.yaml
+++ b/.tekton/listener.yaml
@@ -56,6 +56,9 @@ spec:
     - name: extra-test-cases
       description: publish images to dockerhub
       default: "0"
+    - name: skip-pipeline-loop
+      descript: skip the pipeline loop test case
+      default: "0"
     - name: image-tag
       description: image tag
       default: "nightly"
@@ -135,6 +138,8 @@ spec:
           value: $(params.publish-to-dockerhub)
         - name: extra-test-cases
           value: $(params.extra-test-cases)
+        - name: skip-pipeline-loop
+          value: $(params.skip-pipeline-loop)
         - name: images
           value: $(params.images)
 ---

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -55,6 +55,9 @@ spec:
     - name: extra-test-cases
       description: execute extra test cases
       default: "0"
+    - name: skip-pipeline-loop
+      descript: skip the pipeline loop test case
+      default: "0"
     - name: image-tag
       description: image tag
       default: "nightly"
@@ -504,6 +507,7 @@ spec:
           value: $(params.space)
         - name: test-commands
           value: |
+            export SKIP_PIPELINE_LOOP=$(params.skip-pipeline-loop);
             source scripts/deploy/iks/tekton-catalog/deploy-pipeline-loops-e2e.sh;
       workspaces:
       - name: task-pvc

--- a/scripts/deploy/iks/tekton-catalog/deploy-pipeline-loops-e2e.sh
+++ b/scripts/deploy/iks/tekton-catalog/deploy-pipeline-loops-e2e.sh
@@ -33,6 +33,12 @@ kubectl apply -f config
 wait_for_pod "tekton-pipelines" "tekton-pipelineloop-controller" 10 30
 wait_for_pod "tekton-pipelines" "tekton-pipelineloop-webhook" 10 30
 
+if [ "$SKIP_PIPELINE_LOOP" = "1" ]; then
+    echo "skip pipeline loop test case and treat it as a success run."
+    popd > /dev/null
+    exit 0
+fi
+
 kubectl apply -f ${E2E_MANIFEST}
 
 wait_for_pipeline_run "pr-loop-example" 20 30


### PR DESCRIPTION
Add a flag to turn on/off the pipeline-loop e2e test case.
By default, the pipeline-loop test case is turned on. Use
`skip-pipeline-loop:1` to turn it off.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

**Which issue is resolved by this Pull Request:** 

Currently, `pipeline-loop` test case depends on the latest tekton. However, the latest version is not final yet and the manifest is not updated either. For now, the e2e testing should skip `pipeline-loop` test case and resume it when the tekton release is available.  

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
