### PR TITLE
feat(sdk): Add an API to return prepared workflow as python dicts.

### DIFF
--- a/guides/kfp-user-guide/README.md
+++ b/guides/kfp-user-guide/README.md
@@ -59,9 +59,58 @@ from kfp_tekton.compiler import TektonCompiler
 TektonCompiler().compile(echo_pipeline, 'echo_pipeline.yaml')
 ```
 
-In addition, we can put the above python code into a python `__main__` function. Then, the compilation can be done in terminal with a simple python command.
+Place the above python code into a python `__main__` function. Then, the compilation can be done in terminal with a simple python command.
 ```shell
 python echo_pipeline.py
+```
+
+Additionally, if user wants to have a python dict of compiled output for further processing. Use `prepare_workflow` API.
+
+```python
+from kfp_tekton.compiler import TektonCompiler
+python_dict = TektonCompiler().prepare_workflow(echo_pipeline)
+
+pprint(python_dict)
+```
+
+This returns the tuple of `pipeline_loop_crs, workflow dict`. `pipeline_loop_crs` is a List of Dict (where each dict is 
+a custom resource for the `PipelineLoop` custom task ) and `workflow` is a dict containing the compiled tekton
+`PipelineRun`. By default, all except recursive pipelines, `pipelineloop` crs are embedded in workflow via 
+task inlining. So, for most pipelines first list will be empty.
+
+For example output of above snippet is:
+
+```
+([],
+ {'apiVersion': 'tekton.dev/v1beta1',
+  'kind': 'PipelineRun',
+  'metadata': {'annotations': {'pipelines.kubeflow.org/pipeline_spec': '{"description": '
+                                                                       '"echo '
+                                                                       'pipeline", '
+                                                                       '"name": '
+                                                                       '"echo"}',
+                               'sidecar.istio.io/inject': 'false',
+                               'tekton.dev/artifact_bucket': 'mlpipeline',
+                               'tekton.dev/artifact_endpoint': 'minio-service.kubeflow:9000',
+                               'tekton.dev/artifact_endpoint_scheme': 'http://',
+                               'tekton.dev/artifact_items': '{"echo": []}',
+                               'tekton.dev/input_artifacts': '{}',
+                               'tekton.dev/output_artifacts': '{}'},
+               'name': 'echo'},
+  'spec': {'pipelineSpec': {'tasks': [{'name': 'echo',
+                                       'taskSpec': {'metadata': {'annotations': {'tekton.dev/template': ''},
+                                                                 'labels': {'pipelines.kubeflow.org/cache_enabled': 'true',
+                                                                            'pipelines.kubeflow.org/generation': '',
+                                                                            'pipelines.kubeflow.org/pipelinename': ''}},
+                                                    'steps': [{'args': ['echo '
+                                                                        '"Got '
+                                                                        'scheduled"'],
+                                                               'command': ['sh',
+                                                                           '-c'],
+                                                               'image': 'busybox',
+                                                               'name': 'main'}]},
+                                       'timeout': '0s'}]},
+           'timeout': '0s'}})
 ```
 
 ### 2. Compile Pipelines Using the `dsl-compile-tekton` Bash Command Line Tool

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -1285,7 +1285,7 @@ class TektonCompiler(Compiler):
     """Dump pipeline workflow into yaml spec and write out in the format specified by the user.
 
     Args:
-      workflow: Workflow spec of the pipline, dict.
+      workflow: Workflow spec of the pipeline, dict.
       package_path: file path to be written. If not specified, a yaml_text string
         will be returned.
     """
@@ -1333,7 +1333,22 @@ class TektonCompiler(Compiler):
           'The output path %s should end with one of the following formats: '
           '[.tar.gz, .tgz, .zip, .yaml, .yml]' % package_path)
 
-  def prepare_workflow(self, workflow: Dict[Text, Any]):
+  def prepare_workflow(self,
+                       pipeline_func: Callable,
+                       pipeline_name: Text = None,
+                       pipeline_description: Text = None,
+                       params_list: List[dsl.PipelineParam] = None,
+                       pipeline_conf: dsl.PipelineConf = None,
+                       ):
+    """Compile the given pipeline function and return a python Dict."""
+
+    workflow = self._create_workflow(
+      pipeline_func,
+      pipeline_name,
+      pipeline_description,
+      params_list,
+      pipeline_conf)
+
     # Separate loop workflow from the main workflow
     pipeline_loop_crs = []
     if self.loops_pipeline:
@@ -1373,14 +1388,14 @@ class TektonCompiler(Compiler):
                                  package_path: Text = None,
                                  ) -> None:
     """Compile the given pipeline function and dump it to specified file format."""
-    workflow = self._create_workflow(
-        pipeline_func,
-        pipeline_name,
-        pipeline_description,
-        params_list,
-        pipeline_conf)
 
-    pipeline_loop_crs, workflow = self.prepare_workflow(workflow)
+    pipeline_loop_crs, workflow = self.prepare_workflow(
+      pipeline_func,
+      pipeline_name,
+      pipeline_description,
+      params_list,
+      pipeline_conf)
+
     # create cr yaml for only those pipelineLoop cr which could not be converted to inlined spec.
     loop_package_annotations = []
     for i in range(len(pipeline_loop_crs)):


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #737

**Description of your changes:**
Add an API (i.e. prepare_workflow) to return prepared workflow as python dicts.

Advantage of this API is, that is saves few microseconds spent in compiling python dict in yaml and store on disk, 
because it returns the python dict in memory.

Disadvantage of the approach,

It will allow the end users to direct consume internal data-structure and they may tend to rely on its structure. In future, we do not guarantee that the fields or structure of field will not change in this dict.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
