### PR TITLE
Add UI backward compatibility for dsl.container syntax

### DIFF
--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -434,7 +434,7 @@ export default class WorkflowParser {
       workflow.spec.pipelineSpec.tasks.forEach((task: any) => {
         if (
           parentTask === task.name &&
-          task.taskSpec.metadata.labels['pipelines.kubeflow.org/cache_enabled'] === 'true' &&
+          ((((task.taskSpec||{}).metadata||{}).labels||{})['pipelines.kubeflow.org/cache_enabled']||'false') === 'true' &&
           cachedPipelineRun
         )
           pipelineRunID = cachedPipelineRun;
@@ -472,7 +472,7 @@ export default class WorkflowParser {
       workflow.spec.pipelineSpec.tasks.forEach((task: any) => {
         if (
           taskName === task.name &&
-          task.taskSpec.metadata.labels['pipelines.kubeflow.org/cache_enabled'] === 'true' &&
+          ((((task.taskSpec||{}).metadata||{}).labels||{})['pipelines.kubeflow.org/cache_enabled']||'false') === 'true' &&
           cachedPipelineRun
         )
           pipelineRunID = cachedPipelineRun;

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -815,15 +815,17 @@ class TektonCompiler(Compiler):
         if task_ref.get('taskSpec', ''):
           task_ref['taskSpec']['metadata'] = task_ref['taskSpec'].get('metadata', {})
           task_labels = template['metadata'].get('labels', {})
-          task_ref['taskSpec']['metadata']['labels'] = task_labels
           task_labels['pipelines.kubeflow.org/pipelinename'] = task_labels.get('pipelines.kubeflow.org/pipelinename', '')
           task_labels['pipelines.kubeflow.org/generation'] = task_labels.get('pipelines.kubeflow.org/generation', '')
           cache_default = self.pipeline_labels.get('pipelines.kubeflow.org/cache_enabled', 'true')
           task_labels['pipelines.kubeflow.org/cache_enabled'] = task_labels.get('pipelines.kubeflow.org/cache_enabled', cache_default)
 
           task_annotations = template['metadata'].get('annotations', {})
-          task_ref['taskSpec']['metadata']['annotations'] = task_annotations
           task_annotations['tekton.dev/template'] = task_annotations.get('tekton.dev/template', '')
+
+          # Updata default metadata at the end.
+          task_ref['taskSpec']['metadata']['labels'] = task_labels
+          task_ref['taskSpec']['metadata']['annotations'] = task_annotations
 
         task_refs.append(task_ref)
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #767 

**Description of your changes:**
The UI backward compatibility for dsl.container syntax was broken because there's some new metadata introduced for the cached workloads. So we add a dummy annotation template when users didn't create the pipeline using the component.yaml.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
