### PR TITLE
fix(sdk): "when" in some ParallelFor loops

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -713,8 +713,13 @@ class TektonCompiler(Compiler):
                         return True
               return False
             if is_custom_task_output(condition_operand1) or is_custom_task_output(condition_operand2):
-              map_cel_vars = lambda a: '$(tasks.%s.results.%s)' % \
-                (sanitize_k8s_name(a['op_name']), sanitize_k8s_name(a['output_name'])) if a.get('type', '') == dsl.PipelineParam else a.get('value', '')
+              def map_cel_vars(a):
+                if a.get('type', '') == dsl.PipelineParam:
+                  op_name = sanitize_k8s_name(a['op_name'])
+                  output_name = sanitize_k8s_name(a['output_name'])
+                  return '$(tasks.%s.results.%s)' % (op_name, output_name)
+                else:
+                  return a.get('value', '')
 
               condition_refs[template['metadata']['name']] = [
                   {


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #761

**Description of your changes:**
As described in the issue:

```python
map_cel_vars = lambda a: '$(tasks.%s.results.%s)' % (sanitize_k8s_name(a['value'].split('.')[-1]),
  sanitize_k8s_name(a['output_name'])) if a.get('type', '') == dsl.PipelineParam else a.get('value', '')

condition_refs[template['metadata']['name']] = [
  {
    'input': map_cel_vars(condition_operand1),
    'operator': conditionOp_mapping[condition_operator['value']],
    'values': [map_cel_vars(condition_operand2)]
  }
]
```

Uses `'value'` field and tries to decompose it, instead of using `'op_name'` directly. This PR changes that.

**Environment tested:**

* Python Version (use `python --version`): 3.9.0
* Tekton Version (use `tkn version`): irrelevant
* Kubernetes Version (use `kubectl version`): irrelevant
* OS (e.g. from `/etc/os-release`): irrelevant

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
