### PR TITLE
Remove Argo template UI reference to avoid UX conflicts with v2 compatible mode

### DIFF
--- a/frontend/src/lib/v2/WorkflowUtils.ts
+++ b/frontend/src/lib/v2/WorkflowUtils.ts
@@ -27,6 +27,13 @@ export function isArgoWorkflowTemplate(template: Workflow): boolean {
   return false;
 }
 
+export function isTektonPipelineRunTemplate(template: Workflow): boolean {
+  if (template?.kind === 'PipelineRun' && template?.apiVersion?.startsWith('tekton.dev/')) {
+    return true;
+  }
+  return false;
+}
+
 // Assuming template is the JSON format of PipelineJob in api/v2alpha1/pipeline_spec.proto
 // TODO(zijianjoy): We need to change `template` format to PipelineSpec once SDK support is in.
 export function convertJsonToV2PipelineSpec(template: string): PipelineSpec {


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
There are some new logics to check for Argo yaml when the pipeline could be in v2 compatible mode. Remove the Argo condition so if V2 and V2 compatible mode are not valid, it fails back to render with our Tekton DAG library.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
