### PR TITLE
Upgrade Python SDK to kfp==1.6.3

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -108,7 +108,8 @@ the Tekton YAML instead of Argo YAML. Since the KFP SDK was not designed and imp
 _monkey-patching_ was used to replace non-class methods and functions at runtime.
 
 In order for the _monkey patch_ to work properly, the `kfp-tekton` compiler source code has to be aligned with a
-specific version of the `kfp` SDK compiler. As of now that version is [`1.5.0`](https://github.com/kubeflow/pipelines/releases/tag/1.5.0).
+specific version of the `kfp` SDK compiler. As of now the `kfp-tekton` SDK version is `0.8.1` which is aligned with KFP 
+SDK version [`1.6.3`](https://pypi.org/project/kfp/1.6.3/).
 
 
 ## Adding New Code
@@ -223,7 +224,7 @@ access secrets:
 
 You can also run the dynamically generated end-to-end test suite which takes all of the "golden" YAML files from the
 compiler `testdata` directory and runs them on a Kubernetes cluster, prerequisite that the environment variable
-`KUBECONFIG` is set and the K8s cluster has both Kubeflow Pipelines as well as Tekton Pipelines installed:
+`KUBECONFIG` is set and the K8s cluster has both Kubeflow Pipelines and Tekton Pipelines installed:
 
     make e2e_test
 
@@ -246,7 +247,7 @@ To update the ["Compiler Status Report"](/sdk/python/tests/README.md) use the ou
 ## License Headers
 
 All source files should have the following license header. Adjust the year accordingly to reflect the year the file was
-added and the last year it was modified:
+added, and the last year it was modified:
 
     # Copyright 2019-2021 kubeflow.org
     #
@@ -329,6 +330,3 @@ if __name__ == '__main__':
     from kfp_tekton.compiler import TektonCompiler
     TektonCompiler().compile(pipeline_func, __file__.replace('.py', '.yaml'))
 ```
-
-
-

--- a/sdk/python/kfp_tekton/__init__.py
+++ b/sdk/python/kfp_tekton/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 from ._client import TektonClient  # noqa F401
 from .k8s_client_helper import env_from_secret  # noqa F401

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -1,3 +1,1 @@
-# TODO
-#kfp==1.5.0
-git+https://github.com/kubeflow/pipelines.git@1.5.0#egg=kfp&subdirectory=sdk/python
+kfp==1.6.3

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -30,10 +30,18 @@ docstring-parser==0.7.3
 fire==0.4.0
     # via kfp
 google-api-core==1.26.0
-    # via google-cloud-core
+    # via
+    #   google-api-python-client
+    #   google-cloud-core
+google-api-python-client==1.12.8
+    # via kfp
+google-auth-httplib2==0.1.0
+    # via google-api-python-client
 google-auth==1.27.0
     # via
     #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
     #   google-cloud-core
     #   google-cloud-storage
     #   kfp
@@ -48,17 +56,19 @@ google-resumable-media==1.2.0
     # via google-cloud-storage
 googleapis-common-protos==1.52.0
     # via google-api-core
+httplib2==0.19.1
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
 idna==2.10
     # via requests
 jsonschema==3.2.0
     # via kfp
-kfp-pipeline-spec==0.1.6
+kfp-pipeline-spec==0.1.8
     # via kfp
 kfp-server-api==1.3.0
     # via kfp
-# kfp==1.5.0
-    # TODO
-git+https://github.com/kubeflow/pipelines.git@1.5.0#egg=kfp&subdirectory=sdk/python
+kfp==1.6.3
     # via -r sdk/python/requirements.in
 kubernetes==12.0.1
     # via kfp
@@ -70,6 +80,7 @@ protobuf==3.15.2
     # via
     #   google-api-core
     #   googleapis-common-protos
+    #   kfp
     #   kfp-pipeline-spec
 pyasn1-modules==0.2.8
     # via google-auth
@@ -80,7 +91,9 @@ pyasn1==0.4.8
 pycparser==2.20
     # via cffi
 pyparsing==2.4.7
-    # via packaging
+    # via
+    #   httplib2
+    #   packaging
 pyrsistent==0.17.3
     # via jsonschema
 python-dateutil==2.8.1
@@ -111,7 +124,9 @@ six==1.15.0
     #   absl-py
     #   fire
     #   google-api-core
+    #   google-api-python-client
     #   google-auth
+    #   google-auth-httplib2
     #   google-cloud-core
     #   google-resumable-media
     #   jsonschema
@@ -126,6 +141,8 @@ tabulate==0.8.9
     # via kfp
 termcolor==1.1.0
     # via fire
+uritemplate==3.0.1
+    # via google-api-python-client
 urllib3==1.26.3
     # via
     #   kfp-server-api

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -20,14 +20,14 @@
 #
 # To create a distribution for PyPi run:
 #
-#    $ export KFP_TEKTON_VERSION=0.8.0-rc1
+#    $ export KFP_TEKTON_VERSION=0.8.1-rc1
 #    $ python3 setup.py sdist
 #    $ twine check dist/kfp-tekton-${KFP_TEKTON_VERSION/-rc/rc}.tar.gz
 #    $ twine upload --repository pypi dist/kfp-tekton-${KFP_TEKTON_VERSION/-rc/rc}.tar.gz
 #
 #   ... or:
 #
-#    $ make distribution KFP_TEKTON_VERSION=0.8.0-rc1
+#    $ make distribution KFP_TEKTON_VERSION=0.8.1-rc1
 #
 # =============================================================================
 
@@ -54,7 +54,7 @@ development stage. Contributions are welcome: {}
 # NOTICE, after any updates to the following, ./requirements.in should be updated
 # accordingly.
 REQUIRES = [
-    "kfp @ git+https://github.com/kubeflow/pipelines.git@1.5.0#egg=kfp&subdirectory=sdk/python",
+    "kfp==1.6.3",
 ]
 
 TESTS_REQUIRE = [

--- a/sdk/python/tests/README.md
+++ b/sdk/python/tests/README.md
@@ -27,7 +27,7 @@ You should see an output similar to the one below, outlining which test scripts 
 which are failing:
 
 ```YAML
-KFP version: 1.5.0
+KFP SDK version: 1.6.3
 
 SUCCESS: add_pod_env.py
 SUCCESS: artifact_passing_using_volume.py
@@ -140,5 +140,5 @@ Occurences of other Errors:
 
 ## Disclaimer
 
-**Note:** The reports above were created for the pipeline scripts found in KFP version `1.5.0` since
-the `kfp_tekton` compiler code is currently based on the `kfp` SDK compiler version `1.5.0`.
+**Note:** The reports above were created for the pipeline scripts found in KFP SDK version `1.6.3` since
+the `kfp_tekton` `0.8.1` compiler code is based on the `kfp` SDK compiler version `1.6.3`.

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -67,7 +67,7 @@ spec:
             is failure.
           name: failure-condition
           type: string
-        - default: aipipeline/kubectl-wrapper:0.8.0
+        - default: aipipeline/kubectl-wrapper:0.8.1
           description: Kubectl wrapper image
           name: image
           type: string

--- a/sdk/python/tests/compiler/testdata/volume_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_op.yaml
@@ -78,7 +78,7 @@ spec:
             is failure.
           name: failure-condition
           type: string
-        - default: aipipeline/kubectl-wrapper:0.8.0
+        - default: aipipeline/kubectl-wrapper:0.8.1
           description: Kubectl wrapper image
           name: image
           type: string

--- a/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_snapshot_op.yaml
@@ -84,7 +84,7 @@ spec:
             is failure.
           name: failure-condition
           type: string
-        - default: aipipeline/kubectl-wrapper:0.8.0
+        - default: aipipeline/kubectl-wrapper:0.8.1
           description: Kubectl wrapper image
           name: image
           type: string
@@ -197,7 +197,7 @@ spec:
             is failure.
           name: failure-condition
           type: string
-        - default: aipipeline/kubectl-wrapper:0.8.0
+        - default: aipipeline/kubectl-wrapper:0.8.1
           description: Kubectl wrapper image
           name: image
           type: string
@@ -310,7 +310,7 @@ spec:
             is failure.
           name: failure-condition
           type: string
-        - default: aipipeline/kubectl-wrapper:0.8.0
+        - default: aipipeline/kubectl-wrapper:0.8.1
           description: Kubectl wrapper image
           name: image
           type: string
@@ -423,7 +423,7 @@ spec:
             is failure.
           name: failure-condition
           type: string
-        - default: aipipeline/kubectl-wrapper:0.8.0
+        - default: aipipeline/kubectl-wrapper:0.8.1
           description: Kubectl wrapper image
           name: image
           type: string


### PR DESCRIPTION
Resolves #595

Because KFP skipped the `1.5.0` release for the SDK, we built the `kfp-tekton` `0.8.0` SDK based on the KFP SDK sources in the KFP repo (instead of depending on the proper pip-installable `kfp==1.5.0` release). 

However, `pip install kfp-tekton==0.8.0` will fail since no PyPI package is allowed to depend on packages built from GitHub. 

So in this PR we need to decide if we should create a "fix-patch" release `kfp-tekton==0.8.1` based on `kfp==1.4.0` or `kfp==1.6.3` ([`sdk/python/requirements.in`](https://github.com/kubeflow/kfp-tekton/pull/617/files#diff-63a2db662374dbedfd8bcec50462e9460017527f7efc41d5f5b80ef702f179e3L2-R1)):

```diff
diff --git a/sdk/python/requirements.in b/sdk/python/requirements.in
index 9743334a..8a1727e2 100644
--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -1,3 +1 @@
-# TODO
-#kfp==1.5.0
-git+https://github.com/kubeflow/pipelines.git@1.5.0#egg=kfp&subdirectory=sdk/python
+kfp==1.6.3
```


- [x] Upgraded Python dependencies to align with [kfp==1.6.3](https://pypi.org/project/kfp/1.6.3/), but maybe it should be [kfp==1.4.0](https://pypi.org/project/kfp/1.4.0/)?
- [x] Bumped SDK version to `0.8.1` ("Fix pack" release)
- [x] Bumped project version to `0.8.1` -- but I am not sure we should? The `0.8.1` could be a SDK version only.
- [ ] @Tomcli -- I did not create a new manifest folder for `0.8.1` as I am not sure we need to?
- [x] @Tomcli -- **Note** the changed version of `aipipeline/kubectl-wrapper:0.8.1` that got generated in the new YAML files. I have not built/pushed that new image 

Instead of upgrading the KFP SDK we could also downgrade it to `kfp==1.4.0` just to address the `pip install kfp-tekton` error. And then we do a full rebase for KFP 1.6.0 for API, Backend, Frontend and SDK in a new `0.9.0` release of KFP-Tekton.

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>
