### PR TITLE
fix(sdk): loop argument jsonified, not stringified

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -371,7 +371,7 @@ class TektonCompiler(Compiler):
             sanitized_tasks.append(c_dict)
           loop_args_str_value = json.dumps(sanitized_tasks, sort_keys=True)
         else:
-          loop_args_str_value = str(loop_arg_value)
+          loop_args_str_value = json.dumps(loop_arg_value)
 
         self.loops_pipeline[group_name]['spec']['params'] = [{
           "name": sub_group.loop_args.full_name,


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #656

**Description of your changes:**
For `dsl.ParallelFor` loop arguments, always `json.dump` instead of `str`ingifying in some cases.

**Environment tested:**

* Python Version (use `python --version`): 3.9.0
* SDK Version: master's HEAD 77963c3ceaf042bba1278797c349fe83dc79701b

________

Please add `cherrypick-approved` label.