### PR TITLE
Add doc for break feature for loop

### DIFF
--- a/tekton-catalog/pipeline-loops/README.md
+++ b/tekton-catalog/pipeline-loops/README.md
@@ -35,7 +35,7 @@
 `Parallelism` is to define the number of pipelineruns can be created at the same time. It must be eqaul to or bigger than 1. If it's not set then the default value will be 1. If it's bigger than the total iterations in the loop then the number will be total iterations.
 
 # Break
-It's common to break the loop when some condition met, like what we do in program language. This can be done by specify the task name with the `last-loop-task` label. When the task speicfied the the label is skipped during pipelineloop iteration, the loop will be marked `Succeeded` with a `pass` condition, and no more iteration will be started. The common use case is to check the condition in the task with `when` expression so that to decide whether to break the loop or just continue.
+It's common to break the loop when some condition is met, like what we do in programming languages. This can be done by specifying the task name with the `last-loop-task` label. When the task specified the label is skipped during pipelineloop iteration, the loop will be marked `Succeeded` with a `pass` condition, and no more iteration will be started. The common use case is to check the condition in the task with `when` expression so that to decide whether to break the loop or just continue.
 
 # Verification
 - check controller and the webhook. `kubectl get po -n tekton-pipelines`


### PR DESCRIPTION
The feature to support break in pipelineloop is already implemented. This is to add the document for that.

Can refer to the code https://github.com/kubeflow/kfp-tekton/blob/c835d1470bd9e225b13c67e9b7dcc5ccdc20efb7/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go#L495-L514
I just run the example https://github.com/kubeflow/kfp-tekton/blob/master/tekton-catalog/pipeline-loops/examples/pipelinespec-with-run-condition.yaml and it works well, you can see the loop is defined to run 3 times but break when condition met while just run 2 times.
```
➜  examples git:(master) ✗ k describe run simplepipelinelooprun
Name:         simplepipelinelooprun
Namespace:    gang-test
Labels:       custom.tekton.dev/pipelineLoop=conditionloop
              last-loop-task=task-fail
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"custom.tekton.dev/v1alpha1","kind":"PipelineLoop","metadata":{"annotations":{},"name":"conditionloop","namespace":"gang-tes...
API Version:  tekton.dev/v1alpha1
Kind:         Run
......................
Events:
  Type    Reason     Age                    From              Message
  ----    ------     ----                   ----              -------
  Normal  Started    2m36s (x2 over 2m36s)  run-pipelineloop
  Normal  Running    2m36s (x2 over 2m36s)  run-pipelineloop  Iterations completed: 0
  Normal  Running    2m10s                  run-pipelineloop  Iterations completed: 1
  Normal  Succeeded  2m5s (x2 over 2m5s)    run-pipelineloop  PipelineRuns completed successfully with the conditions are met
```

