### PR TITLE
Update SDK versions

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -108,8 +108,8 @@ the Tekton YAML instead of Argo YAML. Since the KFP SDK was not designed and imp
 _monkey-patching_ was used to replace non-class methods and functions at runtime.
 
 In order for the _monkey patch_ to work properly, the `kfp-tekton` compiler source code has to be aligned with a
-specific version of the `kfp` SDK compiler. As of now the `kfp-tekton` SDK version is `0.9.0` which is aligned with KFP
-SDK version [`1.7.1`](https://pypi.org/project/kfp/1.7.1/).
+specific version of the `kfp` SDK compiler. As of now the `kfp-tekton` SDK version is `1.0.0` which is aligned with KFP
+SDK version [`1.7.2`](https://pypi.org/project/kfp/1.7.2/).
 
 
 ## Adding New Code

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -20,14 +20,14 @@
 #
 # To create a distribution for PyPi run:
 #
-#    $ export KFP_TEKTON_VERSION=0.9.0-rc1
+#    $ export KFP_TEKTON_VERSION=1.0.0-rc1
 #    $ python3 setup.py sdist
 #    $ twine check dist/kfp-tekton-${KFP_TEKTON_VERSION/-rc/rc}.tar.gz
 #    $ twine upload --repository pypi dist/kfp-tekton-${KFP_TEKTON_VERSION/-rc/rc}.tar.gz
 #
 #   ... or:
 #
-#    $ make distribution KFP_TEKTON_VERSION=0.9.0-rc1
+#    $ make distribution KFP_TEKTON_VERSION=1.0.0-rc1
 #
 # =============================================================================
 


### PR DESCRIPTION
I came across some slightly outadate versions while creating the [v1.0.0 PyPI distribution](https://pypi.org/project/kfp-tekton/1.0.0/):

* Reference to `kfp` SDK from 1.7.1 to 1.7.2 in sdk/python/README.md
* PyPI distro comment in sdk/python/setup.py

@Tomcli 
