### PR TITLE
remove ContainerOp from test cases - part 3

### DIFF
--- a/sdk/python/tests/compiler/testdata/opsgroups.yaml
+++ b/sdk/python/tests/compiler/testdata/opsgroups.yaml
@@ -25,39 +25,116 @@ metadata:
     tekton.dev/artifact_items: '{"echo1-task1": [], "echo2-task1": []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "message 1", "name":
-      "text1", "optional": true}, {"default": "message 2", "name": "text2", "optional":
-      true}], "name": "Opsgroups pipeline"}'
+      "text1", "optional": true, "type": "String"}, {"default": "message 2", "name":
+      "text2", "optional": true, "type": "String"}], "name": "opsgroups-pipeline"}'
 spec:
   params:
-  - {name: text1, value: message 1}
-  - {name: text2, value: message 2}
+  - name: text1
+    value: message 1
+  - name: text2
+    value: message 2
   pipelineSpec:
     params:
-    - {name: text1, default: message 1}
-    - {name: text2, default: message 2}
+    - name: text1
+      default: message 1
+    - name: text2
+      default: message 2
     tasks:
-    - name: echo1-task1
+    - name: opsgroups-pipeline-4f58a-raph-component-1
       params:
-      - {name: text1, value: $(params.text1)}
+      - name: just_one_iteration
+        value:
+        - '1'
+      - name: text1
+        value: $(params.text1)
       taskSpec:
-        steps:
-        - name: main
-          args: [echo "$0", $(inputs.params.text1)]
-          command: [sh, -c]
-          image: library/bash:4.4.23
-        params:
-        - {name: text1}
-      timeout: 0s
-    - name: echo2-task1
+        apiVersion: custom.tekton.dev/v1alpha1
+        kind: PipelineLoop
+        spec:
+          pipelineSpec:
+            params:
+            - name: just_one_iteration
+              type: string
+            - name: text1
+              type: string
+            tasks:
+            - name: echo1-task1
+              params:
+              - name: text1
+                value: $(params.text1)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - echo
+                  - $(inputs.params.text1)
+                  command:
+                  - sh
+                  - -c
+                  image: library/bash:4.4.23
+                params:
+                - name: text1
+                  type: string
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec: '{"description": "echo
+                      task", "implementation": {"container": {"args": ["echo", {"inputValue":
+                      "text"}], "command": ["sh", "-c"], "image": "library/bash:4.4.23"}},
+                      "inputs": [{"name": "text", "type": "String"}], "name": "echo1-task1"}'
+                    tekton.dev/template: ''
+              timeout: 0s
+          iterateParam: just_one_iteration
+    - runAfter: []
+      name: opsgroups-pipeline-4f58a-raph-component-2
       params:
-      - {name: text2, value: $(params.text2)}
+      - name: just_one_iteration
+        value:
+        - '1'
+      - name: text2
+        value: $(params.text2)
       taskSpec:
-        steps:
-        - name: main
-          args: [echo "$0", $(inputs.params.text2)]
-          command: [sh, -c]
-          image: library/bash:4.4.23
-        params:
-        - {name: text2}
-      timeout: 0s
+        apiVersion: custom.tekton.dev/v1alpha1
+        kind: PipelineLoop
+        spec:
+          pipelineSpec:
+            params:
+            - name: just_one_iteration
+              type: string
+            - name: text2
+              type: string
+            tasks:
+            - name: echo2-task1
+              params:
+              - name: text2
+                value: $(params.text2)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - echo
+                  - $(inputs.params.text2)
+                  command:
+                  - sh
+                  - -c
+                  image: library/bash:4.4.23
+                params:
+                - name: text2
+                  type: string
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec: '{"description": "echo
+                      task", "implementation": {"container": {"args": ["echo", {"inputValue":
+                      "text"}], "command": ["sh", "-c"], "image": "library/bash:4.4.23"}},
+                      "inputs": [{"name": "text", "type": "String"}], "name": "echo2-task1"}'
+                    tekton.dev/template: ''
+              timeout: 0s
+          iterateParam: just_one_iteration
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/parallel_join.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join.yaml
@@ -18,9 +18,9 @@ metadata:
   name: parallel-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"gcs-download": [{"key": "artifacts/$PIPELINERUN/gcs-download/data.tgz",
-      "name": "gcs-download-data", "path": "/tmp/results.txt"}], "gcs-download-2":
+      "name": "gcs-download-data", "path": "/tmp/outputs/data/data"}], "gcs-download-2":
       [{"key": "artifacts/$PIPELINERUN/gcs-download-2/data.tgz", "name": "gcs-download-2-data",
-      "path": "/tmp/results.txt"}]}'
+      "path": "/tmp/outputs/data/data"}]}'
     tekton.dev/input_artifacts: '{"echo": [{"name": "gcs-download-2-data", "parent_task":
       "gcs-download-2"}, {"name": "gcs-download-data", "parent_task": "gcs-download"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -31,8 +31,8 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Download two messages
       in parallel and prints the concatenated result.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
-      "name": "url1", "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
-      "name": "url2", "optional": true}], "name": "Parallel pipeline"}'
+      "name": "url1", "optional": true, "type": "String"}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
+      "name": "url2", "optional": true, "type": "String"}], "name": "parallel-pipeline"}'
 spec:
   params:
   - name: url1
@@ -54,7 +54,8 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url1)
           - $(results.data.path)
           command:
@@ -65,13 +66,19 @@ spec:
         - name: url1
         results:
         - name: data
-          description: /tmp/results.txt
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:279.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: gcs-download-2
@@ -82,7 +89,8 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url2)
           - $(results.data.path)
           command:
@@ -93,13 +101,19 @@ spec:
         - name: url2
         results:
         - name: data
-          description: /tmp/results.txt
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:279.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: echo
@@ -112,7 +126,8 @@ spec:
         steps:
         - name: main
           args:
-          - 'echo "Text 1: $0"; echo "Text 2: $1"'
+          - |
+            echo "Text 1: $0"; echo "Text 2: $1"
           - $(inputs.params.gcs-download-data)
           - $(inputs.params.gcs-download-2-data)
           command:
@@ -128,6 +143,11 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo \"Text 1: $0\"; echo \"Text 2: $1\"\n",
+              {"inputValue": "input1"}, {"inputValue": "input2"}], "command": ["sh",
+              "-c"], "image": "library/bash:4.4.23"}}, "inputs": [{"name": "input1",
+              "type": "String"}, {"name": "input2", "type": "String"}], "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/parallel_join_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_noninlined.yaml
@@ -18,9 +18,9 @@ metadata:
   name: parallel-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"gcs-download": [{"key": "artifacts/$PIPELINERUN/gcs-download/data.tgz",
-      "name": "gcs-download-data", "path": "/tmp/results.txt"}], "gcs-download-2":
+      "name": "gcs-download-data", "path": "/tmp/outputs/data/data"}], "gcs-download-2":
       [{"key": "artifacts/$PIPELINERUN/gcs-download-2/data.tgz", "name": "gcs-download-2-data",
-      "path": "/tmp/results.txt"}]}'
+      "path": "/tmp/outputs/data/data"}]}'
     tekton.dev/input_artifacts: '{"echo": [{"name": "gcs-download-2-data", "parent_task":
       "gcs-download-2"}, {"name": "gcs-download-data", "parent_task": "gcs-download"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -31,8 +31,8 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Download two messages
       in parallel and prints the concatenated result.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
-      "name": "url1", "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
-      "name": "url2", "optional": true}], "name": "Parallel pipeline"}'
+      "name": "url1", "optional": true, "type": "String"}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
+      "name": "url2", "optional": true, "type": "String"}], "name": "parallel-pipeline"}'
 spec:
   params:
   - name: url1
@@ -54,7 +54,8 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url1)
           - $(results.data.path)
           command:
@@ -65,13 +66,19 @@ spec:
         - name: url1
         results:
         - name: data
-          description: /tmp/results.txt
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:279.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: gcs-download-2
@@ -82,7 +89,8 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url2)
           - $(results.data.path)
           command:
@@ -93,13 +101,19 @@ spec:
         - name: url2
         results:
         - name: data
-          description: /tmp/results.txt
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:279.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: echo
@@ -112,7 +126,8 @@ spec:
         steps:
         - name: main
           args:
-          - 'echo "Text 1: $0"; echo "Text 2: $1"'
+          - |
+            echo "Text 1: $0"; echo "Text 2: $1"
           - $(inputs.params.gcs-download-data)
           - $(inputs.params.gcs-download-2-data)
           command:
@@ -128,6 +143,11 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo \"Text 1: $0\"; echo \"Text 2: $1\"\n",
+              {"inputValue": "input1"}, {"inputValue": "input2"}], "command": ["sh",
+              "-c"], "image": "library/bash:4.4.23"}}, "inputs": [{"name": "input1",
+              "type": "String"}, {"name": "input2", "type": "String"}], "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.py
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.py
@@ -12,38 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp import dsl
+from kfp import dsl, components
 
 
-def gcs_download_op(url):
-    return dsl.ContainerOp(
-        name='GCS - Download',
-        image='google/cloud-sdk:279.0.0',
-        command=['sh', '-c'],
-        arguments=['gsutil cat $0 | tee $1', url, '/tmp/results.txt'],
-        file_outputs={
-            'data': '/tmp/results.txt',
-        }
-    )
+def gcs_download_op(url: str):
+    return components.load_component_from_text("""
+    name: gcs-download
+    description: GCS - Download
+    inputs:
+      - {name: url, type: String}
+    outputs:
+      - {name: data, type: String}
+    implementation:
+      container:
+        image: google/cloud-sdk:279.0.0
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          gsutil cat $0 | tee $1
+        - {inputValue: url}
+        - {outputPath: data}
+    """)(url=url)
 
 
-def echo2_op(text1, text2):
-    return dsl.ContainerOp(
-        name='echo',
-        image='library/bash:4.4.23',
-        command=['sh', '-c'],
-        arguments=['echo "Text 1: $0"; echo "Text 2: $1"; echo "{{inputs.parameters.gcs-download-data}}";\
-            echo "{{workflow.name}}"; echo "{{workflow.namespace}}"; echo "{{workflow.uid}}"', text1, text2]
-    )
+def echo2_op(text1: str, text2: str):
+    return components.load_component_from_text("""
+    name: echo
+    description: echo
+    inputs:
+      - {name: input1, type: String}
+      - {name: input2, type: String}
+    implementation:
+      container:
+        image: library/bash:4.4.23
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          echo "Text 1: $0"; echo "Text 2: $1"; echo "{{inputs.parameters.gcs-download-data}}";\
+          echo "{{workflow.name}}"; echo "{{workflow.namespace}}"; echo "{{workflow.uid}}"
+        - {inputValue: input1}
+        - {inputValue: input2}
+    """)(input1=text1, input2=text2)
 
 
 @dsl.pipeline(
-  name='Parallel pipeline with argo vars',
+  name='parallel-pipeline-with-argo-vars',
   description='Download two messages in parallel and prints the concatenated result and use Argo variables.'
 )
 def download_and_join_with_argo_vars(
-    url1='gs://ml-pipeline-playground/shakespeare1.txt',
-    url2='gs://ml-pipeline-playground/shakespeare2.txt'
+    url1: str = 'gs://ml-pipeline-playground/shakespeare1.txt',
+    url2: str = 'gs://ml-pipeline-playground/shakespeare2.txt'
 ):
     """A three-step pipeline with the first two steps running in parallel with Argo variables."""
 

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
@@ -18,9 +18,9 @@ metadata:
   name: parallel-pipeline-with-argo-vars
   annotations:
     tekton.dev/output_artifacts: '{"gcs-download": [{"key": "artifacts/$PIPELINERUN/gcs-download/data.tgz",
-      "name": "gcs-download-data", "path": "/tmp/results.txt"}], "gcs-download-2":
+      "name": "gcs-download-data", "path": "/tmp/outputs/data/data"}], "gcs-download-2":
       [{"key": "artifacts/$PIPELINERUN/gcs-download-2/data.tgz", "name": "gcs-download-2-data",
-      "path": "/tmp/results.txt"}]}'
+      "path": "/tmp/outputs/data/data"}]}'
     tekton.dev/input_artifacts: '{"echo": [{"name": "gcs-download-2-data", "parent_task":
       "gcs-download-2"}, {"name": "gcs-download-data", "parent_task": "gcs-download"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -32,8 +32,8 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Download two messages
       in parallel and prints the concatenated result and use Argo variables.", "inputs":
       [{"default": "gs://ml-pipeline-playground/shakespeare1.txt", "name": "url1",
-      "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
-      "name": "url2", "optional": true}], "name": "Parallel pipeline with argo vars"}'
+      "optional": true, "type": "String"}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
+      "name": "url2", "optional": true, "type": "String"}], "name": "parallel-pipeline-with-argo-vars"}'
 spec:
   params:
   - name: url1
@@ -55,7 +55,8 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url1)
           - $(results.data.path)
           command:
@@ -66,13 +67,19 @@ spec:
         - name: url1
         results:
         - name: data
-          description: /tmp/results.txt
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:279.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: gcs-download-2
@@ -83,7 +90,8 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url2)
           - $(results.data.path)
           command:
@@ -94,13 +102,19 @@ spec:
         - name: url2
         results:
         - name: data
-          description: /tmp/results.txt
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:279.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: echo
@@ -119,9 +133,8 @@ spec:
         steps:
         - name: main
           args:
-          - 'echo "Text 1: $0"; echo "Text 2: $1"; echo "$(inputs.params.gcs-download-data)";            echo
-            "$(params.pipelineRun-name)"; echo "$(params.pipelineRun-namespace)";
-            echo "$(params.pipelineRun-uid)"'
+          - |
+            echo "Text 1: $0"; echo "Text 2: $1"; echo "$(inputs.params.gcs-download-data)";          echo "$(params.pipelineRun-name)"; echo "$(params.pipelineRun-namespace)"; echo "$(params.pipelineRun-uid)"
           - $(inputs.params.gcs-download-data)
           - $(inputs.params.gcs-download-2-data)
           command:
@@ -140,6 +153,13 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo \"Text 1: $0\"; echo \"Text 2: $1\"; echo
+              \"$(inputs.params.gcs-download-data)\";          echo \"$(context.pipelineRun.name)\";
+              echo \"$(context.pipelineRun.namespace)\"; echo \"$(context.pipelineRun.uid)\"\n",
+              {"inputValue": "input1"}, {"inputValue": "input2"}], "command": ["sh",
+              "-c"], "image": "library/bash:4.4.23"}}, "inputs": [{"name": "input1",
+              "type": "String"}, {"name": "input2", "type": "String"}], "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars_noninlined.yaml
@@ -18,9 +18,9 @@ metadata:
   name: parallel-pipeline-with-argo-vars
   annotations:
     tekton.dev/output_artifacts: '{"gcs-download": [{"key": "artifacts/$PIPELINERUN/gcs-download/data.tgz",
-      "name": "gcs-download-data", "path": "/tmp/results.txt"}], "gcs-download-2":
+      "name": "gcs-download-data", "path": "/tmp/outputs/data/data"}], "gcs-download-2":
       [{"key": "artifacts/$PIPELINERUN/gcs-download-2/data.tgz", "name": "gcs-download-2-data",
-      "path": "/tmp/results.txt"}]}'
+      "path": "/tmp/outputs/data/data"}]}'
     tekton.dev/input_artifacts: '{"echo": [{"name": "gcs-download-2-data", "parent_task":
       "gcs-download-2"}, {"name": "gcs-download-data", "parent_task": "gcs-download"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -32,8 +32,8 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Download two messages
       in parallel and prints the concatenated result and use Argo variables.", "inputs":
       [{"default": "gs://ml-pipeline-playground/shakespeare1.txt", "name": "url1",
-      "optional": true}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
-      "name": "url2", "optional": true}], "name": "Parallel pipeline with argo vars"}'
+      "optional": true, "type": "String"}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
+      "name": "url2", "optional": true, "type": "String"}], "name": "parallel-pipeline-with-argo-vars"}'
 spec:
   params:
   - name: url1
@@ -55,7 +55,8 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url1)
           - $(results.data.path)
           command:
@@ -66,13 +67,19 @@ spec:
         - name: url1
         results:
         - name: data
-          description: /tmp/results.txt
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:279.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: gcs-download-2
@@ -83,7 +90,8 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url2)
           - $(results.data.path)
           command:
@@ -94,13 +102,19 @@ spec:
         - name: url2
         results:
         - name: data
-          description: /tmp/results.txt
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:279.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: echo
@@ -119,9 +133,8 @@ spec:
         steps:
         - name: main
           args:
-          - 'echo "Text 1: $0"; echo "Text 2: $1"; echo "$(inputs.params.gcs-download-data)";            echo
-            "$(params.pipelineRun-name)"; echo "$(params.pipelineRun-namespace)";
-            echo "$(params.pipelineRun-uid)"'
+          - |
+            echo "Text 1: $0"; echo "Text 2: $1"; echo "$(inputs.params.gcs-download-data)";          echo "$(params.pipelineRun-name)"; echo "$(params.pipelineRun-namespace)"; echo "$(params.pipelineRun-uid)"
           - $(inputs.params.gcs-download-data)
           - $(inputs.params.gcs-download-2-data)
           command:
@@ -140,6 +153,13 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo \"Text 1: $0\"; echo \"Text 2: $1\"; echo
+              \"$(inputs.params.gcs-download-data)\";          echo \"$(context.pipelineRun.name)\";
+              echo \"$(context.pipelineRun.namespace)\"; echo \"$(context.pipelineRun.uid)\"\n",
+              {"inputValue": "input1"}, {"inputValue": "input2"}], "command": ["sh",
+              "-c"], "image": "library/bash:4.4.23"}}, "inputs": [{"name": "input1",
+              "type": "String"}, {"name": "input2", "type": "String"}], "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.py
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.py
@@ -46,11 +46,11 @@ def produce_list_of_ints() -> list:
 
 
 @func_to_container_op
-def consume(param1):
+def consume(param1: str):
     print(param1)
 
 
-@kfp.dsl.pipeline()
+@kfp.dsl.pipeline(name='parallelfor-item-argument-resolving')
 def parallelfor_item_argument_resolving():
     produce_str_task = produce_str()
     produce_list_of_strings_task = produce_list_of_strings()
@@ -58,18 +58,18 @@ def parallelfor_item_argument_resolving():
     produce_list_of_dicts_task = produce_list_of_dicts()
 
     with kfp.dsl.ParallelFor(produce_list_of_strings_task.output) as loop_item:
-        consume(produce_list_of_strings_task.output)
-        consume(loop_item)
-        consume(produce_str_task.output)
+        consume(str(produce_list_of_strings_task.output))
+        consume(str(loop_item))
+        consume(str(produce_str_task.output))
 
     with kfp.dsl.ParallelFor(produce_list_of_ints_task.output) as loop_item:
-        consume(produce_list_of_ints_task.output)
-        consume(loop_item)
+        consume(str(produce_list_of_ints_task.output))
+        consume(str(loop_item))
 
     with kfp.dsl.ParallelFor(produce_list_of_dicts_task.output) as loop_item:
-        consume(produce_list_of_dicts_task.output)
+        consume(str(produce_list_of_dicts_task.output))
         # consume(loop_item) # Cannot use the full loop item when it's a dict
-        consume(loop_item.aaa)
+        consume(str(loop_item.aaa))
 
 
 if __name__ == '__main__':

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -39,7 +39,7 @@ metadata:
       "$(results.output.path)"]], "produce-list-of-strings": [["Output", "$(results.output.path)"]],
       "produce-str": [["Output", "$(results.output.path)"]]}'
     sidecar.istio.io/inject: "false"
-    pipelines.kubeflow.org/pipeline_spec: '{"name": "Parallelfor item argument resolving"}'
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "parallelfor-item-argument-resolving"}'
 spec:
   pipelineSpec:
     tasks:
@@ -436,8 +436,8 @@ spec:
                       = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
                       dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
                       = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
-                      "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name":
-                      "Consume"}'
+                      "image": "python:3.7"}}, "inputs": [{"name": "param1", "type":
+                      "String"}], "name": "Consume"}'
                     tekton.dev/template: ''
               timeout: 0s
             - name: consume-2
@@ -485,8 +485,8 @@ spec:
                       = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
                       dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
                       = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
-                      "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name":
-                      "Consume"}'
+                      "image": "python:3.7"}}, "inputs": [{"name": "param1", "type":
+                      "String"}], "name": "Consume"}'
                     tekton.dev/template: ''
               timeout: 0s
             - name: consume-3
@@ -534,8 +534,8 @@ spec:
                       = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
                       dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
                       = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
-                      "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name":
-                      "Consume"}'
+                      "image": "python:3.7"}}, "inputs": [{"name": "param1", "type":
+                      "String"}], "name": "Consume"}'
                     tekton.dev/template: ''
               timeout: 0s
           iterateParam: produce-list-of-strings-Output-loop-item
@@ -603,8 +603,8 @@ spec:
                       = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
                       dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
                       = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
-                      "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name":
-                      "Consume"}'
+                      "image": "python:3.7"}}, "inputs": [{"name": "param1", "type":
+                      "String"}], "name": "Consume"}'
                     tekton.dev/template: ''
               timeout: 0s
             - name: consume-5
@@ -652,8 +652,8 @@ spec:
                       = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
                       dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
                       = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
-                      "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name":
-                      "Consume"}'
+                      "image": "python:3.7"}}, "inputs": [{"name": "param1", "type":
+                      "String"}], "name": "Consume"}'
                     tekton.dev/template: ''
               timeout: 0s
           iterateParam: produce-list-of-ints-Output-loop-item
@@ -721,8 +721,8 @@ spec:
                       = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
                       dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
                       = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
-                      "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name":
-                      "Consume"}'
+                      "image": "python:3.7"}}, "inputs": [{"name": "param1", "type":
+                      "String"}], "name": "Consume"}'
                     tekton.dev/template: ''
               timeout: 0s
             - name: consume-7
@@ -770,8 +770,8 @@ spec:
                       = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
                       dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
                       = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
-                      "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name":
-                      "Consume"}'
+                      "image": "python:3.7"}}, "inputs": [{"name": "param1", "type":
+                      "String"}], "name": "Consume"}'
                     tekton.dev/template: ''
               timeout: 0s
           iterateParam: produce-list-of-dicts-Output-loop-item

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving_noninlined.yaml
@@ -39,7 +39,7 @@ metadata:
       "$(results.output.path)"]], "produce-list-of-strings": [["Output", "$(results.output.path)"]],
       "produce-str": [["Output", "$(results.output.path)"]]}'
     sidecar.istio.io/inject: "false"
-    pipelines.kubeflow.org/pipeline_spec: '{"name": "Parallelfor item argument resolving"}'
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "parallelfor-item-argument-resolving"}'
     tekton.dev/resource_templates: '[{"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "metadata": {"name": "parallelfor-item-argument-resolving-for-loop-1"},
       "spec": {"iterateParam": "produce-list-of-strings-Output-loop-item", "pipelineSpec":
@@ -55,8 +55,8 @@ metadata:
       description='''')\\n_parser.add_argument(\\\"--param1\\\", dest=\\\"param1\\\",
       type=str, required=True, default=argparse.SUPPRESS)\\n_parsed_args = vars(_parser.parse_args())\\n\\n_outputs
       = consume(**_parsed_args)\\n\"], \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\":
-      \"param1\"}], \"name\": \"Consume\"}", "tekton.dev/template": ""}, "labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      \"param1\", \"type\": \"String\"}], \"name\": \"Consume\"}", "tekton.dev/template":
+      ""}, "labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "produce-list-of-strings-Output",
       "type": "string"}], "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-strings-Output)"],
       "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
@@ -74,8 +74,8 @@ metadata:
       = argparse.ArgumentParser(prog=''Consume'', description='''')\\n_parser.add_argument(\\\"--param1\\\",
       dest=\\\"param1\\\", type=str, required=True, default=argparse.SUPPRESS)\\n_parsed_args
       = vars(_parser.parse_args())\\n\\n_outputs = consume(**_parsed_args)\\n\"],
-      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\"}], \"name\":
-      \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
+      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\", \"type\": \"String\"}],
+      \"name\": \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
       "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
       ""}}, "params": [{"name": "produce-list-of-strings-Output-loop-item", "type":
       "string"}], "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-strings-Output-loop-item)"],
@@ -94,8 +94,8 @@ metadata:
       description='''')\\n_parser.add_argument(\\\"--param1\\\", dest=\\\"param1\\\",
       type=str, required=True, default=argparse.SUPPRESS)\\n_parsed_args = vars(_parser.parse_args())\\n\\n_outputs
       = consume(**_parsed_args)\\n\"], \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\":
-      \"param1\"}], \"name\": \"Consume\"}", "tekton.dev/template": ""}, "labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      \"param1\", \"type\": \"String\"}], \"name\": \"Consume\"}", "tekton.dev/template":
+      ""}, "labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "produce-str-Output",
       "type": "string"}], "steps": [{"args": ["--param1", "$(inputs.params.produce-str-Output)"],
       "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
@@ -117,8 +117,8 @@ metadata:
       = argparse.ArgumentParser(prog=''Consume'', description='''')\\n_parser.add_argument(\\\"--param1\\\",
       dest=\\\"param1\\\", type=str, required=True, default=argparse.SUPPRESS)\\n_parsed_args
       = vars(_parser.parse_args())\\n\\n_outputs = consume(**_parsed_args)\\n\"],
-      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\"}], \"name\":
-      \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
+      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\", \"type\": \"String\"}],
+      \"name\": \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
       "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
       ""}}, "params": [{"name": "produce-list-of-ints-Output", "type": "string"}],
       "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-ints-Output)"],
@@ -137,8 +137,8 @@ metadata:
       = argparse.ArgumentParser(prog=''Consume'', description='''')\\n_parser.add_argument(\\\"--param1\\\",
       dest=\\\"param1\\\", type=str, required=True, default=argparse.SUPPRESS)\\n_parsed_args
       = vars(_parser.parse_args())\\n\\n_outputs = consume(**_parsed_args)\\n\"],
-      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\"}], \"name\":
-      \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
+      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\", \"type\": \"String\"}],
+      \"name\": \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
       "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
       ""}}, "params": [{"name": "produce-list-of-ints-Output-loop-item", "type": "string"}],
       "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-ints-Output-loop-item)"],
@@ -161,8 +161,8 @@ metadata:
       argparse\\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\\n_parser.add_argument(\\\"--param1\\\",
       dest=\\\"param1\\\", type=str, required=True, default=argparse.SUPPRESS)\\n_parsed_args
       = vars(_parser.parse_args())\\n\\n_outputs = consume(**_parsed_args)\\n\"],
-      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\"}], \"name\":
-      \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
+      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\", \"type\": \"String\"}],
+      \"name\": \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
       "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
       ""}}, "params": [{"name": "produce-list-of-dicts-Output", "type": "string"}],
       "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-dicts-Output)"],
@@ -181,8 +181,8 @@ metadata:
       = argparse.ArgumentParser(prog=''Consume'', description='''')\\n_parser.add_argument(\\\"--param1\\\",
       dest=\\\"param1\\\", type=str, required=True, default=argparse.SUPPRESS)\\n_parsed_args
       = vars(_parser.parse_args())\\n\\n_outputs = consume(**_parsed_args)\\n\"],
-      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\"}], \"name\":
-      \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
+      \"image\": \"python:3.7\"}}, \"inputs\": [{\"name\": \"param1\", \"type\": \"String\"}],
+      \"name\": \"Consume\"}", "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
       "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
       ""}}, "params": [{"name": "produce-list-of-dicts-Output-loop-item-subvar-aaa",
       "type": "string"}], "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-dicts-Output-loop-item-subvar-aaa)"],

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.py
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.py
@@ -12,16 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp import dsl
+from kfp import dsl, components
 
 
-def print_op(msg):
+def print_op(msg: str):
     """Print a message."""
-    return dsl.ContainerOp(
-        name='Print',
-        image='alpine:3.6',
-        command=['echo', msg],
-    )
+    return components.load_component_from_text("""
+    name: print
+    description: print out msg
+    inputs:
+      - {name: msg, type: String}
+    implementation:
+      container:
+        image: alpine:3.6
+        command:
+        - echo
+        - {inputValue: msg}
+    """)(msg=msg)
 
 
 def add_annotation_and_label(op):
@@ -31,7 +38,7 @@ def add_annotation_and_label(op):
 
 
 @dsl.pipeline(
-    name='Pipeline transformer',
+    name='pipeline-transformer',
     description='The pipeline shows how to apply functions to all ops in the pipeline by pipeline transformers'
 )
 def transform_pipeline():

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
@@ -26,7 +26,7 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline shows how
       to apply functions to all ops in the pipeline by pipeline transformers", "name":
-      "Pipeline transformer"}'
+      "pipeline-transformer"}'
 spec:
   pipelineSpec:
     tasks:
@@ -46,6 +46,10 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             hobby: football
+            pipelines.kubeflow.org/component_spec: '{"description": "print out msg",
+              "implementation": {"container": {"command": ["echo", {"inputValue":
+              "msg"}], "image": "alpine:3.6"}}, "inputs": [{"name": "msg", "type":
+              "String"}], "name": "print"}'
             tekton.dev/template: ''
       timeout: 0s
     - name: print-2
@@ -64,6 +68,10 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             hobby: football
+            pipelines.kubeflow.org/component_spec: '{"description": "print out msg",
+              "implementation": {"container": {"command": ["echo", {"inputValue":
+              "msg"}], "image": "alpine:3.6"}}, "inputs": [{"name": "msg", "type":
+              "String"}], "name": "print"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers_noninlined.yaml
@@ -26,7 +26,7 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline shows how
       to apply functions to all ops in the pipeline by pipeline transformers", "name":
-      "Pipeline transformer"}'
+      "pipeline-transformer"}'
 spec:
   pipelineSpec:
     tasks:
@@ -46,6 +46,10 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             hobby: football
+            pipelines.kubeflow.org/component_spec: '{"description": "print out msg",
+              "implementation": {"container": {"command": ["echo", {"inputValue":
+              "msg"}], "image": "alpine:3.6"}}, "inputs": [{"name": "msg", "type":
+              "String"}], "name": "print"}'
             tekton.dev/template: ''
       timeout: 0s
     - name: print-2
@@ -64,6 +68,10 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             hobby: football
+            pipelines.kubeflow.org/component_spec: '{"description": "print out msg",
+              "implementation": {"container": {"command": ["echo", {"inputValue":
+              "msg"}], "image": "alpine:3.6"}}, "inputs": [{"name": "msg", "type":
+              "String"}], "name": "print"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/pipelineparams.py
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import kfp.dsl as dsl
+from kfp import dsl
 from kubernetes.client.models import V1EnvVar
 
 
-@dsl.pipeline(name='PipelineParams', description='A pipeline with multiple pipeline params.')
+@dsl.pipeline(name='pipeline-params', description='A pipeline with multiple pipeline params.')
 def pipelineparams_pipeline(tag: str = 'latest', sleep_ms: int = 10):
 
     echo = dsl.Sidecar(

--- a/sdk/python/tests/compiler/testdata/pipelineparams.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.yaml
@@ -15,7 +15,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: pipelineparams
+  name: pipeline-params
   annotations:
     tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/downloaded_resultOutput.tgz",
       "name": "download-downloaded_resultOutput", "path": "/tmp/results.txt"}]}'
@@ -30,7 +30,7 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with multiple
       pipeline params.", "inputs": [{"default": "latest", "name": "tag", "optional":
       true, "type": "String"}, {"default": "10", "name": "sleep_ms", "optional": true,
-      "type": "Integer"}], "name": "PipelineParams"}'
+      "type": "Integer"}], "name": "pipeline-params"}'
 spec:
   params:
   - name: sleep_ms

--- a/sdk/python/tests/compiler/testdata/pipelineparams_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams_noninlined.yaml
@@ -15,7 +15,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: pipelineparams
+  name: pipeline-params
   annotations:
     tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/downloaded_resultOutput.tgz",
       "name": "download-downloaded_resultOutput", "path": "/tmp/results.txt"}]}'
@@ -30,7 +30,7 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with multiple
       pipeline params.", "inputs": [{"default": "latest", "name": "tag", "optional":
       true, "type": "String"}, {"default": "10", "name": "sleep_ms", "optional": true,
-      "type": "Integer"}], "name": "PipelineParams"}'
+      "type": "Integer"}], "name": "pipeline-params"}'
 spec:
   params:
   - name: sleep_ms

--- a/sdk/python/tests/compiler/testdata/recur_cond.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_cond.yaml
@@ -18,7 +18,7 @@ metadata:
   name: recur-and-condition
   annotations:
     tekton.dev/output_artifacts: '{"print-iter": [{"key": "artifacts/$PIPELINERUN/print-iter/stdout.tgz",
-      "name": "print-iter-stdout", "path": "/tmp/stdout"}]}'
+      "name": "print-iter-stdout", "path": "/tmp/outputs/stdout/data"}]}'
     tekton.dev/input_artifacts: '{"print-iter": [{"name": "condition-cel-outcome",
       "parent_task": "condition-cel"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -36,17 +36,22 @@ metadata:
       "$(params.iter_num) - 1"}], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
       "kind": "CEL", "name": "cel_condition"}}, {"name": "print-iter", "params": [{"name":
       "condition-cel-outcome", "value": "$(tasks.condition-cel.results.outcome)"}],
-      "taskSpec": {"metadata": {"annotations": {"tekton.dev/template": ""}, "labels":
+      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec":
+      "{\"description\": \"print msg\", \"implementation\": {\"container\": {\"args\":
+      [\"echo $0 > $1\\n\", {\"inputValue\": \"msg\"}, {\"outputPath\": \"stdout\"}],
+      \"command\": [\"sh\", \"-c\"], \"image\": \"alpine:3.6\"}}, \"inputs\": [{\"name\":
+      \"msg\", \"type\": \"String\"}], \"name\": \"print-iter\", \"outputs\": [{\"name\":
+      \"stdout\", \"type\": \"String\"}]}", "tekton.dev/template": ""}, "labels":
       {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "condition-cel-outcome",
-      "type": "string"}], "results": [{"description": "/tmp/stdout", "name": "stdout"}],
-      "steps": [{"command": ["echo", "Iter: $(inputs.params.condition-cel-outcome)",
-      ">", "$(results.stdout.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
-      "0s"}, {"name": "recur", "params": [{"name": "iter_num", "value": "$(tasks.condition-cel.results.outcome)"},
-      {"name": "just_one_iteration", "value": ["1"]}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1",
-      "kind": "PipelineLoop", "name": "recur-and-condition-graph-recur-1"}, "when":
-      [{"input": "$(tasks.condition-cel.results.outcome)", "operator": "notin", "values":
-      ["0"]}]}]}}}]'
+      "type": "string"}], "results": [{"description": "/tmp/outputs/stdout/data",
+      "name": "stdout"}], "steps": [{"args": ["echo $0 > $1\n", "Iter: $(inputs.params.condition-cel-outcome)",
+      "$(results.stdout.path)"], "command": ["sh", "-c"], "image": "alpine:3.6", "name":
+      "main"}]}, "timeout": "0s"}, {"name": "recur", "params": [{"name": "iter_num",
+      "value": "$(tasks.condition-cel.results.outcome)"}, {"name": "just_one_iteration",
+      "value": ["1"]}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1", "kind":
+      "PipelineLoop", "name": "recur-and-condition-graph-recur-1"}, "when": [{"input":
+      "$(tasks.condition-cel.results.outcome)", "operator": "notin", "values": ["0"]}]}]}}}]'
 spec:
   params:
   - name: iter_num

--- a/sdk/python/tests/compiler/testdata/recur_cond_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_cond_noninlined.yaml
@@ -18,7 +18,7 @@ metadata:
   name: recur-and-condition
   annotations:
     tekton.dev/output_artifacts: '{"print-iter": [{"key": "artifacts/$PIPELINERUN/print-iter/stdout.tgz",
-      "name": "print-iter-stdout", "path": "/tmp/stdout"}]}'
+      "name": "print-iter-stdout", "path": "/tmp/outputs/stdout/data"}]}'
     tekton.dev/input_artifacts: '{"print-iter": [{"name": "condition-cel-outcome",
       "parent_task": "condition-cel"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -36,14 +36,19 @@ metadata:
       "$(params.iter_num) - 1"}], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
       "kind": "CEL", "name": "cel_condition"}}, {"name": "print-iter", "params": [{"name":
       "condition-cel-outcome", "value": "$(tasks.condition-cel.results.outcome)"}],
-      "taskSpec": {"metadata": {"annotations": {"tekton.dev/template": ""}, "labels":
+      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec":
+      "{\"description\": \"print msg\", \"implementation\": {\"container\": {\"args\":
+      [\"echo $0 > $1\\n\", {\"inputValue\": \"msg\"}, {\"outputPath\": \"stdout\"}],
+      \"command\": [\"sh\", \"-c\"], \"image\": \"alpine:3.6\"}}, \"inputs\": [{\"name\":
+      \"msg\", \"type\": \"String\"}], \"name\": \"print-iter\", \"outputs\": [{\"name\":
+      \"stdout\", \"type\": \"String\"}]}", "tekton.dev/template": ""}, "labels":
       {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "condition-cel-outcome",
-      "type": "string"}], "results": [{"description": "/tmp/stdout", "name": "stdout"}],
-      "steps": [{"command": ["echo", "Iter: $(inputs.params.condition-cel-outcome)",
-      ">", "$(results.stdout.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
-      "0s"}, {"name": "recur", "params": [{"name": "just_one_iteration", "value":
-      ["1"]}, {"name": "iter_num", "value": "$(tasks.condition-cel.results.outcome)"}],
+      "type": "string"}], "results": [{"description": "/tmp/outputs/stdout/data",
+      "name": "stdout"}], "steps": [{"args": ["echo $0 > $1\n", "Iter: $(inputs.params.condition-cel-outcome)",
+      "$(results.stdout.path)"], "command": ["sh", "-c"], "image": "alpine:3.6", "name":
+      "main"}]}, "timeout": "0s"}, {"name": "recur", "params": [{"name": "just_one_iteration",
+      "value": ["1"]}, {"name": "iter_num", "value": "$(tasks.condition-cel.results.outcome)"}],
       "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop",
       "name": "recur-and-condition-graph-recur-1"}, "when": [{"input": "$(tasks.condition-cel.results.outcome)",
       "operator": "notin", "values": ["0"]}]}]}}}]'

--- a/sdk/python/tests/compiler/testdata/recur_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested.yaml
@@ -18,10 +18,10 @@ metadata:
   name: nested-recursion-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output.tgz",
-      "name": "flip-coin-output", "path": "/tmp/output"}], "flip-coin-2": [{"key":
-      "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
-      "path": "/tmp/output"}], "flip-coin-3": [{"key": "artifacts/$PIPELINERUN/flip-coin-3/output.tgz",
-      "name": "flip-coin-3-output", "path": "/tmp/output"}]}'
+      "name": "flip-coin-output", "path": "/tmp/outputs/output/data"}], "flip-coin-2":
+      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
+      "path": "/tmp/outputs/output/data"}], "flip-coin-3": [{"key": "artifacts/$PIPELINERUN/flip-coin-3/output.tgz",
+      "name": "flip-coin-3-output", "path": "/tmp/outputs/output/data"}]}'
     tekton.dev/input_artifacts: '{"print": [{"name": "flip-coin-output", "parent_task":
       "flip-coin"}], "print-2": [{"name": "flip-coin-output", "parent_task": "flip-coin"}],
       "print-3": [{"name": "flip-coin-output", "parent_task": "flip-coin"}]}'
@@ -34,25 +34,34 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use graph_component
       and nested recursion.", "inputs": [{"default": "12", "name": "maxVal", "optional":
-      true}], "name": "nested recursion pipeline"}'
+      true, "type": "Integer"}], "name": "nested-recursion-pipeline"}'
     tekton.dev/resource_templates: '[{"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "metadata": {"name": "nested-recursion-pipeline-flip-component-1"},
       "spec": {"iterateParam": "just_one_iteration", "pipelineSpec": {"params": [{"name":
       "flip-coin-output", "type": "string"}, {"name": "just_one_iteration", "type":
       "string"}, {"name": "maxVal", "type": "string"}], "tasks": [{"name": "print-2",
       "params": [{"name": "flip-coin-output", "value": "$(params.flip-coin-output)"}],
-      "taskSpec": {"metadata": {"annotations": {"tekton.dev/template": ""}, "labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec":
+      "{\"description\": \"print msg\", \"implementation\": {\"container\": {\"command\":
+      [\"echo\", {\"inputValue\": \"msg\"}], \"image\": \"alpine:3.6\"}}, \"inputs\":
+      [{\"name\": \"msg\", \"type\": \"String\"}], \"name\": \"print\"}", "tekton.dev/template":
+      ""}, "labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "flip-coin-output",
       "type": "string"}], "steps": [{"command": ["echo", "$(inputs.params.flip-coin-output)"],
       "image": "alpine:3.6", "name": "main"}]}, "timeout": "0s", "when": [{"input":
       "$(tasks.condition-5.results.outcome)", "operator": "in", "values": ["true"]}]},
       {"name": "flip-coin-3", "runAfter": ["print-2"], "taskSpec": {"metadata": {"annotations":
-      {"tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/output", "name": "output"}], "steps":
-      [{"args": ["python -c \"import random; result = ''heads'' if random.randint(0,1)
-      == 0 else ''tails''; print(result)\" | tee $(results.output.path)"], "command":
+      {"pipelines.kubeflow.org/component_spec": "{\"description\": \"flip coin\",
+      \"implementation\": {\"container\": {\"args\": [\"python -c \\\"import random;
+      result = ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\\\"
+      | tee $0\\n\", {\"outputPath\": \"output\"}], \"command\": [\"sh\", \"-c\"],
+      \"image\": \"python:alpine3.6\"}}, \"name\": \"flip-coin\", \"outputs\": [{\"name\":
+      \"output\", \"type\": \"String\"}]}", "tekton.dev/template": ""}, "labels":
+      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "", "pipelines.kubeflow.org/pipelinename": ""}}, "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output"}], "steps": [{"args": ["python
+      -c \"import random; result = ''heads'' if random.randint(0,1) == 0           else
+      ''tails''; print(result)\" | tee $0\n", "$(results.output.path)"], "command":
       ["sh", "-c"], "image": "python:alpine3.6", "name": "main"}]}, "timeout": "0s",
       "when": [{"input": "$(tasks.condition-5.results.outcome)", "operator": "in",
       "values": ["true"]}]}, {"name": "condition-2", "params": [{"name": "operand1",
@@ -89,18 +98,27 @@ metadata:
       "flip-coin-output", "type": "string"}, {"name": "just_one_iteration", "type":
       "string"}, {"name": "maxVal", "type": "string"}], "tasks": [{"name": "print",
       "params": [{"name": "flip-coin-output", "value": "$(params.flip-coin-output)"}],
-      "taskSpec": {"metadata": {"annotations": {"tekton.dev/template": ""}, "labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec":
+      "{\"description\": \"print msg\", \"implementation\": {\"container\": {\"command\":
+      [\"echo\", {\"inputValue\": \"msg\"}], \"image\": \"alpine:3.6\"}}, \"inputs\":
+      [{\"name\": \"msg\", \"type\": \"String\"}], \"name\": \"print\"}", "tekton.dev/template":
+      ""}, "labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "flip-coin-output",
       "type": "string"}], "steps": [{"command": ["echo", "$(inputs.params.flip-coin-output)"],
       "image": "alpine:3.6", "name": "main"}]}, "timeout": "0s", "when": [{"input":
       "$(tasks.condition-4.results.outcome)", "operator": "in", "values": ["true"]}]},
       {"name": "flip-coin-2", "runAfter": ["print"], "taskSpec": {"metadata": {"annotations":
-      {"tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/output", "name": "output"}], "steps":
-      [{"args": ["python -c \"import random; result = ''heads'' if random.randint(0,1)
-      == 0 else ''tails''; print(result)\" | tee $(results.output.path)"], "command":
+      {"pipelines.kubeflow.org/component_spec": "{\"description\": \"flip coin\",
+      \"implementation\": {\"container\": {\"args\": [\"python -c \\\"import random;
+      result = ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\\\"
+      | tee $0\\n\", {\"outputPath\": \"output\"}], \"command\": [\"sh\", \"-c\"],
+      \"image\": \"python:alpine3.6\"}}, \"name\": \"flip-coin\", \"outputs\": [{\"name\":
+      \"output\", \"type\": \"String\"}]}", "tekton.dev/template": ""}, "labels":
+      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "", "pipelines.kubeflow.org/pipelinename": ""}}, "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output"}], "steps": [{"args": ["python
+      -c \"import random; result = ''heads'' if random.randint(0,1) == 0           else
+      ''tails''; print(result)\" | tee $0\n", "$(results.output.path)"], "command":
       ["sh", "-c"], "image": "python:alpine3.6", "name": "main"}]}, "timeout": "0s",
       "when": [{"input": "$(tasks.condition-4.results.outcome)", "operator": "in",
       "values": ["true"]}]}, {"name": "condition-4", "params": [{"name": "operand1",
@@ -132,21 +150,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output
-          description: /tmp/output
+          description: /tmp/outputs/output/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output"}], "command": ["sh", "-c"], "image":
+              "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name": "output",
+              "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: print-3
@@ -168,6 +193,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "print msg", "implementation":
+              {"container": {"command": ["echo", {"inputValue": "msg"}], "image":
+              "alpine:3.6"}}, "inputs": [{"name": "msg", "type": "String"}], "name":
+              "print"}'
             tekton.dev/template: ''
       runAfter:
       - nested-recursion-pipeline-flip-component-1

--- a/sdk/python/tests/compiler/testdata/recur_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested_noninlined.yaml
@@ -18,10 +18,10 @@ metadata:
   name: nested-recursion-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output.tgz",
-      "name": "flip-coin-output", "path": "/tmp/output"}], "flip-coin-2": [{"key":
-      "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
-      "path": "/tmp/output"}], "flip-coin-3": [{"key": "artifacts/$PIPELINERUN/flip-coin-3/output.tgz",
-      "name": "flip-coin-3-output", "path": "/tmp/output"}]}'
+      "name": "flip-coin-output", "path": "/tmp/outputs/output/data"}], "flip-coin-2":
+      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
+      "path": "/tmp/outputs/output/data"}], "flip-coin-3": [{"key": "artifacts/$PIPELINERUN/flip-coin-3/output.tgz",
+      "name": "flip-coin-3-output", "path": "/tmp/outputs/output/data"}]}'
     tekton.dev/input_artifacts: '{"print": [{"name": "flip-coin-output", "parent_task":
       "flip-coin"}], "print-2": [{"name": "flip-coin-output", "parent_task": "flip-coin"}],
       "print-3": [{"name": "flip-coin-output", "parent_task": "flip-coin"}]}'
@@ -34,25 +34,34 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use graph_component
       and nested recursion.", "inputs": [{"default": "12", "name": "maxVal", "optional":
-      true}], "name": "nested recursion pipeline"}'
+      true, "type": "Integer"}], "name": "nested-recursion-pipeline"}'
     tekton.dev/resource_templates: '[{"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "metadata": {"name": "nested-recursion-pipeline-flip-component-1"},
       "spec": {"iterateParam": "just_one_iteration", "pipelineSpec": {"params": [{"name":
       "flip-coin-output", "type": "string"}, {"name": "just_one_iteration", "type":
       "string"}, {"name": "maxVal", "type": "string"}], "tasks": [{"name": "print-2",
       "params": [{"name": "flip-coin-output", "value": "$(params.flip-coin-output)"}],
-      "taskSpec": {"metadata": {"annotations": {"tekton.dev/template": ""}, "labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec":
+      "{\"description\": \"print msg\", \"implementation\": {\"container\": {\"command\":
+      [\"echo\", {\"inputValue\": \"msg\"}], \"image\": \"alpine:3.6\"}}, \"inputs\":
+      [{\"name\": \"msg\", \"type\": \"String\"}], \"name\": \"print\"}", "tekton.dev/template":
+      ""}, "labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "flip-coin-output",
       "type": "string"}], "steps": [{"command": ["echo", "$(inputs.params.flip-coin-output)"],
       "image": "alpine:3.6", "name": "main"}]}, "timeout": "0s", "when": [{"input":
       "$(tasks.condition-5.results.outcome)", "operator": "in", "values": ["true"]}]},
       {"name": "flip-coin-3", "runAfter": ["print-2"], "taskSpec": {"metadata": {"annotations":
-      {"tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/output", "name": "output"}], "steps":
-      [{"args": ["python -c \"import random; result = ''heads'' if random.randint(0,1)
-      == 0 else ''tails''; print(result)\" | tee $(results.output.path)"], "command":
+      {"pipelines.kubeflow.org/component_spec": "{\"description\": \"flip coin\",
+      \"implementation\": {\"container\": {\"args\": [\"python -c \\\"import random;
+      result = ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\\\"
+      | tee $0\\n\", {\"outputPath\": \"output\"}], \"command\": [\"sh\", \"-c\"],
+      \"image\": \"python:alpine3.6\"}}, \"name\": \"flip-coin\", \"outputs\": [{\"name\":
+      \"output\", \"type\": \"String\"}]}", "tekton.dev/template": ""}, "labels":
+      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "", "pipelines.kubeflow.org/pipelinename": ""}}, "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output"}], "steps": [{"args": ["python
+      -c \"import random; result = ''heads'' if random.randint(0,1) == 0           else
+      ''tails''; print(result)\" | tee $0\n", "$(results.output.path)"], "command":
       ["sh", "-c"], "image": "python:alpine3.6", "name": "main"}]}, "timeout": "0s",
       "when": [{"input": "$(tasks.condition-5.results.outcome)", "operator": "in",
       "values": ["true"]}]}, {"name": "condition-2", "params": [{"name": "operand1",
@@ -89,18 +98,27 @@ metadata:
       "flip-coin-output", "type": "string"}, {"name": "just_one_iteration", "type":
       "string"}, {"name": "maxVal", "type": "string"}], "tasks": [{"name": "print",
       "params": [{"name": "flip-coin-output", "value": "$(params.flip-coin-output)"}],
-      "taskSpec": {"metadata": {"annotations": {"tekton.dev/template": ""}, "labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec":
+      "{\"description\": \"print msg\", \"implementation\": {\"container\": {\"command\":
+      [\"echo\", {\"inputValue\": \"msg\"}], \"image\": \"alpine:3.6\"}}, \"inputs\":
+      [{\"name\": \"msg\", \"type\": \"String\"}], \"name\": \"print\"}", "tekton.dev/template":
+      ""}, "labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "flip-coin-output",
       "type": "string"}], "steps": [{"command": ["echo", "$(inputs.params.flip-coin-output)"],
       "image": "alpine:3.6", "name": "main"}]}, "timeout": "0s", "when": [{"input":
       "$(tasks.condition-4.results.outcome)", "operator": "in", "values": ["true"]}]},
       {"name": "flip-coin-2", "runAfter": ["print"], "taskSpec": {"metadata": {"annotations":
-      {"tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/output", "name": "output"}], "steps":
-      [{"args": ["python -c \"import random; result = ''heads'' if random.randint(0,1)
-      == 0 else ''tails''; print(result)\" | tee $(results.output.path)"], "command":
+      {"pipelines.kubeflow.org/component_spec": "{\"description\": \"flip coin\",
+      \"implementation\": {\"container\": {\"args\": [\"python -c \\\"import random;
+      result = ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\\\"
+      | tee $0\\n\", {\"outputPath\": \"output\"}], \"command\": [\"sh\", \"-c\"],
+      \"image\": \"python:alpine3.6\"}}, \"name\": \"flip-coin\", \"outputs\": [{\"name\":
+      \"output\", \"type\": \"String\"}]}", "tekton.dev/template": ""}, "labels":
+      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "", "pipelines.kubeflow.org/pipelinename": ""}}, "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output"}], "steps": [{"args": ["python
+      -c \"import random; result = ''heads'' if random.randint(0,1) == 0           else
+      ''tails''; print(result)\" | tee $0\n", "$(results.output.path)"], "command":
       ["sh", "-c"], "image": "python:alpine3.6", "name": "main"}]}, "timeout": "0s",
       "when": [{"input": "$(tasks.condition-4.results.outcome)", "operator": "in",
       "values": ["true"]}]}, {"name": "condition-4", "params": [{"name": "operand1",
@@ -132,21 +150,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output
-          description: /tmp/output
+          description: /tmp/outputs/output/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output"}], "command": ["sh", "-c"], "image":
+              "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name": "output",
+              "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: print-3
@@ -168,6 +193,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "print msg", "implementation":
+              {"container": {"command": ["echo", {"inputValue": "msg"}], "image":
+              "alpine:3.6"}}, "inputs": [{"name": "msg", "type": "String"}], "name":
+              "print"}'
             tekton.dev/template: ''
       runAfter:
       - nested-recursion-pipeline-flip-component-1

--- a/sdk/python/tests/compiler/testdata/recur_nested_separate.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested_separate.yaml
@@ -18,10 +18,10 @@ metadata:
   name: nested-recursion-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output.tgz",
-      "name": "flip-coin-output", "path": "/tmp/output"}], "flip-coin-2": [{"key":
-      "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
-      "path": "/tmp/output"}], "flip-coin-3": [{"key": "artifacts/$PIPELINERUN/flip-coin-3/output.tgz",
-      "name": "flip-coin-3-output", "path": "/tmp/output"}]}'
+      "name": "flip-coin-output", "path": "/tmp/outputs/output/data"}], "flip-coin-2":
+      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
+      "path": "/tmp/outputs/output/data"}], "flip-coin-3": [{"key": "artifacts/$PIPELINERUN/flip-coin-3/output.tgz",
+      "name": "flip-coin-3-output", "path": "/tmp/outputs/output/data"}]}'
     tekton.dev/input_artifacts: '{"print": [{"name": "flip-coin-output", "parent_task":
       "flip-coin"}], "print-2": [{"name": "flip-coin-output", "parent_task": "flip-coin"}],
       "print-3": [{"name": "flip-coin-output", "parent_task": "flip-coin"}]}'
@@ -34,7 +34,7 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use graph_component
       and nested recursion.", "inputs": [{"default": "12", "name": "maxVal", "optional":
-      true}], "name": "nested recursion pipeline"}'
+      true, "type": "Integer"}], "name": "nested-recursion-pipeline"}'
 spec:
   params:
   - name: maxVal
@@ -49,21 +49,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output
-          description: /tmp/output
+          description: /tmp/outputs/output/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output"}], "command": ["sh", "-c"], "image":
+              "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name": "output",
+              "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: print-3
@@ -85,6 +92,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "print msg", "implementation":
+              {"container": {"command": ["echo", {"inputValue": "msg"}], "image":
+              "alpine:3.6"}}, "inputs": [{"name": "msg", "type": "String"}], "name":
+              "print"}'
             tekton.dev/template: ''
       runAfter:
       - nested-recursion-pipeline-flip-component-1

--- a/sdk/python/tests/compiler/testdata/recur_nested_separate_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested_separate_noninlined.yaml
@@ -18,10 +18,10 @@ metadata:
   name: nested-recursion-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output.tgz",
-      "name": "flip-coin-output", "path": "/tmp/output"}], "flip-coin-2": [{"key":
-      "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
-      "path": "/tmp/output"}], "flip-coin-3": [{"key": "artifacts/$PIPELINERUN/flip-coin-3/output.tgz",
-      "name": "flip-coin-3-output", "path": "/tmp/output"}]}'
+      "name": "flip-coin-output", "path": "/tmp/outputs/output/data"}], "flip-coin-2":
+      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
+      "path": "/tmp/outputs/output/data"}], "flip-coin-3": [{"key": "artifacts/$PIPELINERUN/flip-coin-3/output.tgz",
+      "name": "flip-coin-3-output", "path": "/tmp/outputs/output/data"}]}'
     tekton.dev/input_artifacts: '{"print": [{"name": "flip-coin-output", "parent_task":
       "flip-coin"}], "print-2": [{"name": "flip-coin-output", "parent_task": "flip-coin"}],
       "print-3": [{"name": "flip-coin-output", "parent_task": "flip-coin"}]}'
@@ -34,7 +34,7 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use graph_component
       and nested recursion.", "inputs": [{"default": "12", "name": "maxVal", "optional":
-      true}], "name": "nested recursion pipeline"}'
+      true, "type": "Integer"}], "name": "nested-recursion-pipeline"}'
 spec:
   params:
   - name: maxVal
@@ -49,21 +49,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output
-          description: /tmp/output
+          description: /tmp/outputs/output/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output"}], "command": ["sh", "-c"], "image":
+              "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name": "output",
+              "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: print-3
@@ -85,6 +92,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "print msg", "implementation":
+              {"container": {"command": ["echo", {"inputValue": "msg"}], "image":
+              "alpine:3.6"}}, "inputs": [{"name": "msg", "type": "String"}], "name":
+              "print"}'
             tekton.dev/template: ''
       runAfter:
       - nested-recursion-pipeline-flip-component-1

--- a/sdk/python/tests/compiler/testdata/recursion_while.py
+++ b/sdk/python/tests/compiler/testdata/recursion_while.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp import dsl
+from kfp import dsl, components
 from kfp_tekton.compiler import TektonCompiler
 
 
@@ -26,23 +26,39 @@ TektonCompiler._get_unique_id_code = Coder.empty
 
 def flip_coin_op():
     """Flip a coin and output heads or tails randomly."""
-    return dsl.ContainerOp(
-        name='Flip coin',
-        image='python:alpine3.6',
-        command=['sh', '-c'],
-        arguments=['python -c "import random; result = \'heads\' if random.randint(0,1) == 0 '
-                  'else \'tails\'; print(result)" | tee /tmp/output'],
-        file_outputs={'output': '/tmp/output'}
-    )
+    return components.load_component_from_text("""
+    name: flip-coin
+    description: flip coin
+    outputs:
+      - {name: output, type: String}
+    implementation:
+      container:
+        image: python:alpine3.6
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          python -c "import random; result = \'heads\' if random.randint(0,1) == 0 \
+          else 'tails'; print(result)" | tee $0
+        - {outputPath: output}
+    """)()
 
 
-def print_op(msg):
+def print_op(msg: str):
     """Print a message."""
-    return dsl.ContainerOp(
-        name='Print',
-        image='alpine:3.6',
-        command=['echo', msg],
-    )
+    return components.load_component_from_text("""
+    name: print
+    description: print msg
+    inputs:
+      - {name: msg, type: String}
+    implementation:
+      container:
+        image: alpine:3.6
+        command:
+        - echo
+        - {inputValue: msg}
+    """)(msg=msg)
 
 
 @dsl._component.graph_component
@@ -54,10 +70,10 @@ def flip_component(flip_result, maxVal):
 
 
 @dsl.pipeline(
-    name='recursion pipeline',
+    name='recursion-pipeline',
     description='shows how to use graph_component and recursion.'
 )
-def flipcoin(maxVal=12):
+def flipcoin(maxVal: int = 12):
   flip_out = flip_coin_op()
   flip_loop = flip_component(flip_out.output, maxVal)
   print_op('cool, it is over. %s' % flip_out.output).after(flip_loop)

--- a/sdk/python/tests/compiler/testdata/recursion_while.yaml
+++ b/sdk/python/tests/compiler/testdata/recursion_while.yaml
@@ -18,9 +18,9 @@ metadata:
   name: recursion-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output.tgz",
-      "name": "flip-coin-output", "path": "/tmp/output"}], "flip-coin-2": [{"key":
-      "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
-      "path": "/tmp/output"}]}'
+      "name": "flip-coin-output", "path": "/tmp/outputs/output/data"}], "flip-coin-2":
+      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
+      "path": "/tmp/outputs/output/data"}]}'
     tekton.dev/input_artifacts: '{"print": [{"name": "flip-coin-output", "parent_task":
       "flip-coin"}], "print-2": [{"name": "flip-coin-output", "parent_task": "flip-coin"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -32,25 +32,34 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use graph_component
       and recursion.", "inputs": [{"default": "12", "name": "maxVal", "optional":
-      true}], "name": "recursion pipeline"}'
+      true, "type": "Integer"}], "name": "recursion-pipeline"}'
     tekton.dev/resource_templates: '[{"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "metadata": {"name": "recursion-pipeline-flip-component-1"},
       "spec": {"iterateParam": "just_one_iteration", "pipelineSpec": {"params": [{"name":
       "flip-coin-output", "type": "string"}, {"name": "just_one_iteration", "type":
       "string"}, {"name": "maxVal", "type": "string"}], "tasks": [{"name": "print",
       "params": [{"name": "flip-coin-output", "value": "$(params.flip-coin-output)"}],
-      "taskSpec": {"metadata": {"annotations": {"tekton.dev/template": ""}, "labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec":
+      "{\"description\": \"print msg\", \"implementation\": {\"container\": {\"command\":
+      [\"echo\", {\"inputValue\": \"msg\"}], \"image\": \"alpine:3.6\"}}, \"inputs\":
+      [{\"name\": \"msg\", \"type\": \"String\"}], \"name\": \"print\"}", "tekton.dev/template":
+      ""}, "labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "flip-coin-output",
       "type": "string"}], "steps": [{"command": ["echo", "$(inputs.params.flip-coin-output)"],
       "image": "alpine:3.6", "name": "main"}]}, "timeout": "0s", "when": [{"input":
       "$(tasks.condition-2.results.outcome)", "operator": "in", "values": ["true"]}]},
       {"name": "flip-coin-2", "runAfter": ["print"], "taskSpec": {"metadata": {"annotations":
-      {"tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/output", "name": "output"}], "steps":
-      [{"args": ["python -c \"import random; result = ''heads'' if random.randint(0,1)
-      == 0 else ''tails''; print(result)\" | tee $(results.output.path)"], "command":
+      {"pipelines.kubeflow.org/component_spec": "{\"description\": \"flip coin\",
+      \"implementation\": {\"container\": {\"args\": [\"python -c \\\"import random;
+      result = ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\\\"
+      | tee $0\\n\", {\"outputPath\": \"output\"}], \"command\": [\"sh\", \"-c\"],
+      \"image\": \"python:alpine3.6\"}}, \"name\": \"flip-coin\", \"outputs\": [{\"name\":
+      \"output\", \"type\": \"String\"}]}", "tekton.dev/template": ""}, "labels":
+      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "", "pipelines.kubeflow.org/pipelinename": ""}}, "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output"}], "steps": [{"args": ["python
+      -c \"import random; result = ''heads'' if random.randint(0,1) == 0           else
+      ''tails''; print(result)\" | tee $0\n", "$(results.output.path)"], "command":
       ["sh", "-c"], "image": "python:alpine3.6", "name": "main"}]}, "timeout": "0s",
       "when": [{"input": "$(tasks.condition-2.results.outcome)", "operator": "in",
       "values": ["true"]}]}, {"name": "condition-2", "params": [{"name": "operand1",
@@ -82,21 +91,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output
-          description: /tmp/output
+          description: /tmp/outputs/output/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output"}], "command": ["sh", "-c"], "image":
+              "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name": "output",
+              "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: print-2
@@ -118,6 +134,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "print msg", "implementation":
+              {"container": {"command": ["echo", {"inputValue": "msg"}], "image":
+              "alpine:3.6"}}, "inputs": [{"name": "msg", "type": "String"}], "name":
+              "print"}'
             tekton.dev/template: ''
       runAfter:
       - recursion-pipeline-flip-component-1

--- a/sdk/python/tests/compiler/testdata/recursion_while_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/recursion_while_noninlined.yaml
@@ -18,9 +18,9 @@ metadata:
   name: recursion-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output.tgz",
-      "name": "flip-coin-output", "path": "/tmp/output"}], "flip-coin-2": [{"key":
-      "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
-      "path": "/tmp/output"}]}'
+      "name": "flip-coin-output", "path": "/tmp/outputs/output/data"}], "flip-coin-2":
+      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output.tgz", "name": "flip-coin-2-output",
+      "path": "/tmp/outputs/output/data"}]}'
     tekton.dev/input_artifacts: '{"print": [{"name": "flip-coin-output", "parent_task":
       "flip-coin"}], "print-2": [{"name": "flip-coin-output", "parent_task": "flip-coin"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -32,25 +32,34 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use graph_component
       and recursion.", "inputs": [{"default": "12", "name": "maxVal", "optional":
-      true}], "name": "recursion pipeline"}'
+      true, "type": "Integer"}], "name": "recursion-pipeline"}'
     tekton.dev/resource_templates: '[{"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "metadata": {"name": "recursion-pipeline-flip-component-1"},
       "spec": {"iterateParam": "just_one_iteration", "pipelineSpec": {"params": [{"name":
       "flip-coin-output", "type": "string"}, {"name": "just_one_iteration", "type":
       "string"}, {"name": "maxVal", "type": "string"}], "tasks": [{"name": "print",
       "params": [{"name": "flip-coin-output", "value": "$(params.flip-coin-output)"}],
-      "taskSpec": {"metadata": {"annotations": {"tekton.dev/template": ""}, "labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec":
+      "{\"description\": \"print msg\", \"implementation\": {\"container\": {\"command\":
+      [\"echo\", {\"inputValue\": \"msg\"}], \"image\": \"alpine:3.6\"}}, \"inputs\":
+      [{\"name\": \"msg\", \"type\": \"String\"}], \"name\": \"print\"}", "tekton.dev/template":
+      ""}, "labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
       "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "flip-coin-output",
       "type": "string"}], "steps": [{"command": ["echo", "$(inputs.params.flip-coin-output)"],
       "image": "alpine:3.6", "name": "main"}]}, "timeout": "0s", "when": [{"input":
       "$(tasks.condition-2.results.outcome)", "operator": "in", "values": ["true"]}]},
       {"name": "flip-coin-2", "runAfter": ["print"], "taskSpec": {"metadata": {"annotations":
-      {"tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/output", "name": "output"}], "steps":
-      [{"args": ["python -c \"import random; result = ''heads'' if random.randint(0,1)
-      == 0 else ''tails''; print(result)\" | tee $(results.output.path)"], "command":
+      {"pipelines.kubeflow.org/component_spec": "{\"description\": \"flip coin\",
+      \"implementation\": {\"container\": {\"args\": [\"python -c \\\"import random;
+      result = ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\\\"
+      | tee $0\\n\", {\"outputPath\": \"output\"}], \"command\": [\"sh\", \"-c\"],
+      \"image\": \"python:alpine3.6\"}}, \"name\": \"flip-coin\", \"outputs\": [{\"name\":
+      \"output\", \"type\": \"String\"}]}", "tekton.dev/template": ""}, "labels":
+      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "", "pipelines.kubeflow.org/pipelinename": ""}}, "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output"}], "steps": [{"args": ["python
+      -c \"import random; result = ''heads'' if random.randint(0,1) == 0           else
+      ''tails''; print(result)\" | tee $0\n", "$(results.output.path)"], "command":
       ["sh", "-c"], "image": "python:alpine3.6", "name": "main"}]}, "timeout": "0s",
       "when": [{"input": "$(tasks.condition-2.results.outcome)", "operator": "in",
       "values": ["true"]}]}, {"name": "condition-2", "params": [{"name": "operand1",
@@ -82,21 +91,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output
-          description: /tmp/output
+          description: /tmp/outputs/output/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output"}], "command": ["sh", "-c"], "image":
+              "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name": "output",
+              "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: print-2
@@ -118,6 +134,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "print msg", "implementation":
+              {"container": {"command": ["echo", {"inputValue": "msg"}], "image":
+              "alpine:3.6"}}, "inputs": [{"name": "msg", "type": "String"}], "name":
+              "print"}'
             tekton.dev/template: ''
       runAfter:
       - recursion-pipeline-flip-component-1

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.py
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.py
@@ -48,7 +48,7 @@ _CONTAINER_MANIFEST = """
 
 
 @dsl.pipeline(
-    name="ResourceOp Basic",
+    name="resource-op-basic",
     description="A Basic Example on ResourceOp Usage."
 )
 def resourceop_basic():

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -15,7 +15,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: resourceop-basic
+  name: resource-op-basic
   annotations:
     tekton.dev/output_artifacts: '{}'
     tekton.dev/input_artifacts: '{}'
@@ -25,7 +25,7 @@ metadata:
     tekton.dev/artifact_items: '{"test-step": []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A Basic Example on ResourceOp
-      Usage.", "name": "ResourceOp Basic"}'
+      Usage.", "name": "resource-op-basic"}'
 spec:
   pipelineSpec:
     tasks:

--- a/sdk/python/tests/compiler/testdata/resourceop_basic_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic_noninlined.yaml
@@ -15,7 +15,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: resourceop-basic
+  name: resource-op-basic
   annotations:
     tekton.dev/output_artifacts: '{}'
     tekton.dev/input_artifacts: '{}'
@@ -25,7 +25,7 @@ metadata:
     tekton.dev/artifact_items: '{"test-step": []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A Basic Example on ResourceOp
-      Usage.", "name": "ResourceOp Basic"}'
+      Usage.", "name": "resource-op-basic"}'
 spec:
   pipelineSpec:
     tasks:

--- a/sdk/python/tests/compiler/testdata/retry.yaml
+++ b/sdk/python/tests/compiler/testdata/retry.yaml
@@ -26,7 +26,7 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline includes
       two steps which fail randomly. It shows how to use ContainerOp(...).set_retry(...).",
-      "name": "Retry random failures"}'
+      "name": "retry-random-failures"}'
 spec:
   pipelineSpec:
     tasks:
@@ -35,8 +35,8 @@ spec:
         steps:
         - name: main
           args:
-          - import random; import sys; exit_code = random.choice([int(i) for i in
-            sys.argv[1].split(",")]); print(exit_code); sys.exit(exit_code)
+          - |
+            import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]);           print(exit_code); sys.exit(exit_code)
           - 0,1,2,3
           command:
           - python
@@ -48,6 +48,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "random failure",
+              "implementation": {"container": {"args": ["import random; import sys;
+              exit_code = random.choice([int(i) for i in sys.argv[1].split(\",\")]);           print(exit_code);
+              sys.exit(exit_code)\n", {"inputValue": "exitcode"}], "command": ["python",
+              "-c"], "image": "python:alpine3.6"}}, "inputs": [{"name": "exitcode",
+              "type": "String"}], "name": "random-failure"}'
             tekton.dev/template: ''
       retries: 10
       timeout: 0s
@@ -56,8 +62,8 @@ spec:
         steps:
         - name: main
           args:
-          - import random; import sys; exit_code = random.choice([int(i) for i in
-            sys.argv[1].split(",")]); print(exit_code); sys.exit(exit_code)
+          - |
+            import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]);           print(exit_code); sys.exit(exit_code)
           - 0,1
           command:
           - python
@@ -69,6 +75,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "random failure",
+              "implementation": {"container": {"args": ["import random; import sys;
+              exit_code = random.choice([int(i) for i in sys.argv[1].split(\",\")]);           print(exit_code);
+              sys.exit(exit_code)\n", {"inputValue": "exitcode"}], "command": ["python",
+              "-c"], "image": "python:alpine3.6"}}, "inputs": [{"name": "exitcode",
+              "type": "String"}], "name": "random-failure"}'
             tekton.dev/template: ''
       retries: 5
       timeout: 0s

--- a/sdk/python/tests/compiler/testdata/retry_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/retry_noninlined.yaml
@@ -26,7 +26,7 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline includes
       two steps which fail randomly. It shows how to use ContainerOp(...).set_retry(...).",
-      "name": "Retry random failures"}'
+      "name": "retry-random-failures"}'
 spec:
   pipelineSpec:
     tasks:
@@ -35,8 +35,8 @@ spec:
         steps:
         - name: main
           args:
-          - import random; import sys; exit_code = random.choice([int(i) for i in
-            sys.argv[1].split(",")]); print(exit_code); sys.exit(exit_code)
+          - |
+            import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]);           print(exit_code); sys.exit(exit_code)
           - 0,1,2,3
           command:
           - python
@@ -48,6 +48,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "random failure",
+              "implementation": {"container": {"args": ["import random; import sys;
+              exit_code = random.choice([int(i) for i in sys.argv[1].split(\",\")]);           print(exit_code);
+              sys.exit(exit_code)\n", {"inputValue": "exitcode"}], "command": ["python",
+              "-c"], "image": "python:alpine3.6"}}, "inputs": [{"name": "exitcode",
+              "type": "String"}], "name": "random-failure"}'
             tekton.dev/template: ''
       retries: 10
       timeout: 0s
@@ -56,8 +62,8 @@ spec:
         steps:
         - name: main
           args:
-          - import random; import sys; exit_code = random.choice([int(i) for i in
-            sys.argv[1].split(",")]); print(exit_code); sys.exit(exit_code)
+          - |
+            import random; import sys; exit_code = random.choice([int(i) for i in sys.argv[1].split(",")]);           print(exit_code); sys.exit(exit_code)
           - 0,1
           command:
           - python
@@ -69,6 +75,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "random failure",
+              "implementation": {"container": {"args": ["import random; import sys;
+              exit_code = random.choice([int(i) for i in sys.argv[1].split(\",\")]);           print(exit_code);
+              sys.exit(exit_code)\n", {"inputValue": "exitcode"}], "command": ["python",
+              "-c"], "image": "python:alpine3.6"}}, "inputs": [{"name": "exitcode",
+              "type": "String"}], "name": "random-failure"}'
             tekton.dev/template: ''
       retries: 5
       timeout: 0s

--- a/sdk/python/tests/compiler/testdata/sequential.yaml
+++ b/sdk/python/tests/compiler/testdata/sequential.yaml
@@ -17,17 +17,18 @@ kind: PipelineRun
 metadata:
   name: sequential-pipeline
   annotations:
-    tekton.dev/output_artifacts: '{}'
+    tekton.dev/output_artifacts: '{"gcs-download": [{"key": "artifacts/$PIPELINERUN/gcs-download/data.tgz",
+      "name": "gcs-download-data", "path": "/tmp/outputs/data/data"}]}'
     tekton.dev/input_artifacts: '{}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
     tekton.dev/artifact_endpoint_scheme: http://
-    tekton.dev/artifact_items: '{"echo": [], "gcs-download": []}'
+    tekton.dev/artifact_items: '{"echo": [], "gcs-download": [["data", "$(results.data.path)"]]}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with two sequential
       steps.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
-      "name": "url", "optional": true}, {"default": "/tmp/results.txt", "name": "path",
-      "optional": true}], "name": "Sequential pipeline"}'
+      "name": "url", "optional": true, "type": "String"}, {"default": "/tmp/results.txt",
+      "name": "path", "optional": true, "type": "String"}], "name": "sequential-pipeline"}'
 spec:
   params:
   - name: path
@@ -49,21 +50,31 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url)
-          - /tmp/results.txt
+          - $(results.data.path)
           command:
           - sh
           - -c
           image: google/cloud-sdk:216.0.0
         params:
         - name: url
+        results:
+        - name: data
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:216.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: echo
@@ -74,7 +85,7 @@ spec:
         steps:
         - name: main
           args:
-          - echo "$0"
+          - echo
           - $(inputs.params.path)
           command:
           - sh
@@ -88,6 +99,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "print msg", "implementation":
+              {"container": {"args": ["echo", {"inputValue": "msg"}], "command": ["sh",
+              "-c"], "image": "library/bash:4.4.23"}}, "inputs": [{"name": "msg",
+              "type": "String"}], "name": "echo"}'
             tekton.dev/template: ''
       runAfter:
       - gcs-download

--- a/sdk/python/tests/compiler/testdata/sequential_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/sequential_noninlined.yaml
@@ -17,17 +17,18 @@ kind: PipelineRun
 metadata:
   name: sequential-pipeline
   annotations:
-    tekton.dev/output_artifacts: '{}'
+    tekton.dev/output_artifacts: '{"gcs-download": [{"key": "artifacts/$PIPELINERUN/gcs-download/data.tgz",
+      "name": "gcs-download-data", "path": "/tmp/outputs/data/data"}]}'
     tekton.dev/input_artifacts: '{}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
     tekton.dev/artifact_endpoint_scheme: http://
-    tekton.dev/artifact_items: '{"echo": [], "gcs-download": []}'
+    tekton.dev/artifact_items: '{"echo": [], "gcs-download": [["data", "$(results.data.path)"]]}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with two sequential
       steps.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
-      "name": "url", "optional": true}, {"default": "/tmp/results.txt", "name": "path",
-      "optional": true}], "name": "Sequential pipeline"}'
+      "name": "url", "optional": true, "type": "String"}, {"default": "/tmp/results.txt",
+      "name": "path", "optional": true, "type": "String"}], "name": "sequential-pipeline"}'
 spec:
   params:
   - name: path
@@ -49,21 +50,31 @@ spec:
         steps:
         - name: main
           args:
-          - gsutil cat $0 | tee $1
+          - |
+            gsutil cat $0 | tee $1
           - $(inputs.params.url)
-          - /tmp/results.txt
+          - $(results.data.path)
           command:
           - sh
           - -c
           image: google/cloud-sdk:216.0.0
         params:
         - name: url
+        results:
+        - name: data
+          description: /tmp/outputs/data/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "GCS - Download",
+              "implementation": {"container": {"args": ["gsutil cat $0 | tee $1\n",
+              {"inputValue": "url"}, {"outputPath": "data"}], "command": ["sh", "-c"],
+              "image": "google/cloud-sdk:216.0.0"}}, "inputs": [{"name": "url", "type":
+              "String"}], "name": "gcs-download", "outputs": [{"name": "data", "type":
+              "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: echo
@@ -74,7 +85,7 @@ spec:
         steps:
         - name: main
           args:
-          - echo "$0"
+          - echo
           - $(inputs.params.path)
           command:
           - sh
@@ -88,6 +99,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "print msg", "implementation":
+              {"container": {"args": ["echo", {"inputValue": "msg"}], "command": ["sh",
+              "-c"], "image": "library/bash:4.4.23"}}, "inputs": [{"name": "msg",
+              "type": "String"}], "name": "echo"}'
             tekton.dev/template: ''
       runAfter:
       - gcs-download

--- a/sdk/python/tests/compiler/testdata/set_display_name.py
+++ b/sdk/python/tests/compiler/testdata/set_display_name.py
@@ -12,16 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp import dsl
+from kfp import dsl, components
 
 
 def echo_op():
-    return dsl.ContainerOp(
-        name='echo',
-        image='busybox',
-        command=['sh', '-c'],
-        arguments=['echo "Got scheduled"']
-    )
+    return components.load_component_from_text("""
+    name: echo
+    description: echo
+    implementation:
+      container:
+        image: busybox
+        command:
+        - sh
+        - -c
+        args:
+        - echo
+        - Got scheduled
+    """)()
 
 
 @dsl.pipeline(

--- a/sdk/python/tests/compiler/testdata/set_display_name.yaml
+++ b/sdk/python/tests/compiler/testdata/set_display_name.yaml
@@ -34,7 +34,8 @@ spec:
         steps:
         - name: main
           args:
-          - echo "Got scheduled"
+          - echo
+          - Got scheduled
           command:
           - sh
           - -c
@@ -46,6 +47,9 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/task_display_name: Hello World
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo", "Got scheduled"], "command": ["sh",
+              "-c"], "image": "busybox"}}, "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/set_display_name_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/set_display_name_noninlined.yaml
@@ -34,7 +34,8 @@ spec:
         steps:
         - name: main
           args:
-          - echo "Got scheduled"
+          - echo
+          - Got scheduled
           command:
           - sh
           - -c
@@ -46,6 +47,9 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/task_display_name: Hello World
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo", "Got scheduled"], "command": ["sh",
+              "-c"], "image": "busybox"}}, "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/sidecar.yaml
+++ b/sdk/python/tests/compiler/testdata/sidecar.yaml
@@ -17,18 +17,18 @@ kind: PipelineRun
 metadata:
   name: sidecar
   annotations:
-    tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/downloaded.tgz",
-      "name": "download-downloaded", "path": "/tmp/results.txt"}]}'
-    tekton.dev/input_artifacts: '{"echo": [{"name": "download-downloaded", "parent_task":
+    tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/download.tgz",
+      "name": "download-download", "path": "/tmp/outputs/download/data"}]}'
+    tekton.dev/input_artifacts: '{"echo": [{"name": "download-download", "parent_task":
       "download"}]}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
     tekton.dev/artifact_endpoint_scheme: http://
-    tekton.dev/artifact_items: '{"download": [["downloaded", "$(results.downloaded.path)"]],
+    tekton.dev/artifact_items: '{"download": [["download", "$(results.download.path)"]],
       "echo": []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with sidecars.",
-      "name": "Sidecar"}'
+      "name": "sidecar"}'
 spec:
   pipelineSpec:
     tasks:
@@ -37,48 +37,54 @@ spec:
         steps:
         - name: main
           args:
-          - sleep 10; wget localhost:5678 -O $(results.downloaded.path)
+          - |
+            sleep 10; wget localhost:5678 -O $0
+          - $(results.download.path)
           command:
           - sh
           - -c
           image: busybox
         results:
-        - name: downloaded
-          description: /tmp/results.txt
-        sidecars:
-        - args:
-          - -text="hello world"
-          image: hashicorp/http-echo
-          name: echo
+        - name: download
+          description: /tmp/outputs/download/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "download", "implementation":
+              {"container": {"args": ["sleep 10; wget localhost:5678 -O $0\n", {"outputPath":
+              "download"}], "command": ["sh", "-c"], "image": "busybox"}}, "name":
+              "download", "outputs": [{"name": "download", "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: echo
       params:
-      - name: download-downloaded
-        value: $(tasks.download.results.downloaded)
+      - name: download-download
+        value: $(tasks.download.results.download)
       taskSpec:
         steps:
         - name: main
           args:
-          - echo $(inputs.params.download-downloaded)
+          - echo
+          - $(inputs.params.download-download)
           command:
           - sh
           - -c
           image: library/bash
         params:
-        - name: download-downloaded
+        - name: download-download
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo", {"inputValue": "msg"}], "command": ["sh",
+              "-c"], "image": "library/bash"}}, "inputs": [{"name": "msg", "type":
+              "String"}], "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/sidecar_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/sidecar_noninlined.yaml
@@ -17,18 +17,18 @@ kind: PipelineRun
 metadata:
   name: sidecar
   annotations:
-    tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/downloaded.tgz",
-      "name": "download-downloaded", "path": "/tmp/results.txt"}]}'
-    tekton.dev/input_artifacts: '{"echo": [{"name": "download-downloaded", "parent_task":
+    tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/download.tgz",
+      "name": "download-download", "path": "/tmp/outputs/download/data"}]}'
+    tekton.dev/input_artifacts: '{"echo": [{"name": "download-download", "parent_task":
       "download"}]}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
     tekton.dev/artifact_endpoint_scheme: http://
-    tekton.dev/artifact_items: '{"download": [["downloaded", "$(results.downloaded.path)"]],
+    tekton.dev/artifact_items: '{"download": [["download", "$(results.download.path)"]],
       "echo": []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with sidecars.",
-      "name": "Sidecar"}'
+      "name": "sidecar"}'
 spec:
   pipelineSpec:
     tasks:
@@ -37,48 +37,54 @@ spec:
         steps:
         - name: main
           args:
-          - sleep 10; wget localhost:5678 -O $(results.downloaded.path)
+          - |
+            sleep 10; wget localhost:5678 -O $0
+          - $(results.download.path)
           command:
           - sh
           - -c
           image: busybox
         results:
-        - name: downloaded
-          description: /tmp/results.txt
-        sidecars:
-        - args:
-          - -text="hello world"
-          image: hashicorp/http-echo
-          name: echo
+        - name: download
+          description: /tmp/outputs/download/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "download", "implementation":
+              {"container": {"args": ["sleep 10; wget localhost:5678 -O $0\n", {"outputPath":
+              "download"}], "command": ["sh", "-c"], "image": "busybox"}}, "name":
+              "download", "outputs": [{"name": "download", "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: echo
       params:
-      - name: download-downloaded
-        value: $(tasks.download.results.downloaded)
+      - name: download-download
+        value: $(tasks.download.results.download)
       taskSpec:
         steps:
         - name: main
           args:
-          - echo $(inputs.params.download-downloaded)
+          - echo
+          - $(inputs.params.download-download)
           command:
           - sh
           - -c
           image: library/bash
         params:
-        - name: download-downloaded
+        - name: download-download
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo", {"inputValue": "msg"}], "command": ["sh",
+              "-c"], "image": "library/bash"}}, "inputs": [{"name": "msg", "type":
+              "String"}], "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/tekton_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_custom_task.yaml
@@ -18,9 +18,9 @@ metadata:
   name: tekton-custom-task-on-kubeflow-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output_result.tgz",
-      "name": "flip-coin-output_result", "path": "/tmp/output_result"}], "flip-coin-2":
-      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output_result.tgz", "name": "flip-coin-2-output_result",
-      "path": "/tmp/output_result"}]}'
+      "name": "flip-coin-output_result", "path": "/tmp/outputs/output_result/data"}],
+      "flip-coin-2": [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output_result.tgz",
+      "name": "flip-coin-2-output_result", "path": "/tmp/outputs/output_result/data"}]}'
     tekton.dev/input_artifacts: '{"print": [{"name": "condition-cel-outcome", "parent_task":
       "condition-cel"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -31,7 +31,7 @@ metadata:
       []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use Tekton
-      custom task with KFP", "name": "Tekton custom task on Kubeflow Pipeline"}'
+      custom task with KFP", "name": "tekton-custom-task-on-kubeflow-pipeline"}'
 spec:
   pipelineSpec:
     tasks:
@@ -40,21 +40,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output-result.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output-result.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output-result
-          description: /tmp/output_result
+          description: /tmp/outputs/output_result/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "Flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output_result"}], "command": ["sh", "-c"],
+              "image": "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name":
+              "output_result", "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: flip-coin-2
@@ -62,21 +69,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output-result.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output-result.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output-result
-          description: /tmp/output_result
+          description: /tmp/outputs/output_result/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "Flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output_result"}], "command": ["sh", "-c"],
+              "image": "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name":
+              "output_result", "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: condition-cel
@@ -106,6 +120,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "Print", "implementation":
+              {"container": {"command": ["echo", {"inputValue": "msg"}], "image":
+              "alpine:3.6"}}, "inputs": [{"name": "msg", "type": "String"}], "name":
+              "print"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/tekton_custom_task_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_custom_task_noninlined.yaml
@@ -18,9 +18,9 @@ metadata:
   name: tekton-custom-task-on-kubeflow-pipeline
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/output_result.tgz",
-      "name": "flip-coin-output_result", "path": "/tmp/output_result"}], "flip-coin-2":
-      [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output_result.tgz", "name": "flip-coin-2-output_result",
-      "path": "/tmp/output_result"}]}'
+      "name": "flip-coin-output_result", "path": "/tmp/outputs/output_result/data"}],
+      "flip-coin-2": [{"key": "artifacts/$PIPELINERUN/flip-coin-2/output_result.tgz",
+      "name": "flip-coin-2-output_result", "path": "/tmp/outputs/output_result/data"}]}'
     tekton.dev/input_artifacts: '{"print": [{"name": "condition-cel-outcome", "parent_task":
       "condition-cel"}]}'
     tekton.dev/artifact_bucket: mlpipeline
@@ -31,7 +31,7 @@ metadata:
       []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use Tekton
-      custom task with KFP", "name": "Tekton custom task on Kubeflow Pipeline"}'
+      custom task with KFP", "name": "tekton-custom-task-on-kubeflow-pipeline"}'
 spec:
   pipelineSpec:
     tasks:
@@ -40,21 +40,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output-result.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output-result.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output-result
-          description: /tmp/output_result
+          description: /tmp/outputs/output_result/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "Flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output_result"}], "command": ["sh", "-c"],
+              "image": "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name":
+              "output_result", "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: flip-coin-2
@@ -62,21 +69,28 @@ spec:
         steps:
         - name: main
           args:
-          - python -c "import random; result = 'heads' if random.randint(0,1) == 0
-            else 'tails'; print(result)" | tee $(results.output-result.path)
+          - |
+            python -c "import random; result = 'heads' if random.randint(0,1) == 0           else 'tails'; print(result)" | tee $0
+          - $(results.output-result.path)
           command:
           - sh
           - -c
           image: python:alpine3.6
         results:
         - name: output-result
-          description: /tmp/output_result
+          description: /tmp/outputs/output_result/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "Flip coin", "implementation":
+              {"container": {"args": ["python -c \"import random; result = ''heads''
+              if random.randint(0,1) == 0           else ''tails''; print(result)\"
+              | tee $0\n", {"outputPath": "output_result"}], "command": ["sh", "-c"],
+              "image": "python:alpine3.6"}}, "name": "flip-coin", "outputs": [{"name":
+              "output_result", "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
     - name: condition-cel
@@ -106,6 +120,10 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "Print", "implementation":
+              {"container": {"command": ["echo", {"inputValue": "msg"}], "image":
+              "alpine:3.6"}}, "inputs": [{"name": "msg", "type": "String"}], "name":
+              "print"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.py
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.py
@@ -12,17 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp import dsl
+from kfp import dsl, components
 import kfp_tekton
 
 
 def echo_op():
-    return dsl.ContainerOp(
-        name='echo',
-        image='busybox',
-        command=['sh', '-c'],
-        arguments=['echo "Got scheduled"']
-    )
+    return components.load_component_from_text("""
+    name: echo
+    description: echo
+    implementation:
+      container:
+        image: busybox
+        command:
+        - sh
+        - -c
+        args:
+        - echo
+        - Got scheduled
+    """)()
 
 
 @dsl.pipeline(

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.yaml
@@ -38,7 +38,8 @@ spec:
         steps:
         - name: main
           args:
-          - echo "Got scheduled"
+          - echo
+          - Got scheduled
           command:
           - sh
           - -c
@@ -49,6 +50,9 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo", "Got scheduled"], "command": ["sh",
+              "-c"], "image": "busybox"}}, "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_conf_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_conf_noninlined.yaml
@@ -38,7 +38,8 @@ spec:
         steps:
         - name: main
           args:
-          - echo "Got scheduled"
+          - echo
+          - Got scheduled
           command:
           - sh
           - -c
@@ -49,6 +50,9 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "echo", "implementation":
+              {"container": {"args": ["echo", "Got scheduled"], "command": ["sh",
+              "-c"], "image": "busybox"}}, "name": "echo"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_variables.py
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_variables.py
@@ -12,27 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp import dsl
+from kfp import dsl, components
 from kfp_tekton.compiler import TektonCompiler
 
 
 @dsl.pipeline(
-    name="Tekton Pipeline Variables",
+    name="tekton-pipeline-variables",
     description="Tests for Tekton Pipeline Variables",
 )
 def tekton_pipeline_variables(
 ):
-    task1 = dsl.ContainerOp(
-        name="task1",
-        image="registry.access.redhat.com/ubi8/ubi-minimal",
-        command=["/bin/bash", "-c"],
-        arguments=["echo \
-            Pipeline name: $(context.pipeline.name), \
-            PipelineRun name: $(context.pipelineRun.name), \
-            PipelineRun namespace: $(context.pipelineRun.namespace), \
-            pipelineRun id: $(context.pipelineRun.uid)"
-        ]
-    )
+    task1 = components.load_component_from_text("""
+    name: task1
+    description: task1
+    implementation:
+      container:
+        image: registry.access.redhat.com/ubi8/ubi-minimal
+        command:
+        - /bin/bash
+        - -c
+        args:
+        - |
+          echo Pipeline name: $(context.pipeline.name), \
+          PipelineRun name: $(context.pipelineRun.name), \
+          PipelineRun namespace: $(context.pipelineRun.namespace), \
+          pipelineRun id: $(context.pipelineRun.uid)
+    """)()
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_variables.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_variables.yaml
@@ -25,7 +25,7 @@ metadata:
     tekton.dev/artifact_items: '{"task1": []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Tests for Tekton Pipeline
-      Variables", "name": "Tekton Pipeline Variables"}'
+      Variables", "name": "tekton-pipeline-variables"}'
 spec:
   pipelineSpec:
     tasks:
@@ -33,20 +33,39 @@ spec:
       taskSpec:
         steps:
         - name: main
-          args: ['echo             Pipeline name: $(params.pipeline-name),             PipelineRun
-              name: $(params.pipelineRun-name),             PipelineRun namespace:
-              $(params.pipelineRun-namespace),             pipelineRun id: $(params.pipelineRun-uid)']
-          command: [/bin/bash, -c]
+          args:
+          - |
+            echo Pipeline name: $(params.pipeline-name),           PipelineRun name: $(params.pipelineRun-name),           PipelineRun namespace: $(params.pipelineRun-namespace),           pipelineRun id: $(params.pipelineRun-uid)
+          command:
+          - /bin/bash
+          - -c
           image: registry.access.redhat.com/ubi8/ubi-minimal
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "task1", "implementation":
+              {"container": {"args": ["echo Pipeline name: $(context.pipeline.name),           PipelineRun
+              name: $(context.pipelineRun.name),           PipelineRun namespace:
+              $(context.pipelineRun.namespace),           pipelineRun id: $(context.pipelineRun.uid)\n"],
+              "command": ["/bin/bash", "-c"], "image": "registry.access.redhat.com/ubi8/ubi-minimal"}},
+              "name": "task1"}'
+            tekton.dev/template: ''
         params:
-        - {name: pipeline-name}
-        - {name: pipelineRun-name}
-        - {name: pipelineRun-namespace}
-        - {name: pipelineRun-uid}
+        - name: pipeline-name
+        - name: pipelineRun-name
+        - name: pipelineRun-namespace
+        - name: pipelineRun-uid
       timeout: 0s
       params:
-      - {name: pipeline-name, value: $(context.pipeline.name)}
-      - {name: pipelineRun-name, value: $(context.pipelineRun.name)}
-      - {name: pipelineRun-namespace, value: $(context.pipelineRun.namespace)}
-      - {name: pipelineRun-uid, value: $(context.pipelineRun.uid)}
+      - name: pipeline-name
+        value: $(context.pipeline.name)
+      - name: pipelineRun-name
+        value: $(context.pipelineRun.name)
+      - name: pipelineRun-namespace
+        value: $(context.pipelineRun.namespace)
+      - name: pipelineRun-uid
+        value: $(context.pipelineRun.uid)
   timeout: 0s

--- a/sdk/python/tests/compiler/testdata/timeout.py
+++ b/sdk/python/tests/compiler/testdata/timeout.py
@@ -13,29 +13,35 @@
 # limitations under the License.
 
 
-import kfp.dsl as dsl
+from kfp import dsl, components
 
 
-class RandomFailure1Op(dsl.ContainerOp):
-    """A component that fails randomly."""
-
-    def __init__(self, exit_codes):
-        super(RandomFailure1Op, self).__init__(
-            name='random_failure',
-            image='python:alpine3.6',
-            command=['python', '-c'],
-            arguments=[
-                "import random; import sys; exit_code = random.choice([%s]); print(exit_code); "
-                "import time; time.sleep(30); sys.exit(exit_code)" % exit_codes])
+random_failure_1Op = components.load_component_from_text("""
+name: random-failure
+description: random failure
+inputs:
+  - {name: exitcodes, type: String}
+implementation:
+  container:
+    image: python:alpine3.6
+    command:
+    - python
+    - -c
+    args:
+    - |
+      import random; import sys; exit_code = random.choice([$0]); print(exit_code); \
+      import time; time.sleep(30); sys.exit(exit_code)
+    - {inputValue: exitcodes}
+""")
 
 
 @dsl.pipeline(
-    name='pipeline includes two steps which fail randomly.',
+    name='pipeline-includes-two-steps-which-fail-randomly',
     description='shows how to use ContainerOp set_timeout().'
 )
 def timeout_sample_pipeline():
-    op1 = RandomFailure1Op('0,1,2,3').set_timeout(20)
-    op2 = RandomFailure1Op('0,1')
+    op1 = random_failure_1Op('0,1,2,3').set_timeout(20)
+    op2 = random_failure_1Op('0,1')
     dsl.get_pipeline_conf().set_timeout(40)
 
 

--- a/sdk/python/tests/compiler/testdata/timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout.yaml
@@ -25,7 +25,7 @@ metadata:
     tekton.dev/artifact_items: '{"random-failure": [], "random-failure-2": []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use ContainerOp
-      set_timeout().", "name": "pipeline includes two steps which fail randomly."}'
+      set_timeout().", "name": "pipeline-includes-two-steps-which-fail-randomly"}'
 spec:
   pipelineSpec:
     tasks:
@@ -34,8 +34,9 @@ spec:
         steps:
         - name: main
           args:
-          - import random; import sys; exit_code = random.choice([0,1,2,3]); print(exit_code);
-            import time; time.sleep(30); sys.exit(exit_code)
+          - |
+            import random; import sys; exit_code = random.choice([$0]); print(exit_code);       import time; time.sleep(30); sys.exit(exit_code)
+          - 0,1,2,3
           command:
           - python
           - -c
@@ -46,6 +47,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "random failure",
+              "implementation": {"container": {"args": ["import random; import sys;
+              exit_code = random.choice([$0]); print(exit_code);       import time;
+              time.sleep(30); sys.exit(exit_code)\n", {"inputValue": "exitcodes"}],
+              "command": ["python", "-c"], "image": "python:alpine3.6"}}, "inputs":
+              [{"name": "exitcodes", "type": "String"}], "name": "random-failure"}'
             tekton.dev/template: ''
       timeout: 20s
     - name: random-failure-2
@@ -53,8 +60,9 @@ spec:
         steps:
         - name: main
           args:
-          - import random; import sys; exit_code = random.choice([0,1]); print(exit_code);
-            import time; time.sleep(30); sys.exit(exit_code)
+          - |
+            import random; import sys; exit_code = random.choice([$0]); print(exit_code);       import time; time.sleep(30); sys.exit(exit_code)
+          - 0,1
           command:
           - python
           - -c
@@ -65,6 +73,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "random failure",
+              "implementation": {"container": {"args": ["import random; import sys;
+              exit_code = random.choice([$0]); print(exit_code);       import time;
+              time.sleep(30); sys.exit(exit_code)\n", {"inputValue": "exitcodes"}],
+              "command": ["python", "-c"], "image": "python:alpine3.6"}}, "inputs":
+              [{"name": "exitcodes", "type": "String"}], "name": "random-failure"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 40s

--- a/sdk/python/tests/compiler/testdata/timeout_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout_noninlined.yaml
@@ -25,7 +25,7 @@ metadata:
     tekton.dev/artifact_items: '{"random-failure": [], "random-failure-2": []}'
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use ContainerOp
-      set_timeout().", "name": "pipeline includes two steps which fail randomly."}'
+      set_timeout().", "name": "pipeline-includes-two-steps-which-fail-randomly"}'
 spec:
   pipelineSpec:
     tasks:
@@ -34,8 +34,9 @@ spec:
         steps:
         - name: main
           args:
-          - import random; import sys; exit_code = random.choice([0,1,2,3]); print(exit_code);
-            import time; time.sleep(30); sys.exit(exit_code)
+          - |
+            import random; import sys; exit_code = random.choice([$0]); print(exit_code);       import time; time.sleep(30); sys.exit(exit_code)
+          - 0,1,2,3
           command:
           - python
           - -c
@@ -46,6 +47,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "random failure",
+              "implementation": {"container": {"args": ["import random; import sys;
+              exit_code = random.choice([$0]); print(exit_code);       import time;
+              time.sleep(30); sys.exit(exit_code)\n", {"inputValue": "exitcodes"}],
+              "command": ["python", "-c"], "image": "python:alpine3.6"}}, "inputs":
+              [{"name": "exitcodes", "type": "String"}], "name": "random-failure"}'
             tekton.dev/template: ''
       timeout: 20s
     - name: random-failure-2
@@ -53,8 +60,9 @@ spec:
         steps:
         - name: main
           args:
-          - import random; import sys; exit_code = random.choice([0,1]); print(exit_code);
-            import time; time.sleep(30); sys.exit(exit_code)
+          - |
+            import random; import sys; exit_code = random.choice([$0]); print(exit_code);       import time; time.sleep(30); sys.exit(exit_code)
+          - 0,1
           command:
           - python
           - -c
@@ -65,6 +73,12 @@ spec:
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "random failure",
+              "implementation": {"container": {"args": ["import random; import sys;
+              exit_code = random.choice([$0]); print(exit_code);       import time;
+              time.sleep(30); sys.exit(exit_code)\n", {"inputValue": "exitcodes"}],
+              "command": ["python", "-c"], "image": "python:alpine3.6"}}, "inputs":
+              [{"name": "exitcodes", "type": "String"}], "name": "random-failure"}'
             tekton.dev/template: ''
       timeout: 0s
   timeout: 40s

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -18,7 +18,7 @@ metadata:
   name: tolerations
   annotations:
     tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/downloaded.tgz",
-      "name": "download-downloaded", "path": "/tmp/results.txt"}]}'
+      "name": "download-downloaded", "path": "/tmp/outputs/downloaded/data"}]}'
     tekton.dev/input_artifacts: '{}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
@@ -35,20 +35,26 @@ spec:
         steps:
         - name: main
           args:
-          - sleep 10; wget localhost:5678 -O $(results.downloaded.path)
+          - |
+            sleep 10; wget localhost:5678 -O $0
+          - $(results.downloaded.path)
           command:
           - sh
           - -c
           image: busybox
         results:
         - name: downloaded
-          description: /tmp/results.txt
+          description: /tmp/outputs/downloaded/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "download", "implementation":
+              {"container": {"args": ["sleep 10; wget localhost:5678 -O $0\n", {"outputPath":
+              "downloaded"}], "command": ["sh", "-c"], "image": "busybox"}}, "name":
+              "download", "outputs": [{"name": "downloaded", "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
   taskRunSpecs:

--- a/sdk/python/tests/compiler/testdata/tolerations_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations_noninlined.yaml
@@ -18,7 +18,7 @@ metadata:
   name: tolerations
   annotations:
     tekton.dev/output_artifacts: '{"download": [{"key": "artifacts/$PIPELINERUN/download/downloaded.tgz",
-      "name": "download-downloaded", "path": "/tmp/results.txt"}]}'
+      "name": "download-downloaded", "path": "/tmp/outputs/downloaded/data"}]}'
     tekton.dev/input_artifacts: '{}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
@@ -35,20 +35,26 @@ spec:
         steps:
         - name: main
           args:
-          - sleep 10; wget localhost:5678 -O $(results.downloaded.path)
+          - |
+            sleep 10; wget localhost:5678 -O $0
+          - $(results.downloaded.path)
           command:
           - sh
           - -c
           image: busybox
         results:
         - name: downloaded
-          description: /tmp/results.txt
+          description: /tmp/outputs/downloaded/data
         metadata:
           labels:
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
+            pipelines.kubeflow.org/component_spec: '{"description": "download", "implementation":
+              {"container": {"args": ["sleep 10; wget localhost:5678 -O $0\n", {"outputPath":
+              "downloaded"}], "command": ["sh", "-c"], "image": "busybox"}}, "name":
+              "download", "outputs": [{"name": "downloaded", "type": "String"}]}'
             tekton.dev/template: ''
       timeout: 0s
   taskRunSpecs:


### PR DESCRIPTION
eliminate the usage of ContainerOp in testcases and
update the testcase accordingly, including filenames starting
with `o` to `u`

related to #670

Signed-off-by: Yihong Wang <yh.wang@ibm.com>