### PR TITLE
Update Argo link

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -7,7 +7,7 @@
 
 The Kubeflow Pipelines [SDK](https://www.kubeflow.org/docs/pipelines/sdk/sdk-overview/)
 allows data scientists to define end-to-end machine learning and data pipelines.
-The output of the Kubeflow Pipelines SDK compiler is YAML for [Argo](https://github.com/argoproj/argo).
+The output of the Kubeflow Pipelines SDK compiler is YAML for [Argo](https://github.com/argoproj/argo-workflows).
 
 The `kfp-tekton` SDK is extending the `Compiler` and the `Client` of the Kubeflow
 Pipelines SDK to generate [Tekton](https://github.com/tektoncd/pipeline) YAML


### PR DESCRIPTION
**Description of your changes:**

The current Argo link now redirects to the Github repo for the website https://github.com/argoproj/argocon21. It should point to https://github.com/argoproj/argo-workflows

KFP updated the same link a month ago [https://github.com/kubeflow/pipelines/commit/ade3454](https://github.com/kubeflow/pipelines/commit/ade3454#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56)