### PR TITLE
Fix a typo for the openshift docs

### DIFF
--- a/guides/kfp_tekton_install.md
+++ b/guides/kfp_tekton_install.md
@@ -67,7 +67,7 @@ To install the standalone Kubeflow Pipelines with Tekton, run the following step
 
 6. (OpenShift only) If you are running the standalone KFP-Tekton on OpenShift, apply the necessary security context constraint below
    ```shell
-   oc apply -f manifests/kustomize/third-party/openshift/standalone
+   oc apply -k manifests/kustomize/third-party/openshift/standalone
    ```
 
 ## Kubeflow installation including Kubeflow Pipelines with Tekton Backend


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
There's a typo for deploying openshift scc. It should deploy with `-k` flag because our manifests are written in kustomize.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
