### PR TITLE
Remove runid labels from pipelineloop's child pipelinerun 

### DIFF
--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
@@ -66,6 +66,9 @@ const (
 
 	// pipelineLoopIterationLabelKey is the label identifier for the iteration number.  This label is added to the Run's PipelineRuns.
 	pipelineLoopIterationLabelKey = "/pipelineLoopIteration"
+
+	// LabelKeyWorkflowRunId is the label identifier a pipelinerun is managed by the Kubeflow Pipeline persistent agent.
+	LabelKeyWorkflowRunId = "pipeline/runid"
 )
 
 // Reconciler implements controller.Reconciler for Configuration resources.
@@ -690,6 +693,11 @@ func getPipelineRunLabels(run *v1alpha1.Run, iterationStr string) map[string]str
 		prOriginalName = run.ObjectMeta.Labels["tekton.dev/pipelineRun"]
 	}
 	labels[pipelineloop.GroupName+originalPRKey] = prOriginalName
+	// Empty the RunId reference from the KFP persistent agent because LabelKeyWorkflowRunId should be unique across all pipelineruns
+	_, ok := labels[LabelKeyWorkflowRunId]
+	if ok {
+		delete(labels, LabelKeyWorkflowRunId)
+	}
 	return labels
 }
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #488 

**Description of your changes:**
I figured out #488 issue sometimes occur because the pipeline loop controller also copy the runid label to its child pipelineruns. The runid label should be unique across all pipelineruns because the KFP persistent agent is using that as the key to persistent pipelinerun spec into the mysql database. The spec in the database is the source for all the KFP API calls.

Thus, removing the `runid` will stop persistent agent copying the wrong pipelinerun into the mysql database which stop causing inconsistent results from the API.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
