### PR TITLE
fix(sdk) orig_params being overwritten in custom-tasks

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -751,17 +751,19 @@ class TektonCompiler(Compiler):
             for key, value in custom_task_args.items():
               if key not in non_param_keys:
                 task_params.append({'name': key, 'value': value})
+            task_orig_params = task_ref['params']
             task_ref = {
               'name': template['metadata']['name'],
               'params': task_params,
               # For processing Tekton parameter mapping later on.
-              'orig_params': task_ref['params'],
+              'orig_params': task_orig_params,
               'taskRef': {
                 'name': custom_task_args['name'],
                 'apiVersion': custom_task_args['apiVersion'],
                 'kind': custom_task_args['kind']
               }
             }
+
             # Only one of --taskRef and --taskSpec allowed.
             if custom_task_args.get('taskRef', '') and custom_task_args.get('taskSpec', ''):
               raise("Custom task invalid configuration %s, Only one of --taskRef and --taskSpec allowed." % custom_task_args)
@@ -790,8 +792,7 @@ class TektonCompiler(Compiler):
                 task_ref = {
                   'name': template['metadata']['name'],
                   'params': task_params,
-                  # For processing Tekton parameter mapping later on.
-                  'orig_params': task_ref['params'],
+                  'orig_params': task_orig_params,
                   'taskSpec': {
                     'apiVersion': custom_task_args['apiVersion'],
                     'kind': custom_task_args['kind'],


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
In some rare cases (difficult to reproduce), pipeline params in custom tasks are not recognised as `orig_params` and therefore `$(inputs.params.foo-bar)` is produced instead of `$(params.foo-bar)`.

**Description of your changes:**
When custom task spec is overwritten from its `taskSpec`, all fields were pasted as-is. However, one of those was `"orig_params": task_ref["params"]` --- which works differently the first and the second time it's called, thus dropping the actual information on original parameters.

This PR factors out that variable and pastes it in both places without dropping its previous value.


**Environment tested:**

* Python Version (use `python --version`): 3.9.0
* Tekton Version (use `tkn version`): irrelevant
* Kubernetes Version (use `kubectl version`): irrelevant
* OS (e.g. from `/etc/os-release`): irrelevant

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
