### PR TITLE
Add performance test script

### DIFF
--- a/sdk/python/tests/compiler/performance_tests.py
+++ b/sdk/python/tests/compiler/performance_tests.py
@@ -35,12 +35,14 @@ from kfp_tekton.compiler.pipeline_utils import TektonPipelineConf
 # =============================================================================
 
 # TODO: remove defaults below, add instructions and/or script parameters
-PUBLIC_IP = env.get("PUBLIC_IP")  # mlx-demo
+PUBLIC_IP = env.get("PUBLIC_IP")
+NAMESPACE = env.get("NAMESPACE", None)
 USER_INFO = env.get("USER_INFO")
 CONNECT_SID = env.get("CONNECT_SID")
 
 print(f"Environment variables:\n"
       f"  PUBLIC_IP:   {PUBLIC_IP}\n"
+      f"  NAMESPACE:   {NAMESPACE}\n"
       f"  USER_INFO:   {USER_INFO}\n"
       f"  CONNECT_SID: {CONNECT_SID}\n")
 
@@ -56,8 +58,9 @@ experiment_name = "PERF_TEST"
 
 def get_client() -> TektonClient:
     host = f"http://{PUBLIC_IP}/pipeline"
-    cookies = f"connect.sid={CONNECT_SID}; userinfo={USER_INFO}"
+    cookies = f"connect.sid={CONNECT_SID}; userinfo={USER_INFO}" if CONNECT_SID and USER_INFO else None
     client = TektonClient(host=host, cookies=cookies)
+    client.set_user_namespace(NAMESPACE)  # overwrite system default with None if necessary
     return client
 
 

--- a/sdk/python/tests/compiler/performance_tests.py
+++ b/sdk/python/tests/compiler/performance_tests.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import os
+# import sys
+import tempfile
+import time
+
+from datetime import datetime as dt
+from os import environ as env
+from typing import Mapping, Callable
+
+from kfp_server_api import ApiRun, ApiRunDetail, ApiException
+from kfp_tekton.compiler import TektonCompiler
+from kfp_tekton._client import TektonClient
+from kfp_tekton.compiler.pipeline_utils import TektonPipelineConf
+
+
+# =============================================================================
+#  load test settings from environment variables
+# =============================================================================
+
+# TODO: remove defaults below, add instructions and/or script parameters
+PUBLIC_IP = env.get("PUBLIC_IP")  # mlx-demo
+USER_INFO = env.get("USER_INFO")
+CONNECT_SID = env.get("CONNECT_SID")
+
+print(f"Environment variables:\n"
+      f"  PUBLIC_IP:   {PUBLIC_IP}\n"
+      f"  USER_INFO:   {USER_INFO}\n"
+      f"  CONNECT_SID: {CONNECT_SID}\n")
+
+
+# =============================================================================
+#  local settings that are not loaded from env variables
+# =============================================================================
+
+# kfp_tekton_root_dir = os.path.abspath(__file__).replace("sdk/python/tests/compiler/performance_tests.py", "")
+
+experiment_name = "PERF_TEST"
+
+
+def get_client() -> TektonClient:
+    host = f"http://{PUBLIC_IP}/pipeline"
+    cookies = f"connect.sid={CONNECT_SID}; userinfo={USER_INFO}"
+    client = TektonClient(host=host, cookies=cookies)
+    return client
+
+
+def compile_pipeline(pipeline_func: Callable) -> str:
+    pipeline_name = pipeline_func.__name__
+    file_name = pipeline_name + '.yaml'
+    tmpdir = tempfile.gettempdir()
+    pipeline_package_path = os.path.join(tmpdir, file_name)
+    pipeline_conf = TektonPipelineConf()
+    TektonCompiler().compile(pipeline_func=pipeline_func,
+                             package_path=pipeline_package_path,
+                             pipeline_conf=pipeline_conf)
+    return pipeline_package_path
+
+
+def run_pipeline(pipeline_file: str,
+                 arguments: Mapping[str, str] = None):
+    client = get_client()
+    pipeline_name = os.path.splitext(os.path.basename(pipeline_file))[0]
+    run_name = pipeline_name  # + ' ' + datetime.datetime.now().strftime('%Y-%m-%d %H-%M-%S')
+    experiment = client.create_experiment(experiment_name)  # get or create
+    run_result = None
+    while run_result is None:
+        try:
+            run_result: ApiRun = client.run_pipeline(
+                experiment_id=experiment.id,
+                job_name=run_name,
+                pipeline_package_path=pipeline_file,
+                params=arguments)
+        except ApiException as e:
+            print(f"KFP Server Exception: '{e.reason}' {e.status} '{e.body}' {datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')}")
+            time.sleep(1)
+            client = get_client()
+
+    return run_result.id
+
+
+def wait_for_run_to_complete(run_id: str) -> ApiRun:
+    client = get_client()
+    status = None
+    while status not in ["Succeeded", "Failed", "Error", "Skipped", "Terminated", "Completed", "CouldntGetTask"]:
+        try:
+            run_detail: ApiRunDetail = client.get_run(run_id)
+            run: ApiRun = run_detail.run
+            status = run.status
+        except ApiException as e:
+            print(f"KFP Server Exception: {e.reason}")
+            time.sleep(1)
+        time.sleep(0.1)
+    print(f"{run.name} took {(run.finished_at - run.created_at)}:"
+          f" started at {run.created_at.strftime('%H:%M:%S.%f')[:-3]},"
+          f" `{run.status}` at {run.finished_at.strftime('%H:%M:%S.%f')[:-3]}")
+    return run
+
+
+def load_pipeline_functions() -> [Callable]:
+    pipeline_functions = []
+
+    from testdata.sequential import sequential_pipeline
+    pipeline_functions.append(sequential_pipeline)
+
+    from testdata.condition import flipcoin
+    pipeline_functions.append(flipcoin)
+
+    from testdata.compose import save_most_frequent_word
+    pipeline_functions.append(save_most_frequent_word)
+
+    from testdata.retry import retry_sample_pipeline
+    pipeline_functions.append(retry_sample_pipeline)
+
+    from testdata.loop_static import pipeline as loop_static
+    pipeline_functions.append(loop_static)
+
+    # from testdata.condition_custom_task import flipcoin_pipeline
+    # pipeline_functions.append(flipcoin_pipeline)
+
+    from testdata.conditions_and_loops import conditions_and_loops
+    pipeline_functions.append(conditions_and_loops)
+
+    # from testdata.loop_in_recursion import flipcoin as loop_in_loop
+    # pipeline_functions.append(loop_in_loop)
+
+    # TODO: add more pipelines
+
+    # NOTE: loading samples from outside package scope is hacky
+    # sys.path.insert(1, '/Users/dummy/projects/kfp-tekton/samples/lightweight-component')
+    # from calc_pipeline import calc_pipeline
+    # pipeline_functions.append(calc_pipeline)
+
+    return pipeline_functions
+
+
+def run_performance_test():
+
+    output_file = f"performance_test_times_{dt.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv"
+    output_sep = ","
+
+    with open(output_file, "w") as f:
+        f.write(output_sep.join(["Pipeline", "Compile", "Submit", "Run"]) + "\n")
+
+    pipeline_functions = load_pipeline_functions()
+
+    for p in pipeline_functions:
+        t = [dt.now()]
+
+        pipeline_file = compile_pipeline(p)
+        t += [dt.now()]
+
+        run_id = run_pipeline(pipeline_file)
+        t += [dt.now()]
+
+        run_details = wait_for_run_to_complete(run_id)  # noqa F841
+        t += [dt.now()]
+
+        with open(output_file, "a") as f:
+            time_deltas = [str(t[i + 1] - t[i]) for i in range(len(t) - 1)]
+            f.write(output_sep.join([p.__name__] + time_deltas) + "\n")
+
+
+if __name__ == '__main__':
+    run_performance_test()
+
+    # client = get_client()
+    # experiments = client.list_experiments(namespace='mlx')
+    # experiment = client.create_experiment(name='PERF_TESTS', namespace='mlx')
+    # experiment = client.get_experiment(experiment_name='PERF_TESTS')
+    # runs = client.list_runs(experiment_id=experiment.id, page_size=100)
+    # print(experiments)

--- a/sdk/python/tests/compiler/performance_tests.py
+++ b/sdk/python/tests/compiler/performance_tests.py
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
 import datetime
+import functools
 import os
-# import sys
+import sys  # noqa
 import tempfile
 import time
+import threading
 
 from datetime import datetime as dt
 from os import environ as env
@@ -34,17 +37,26 @@ from kfp_tekton.compiler.pipeline_utils import TektonPipelineConf
 #  load test settings from environment variables
 # =============================================================================
 
-# TODO: remove defaults below, add instructions and/or script parameters
+# TODO: turn env vars into script parameters
 PUBLIC_IP = env.get("PUBLIC_IP")
 NAMESPACE = env.get("NAMESPACE", None)
 USER_INFO = env.get("USER_INFO")
 CONNECT_SID = env.get("CONNECT_SID")
+NUM_WORKERS = int(env.get("NUM_WORKERS", 1))
+EXPERIMENT = env.get("EXPERIMENT_NAME", "PERF_TEST")
+OUTPUT_FILE = env.get("OUTPUT_FILE", f"perf_test_{dt.now().strftime('%Y%m%d_%H%M%S')}_{PUBLIC_IP}.csv")
+OUTPUT_SEP = env.get("OUTPUT_SEP", ",")
 
-print(f"Environment variables:\n"
+
+print(f"Environment variables:\n\n"
       f"  PUBLIC_IP:   {PUBLIC_IP}\n"
       f"  NAMESPACE:   {NAMESPACE}\n"
       f"  USER_INFO:   {USER_INFO}\n"
-      f"  CONNECT_SID: {CONNECT_SID}\n")
+      f"  CONNECT_SID: {CONNECT_SID}\n"
+      f"  NUM_WORKERS: {NUM_WORKERS}\n"
+      f"  EXPERIMENT:  {EXPERIMENT}\n"
+      f"  OUTPUT_FILE: {OUTPUT_FILE}\n"
+      f"  OUTPUT_SEP:  {OUTPUT_SEP}\n")
 
 
 # =============================================================================
@@ -52,8 +64,6 @@ print(f"Environment variables:\n"
 # =============================================================================
 
 # kfp_tekton_root_dir = os.path.abspath(__file__).replace("sdk/python/tests/compiler/performance_tests.py", "")
-
-experiment_name = "PERF_TEST"
 
 
 def get_client() -> TektonClient:
@@ -64,10 +74,38 @@ def get_client() -> TektonClient:
     return client
 
 
+# method annotation to ensure the wrapped function is executed synchronously
+def synchronized(function):
+    lock = threading.Lock()
+
+    @functools.wraps(function)
+    def _synchronized_function(*args, **kwargs):
+        with lock:
+            result = function(*args, **kwargs)
+            return result
+
+    return _synchronized_function
+
+
+# TODO: synchronizing pipeline compilation skews recorded compile times since some
+#   pipelines will wait for others to be compiled, yet the recorded compilation
+#   start times are equal for all pipelines
+#   We need to change test design to run and time pipeline compilation sequentially
+#   and only execute pipelines in parallel
+if NUM_WORKERS > 1:
+    print("WARNING: pipeline compilation times are not accurate when running in parallel.\n")
+
+
+# TODO: cannot compile multiple pipelines in parallel due to use of static variables
+#   causing Exception "Nested pipelines are not allowed." in kfp/dsl/_pipeline.py
+#   def __enter__(self):
+#     if Pipeline._default_pipeline:
+#       raise Exception('Nested pipelines are not allowed.')
+@synchronized
 def compile_pipeline(pipeline_func: Callable) -> str:
     pipeline_name = pipeline_func.__name__
     file_name = pipeline_name + '.yaml'
-    tmpdir = tempfile.gettempdir()
+    tmpdir = tempfile.gettempdir()  # TODO: keep compiled pipelines?
     pipeline_package_path = os.path.join(tmpdir, file_name)
     pipeline_conf = TektonPipelineConf()
     TektonCompiler().compile(pipeline_func=pipeline_func,
@@ -81,9 +119,9 @@ def run_pipeline(pipeline_file: str,
                  arguments: Mapping[str, str] = None):
 
     client = get_client()
-    experiment = client.create_experiment(experiment_name)  # get or create
+    experiment = client.create_experiment(EXPERIMENT)  # get or create
     run_result = None
-    while run_result is None:
+    while run_result is None:  # TODO: add timeout or max retries on ApiException
         try:
             run_result: ApiRun = client.run_pipeline(
                 experiment_id=experiment.id,
@@ -91,7 +129,8 @@ def run_pipeline(pipeline_file: str,
                 pipeline_package_path=pipeline_file,
                 params=arguments)
         except ApiException as e:
-            print(f"KFP Server Exception: '{e.reason}' {e.status} '{e.body}' {datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')}")
+            print(f"KFP Server Exception: '{e.reason}' {e.status} '{e.body}'"
+                  f" {datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')}")
             time.sleep(1)
             client = get_client()
 
@@ -101,12 +140,13 @@ def run_pipeline(pipeline_file: str,
 def wait_for_run_to_complete(run_id: str) -> ApiRun:
     client = get_client()
     status = None
-    while status not in ["Succeeded", "Failed", "Error", "Skipped", "Terminated", "Completed", "CouldntGetTask"]:
+    while status not in ["Succeeded", "Failed", "Error", "Skipped", "Terminated",
+                         "Completed", "CouldntGetTask"]:
         try:
             run_detail: ApiRunDetail = client.get_run(run_id)
             run: ApiRun = run_detail.run
             status = run.status
-        except ApiException as e:
+        except ApiException as e:  # TODO: add timeout or max retries on ApiError
             print(f"KFP Server Exception: {e.reason}")
             time.sleep(1)
         time.sleep(0.1)
@@ -137,11 +177,11 @@ def load_pipeline_functions() -> [(Callable, str)]:
     from testdata.conditions_and_loops import conditions_and_loops
     pipeline_functions.append((conditions_and_loops, "conditions_and_loops"))
 
-    from testdata.condition_custom_task import flipcoin_pipeline
-    pipeline_functions.append((flipcoin_pipeline, "condition_custom_task"))
-
-    from testdata.loop_in_recursion import flipcoin as loop_in_loop
-    pipeline_functions.append((loop_in_loop, "loop_in_recursion"))
+    # from testdata.loop_in_recursion import flipcoin as loop_in_loop
+    # pipeline_functions.append((loop_in_loop, "loop_in_recursion"))
+    #
+    # from testdata.condition_custom_task import flipcoin_pipeline
+    # pipeline_functions.append((flipcoin_pipeline, "condition_custom_task"))
 
     # TODO: add more pipelines
 
@@ -153,39 +193,68 @@ def load_pipeline_functions() -> [(Callable, str)]:
     return pipeline_functions
 
 
-def run_performance_test():
+def run_single_pipeline_performance_test(pipeline_func: Callable, run_name: str) -> ApiRun:
+    t = [dt.now()]
 
-    output_file = f"performance_test_times_{dt.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv"
-    output_sep = ","
+    pipeline_file = compile_pipeline(pipeline_func)
+    t += [dt.now()]
 
-    with open(output_file, "w") as f:
-        f.write(output_sep.join(["Pipeline", "Compile", "Submit", "Run"]) + "\n")
+    run_id = run_pipeline(pipeline_file, run_name)
+    t += [dt.now()]
+
+    run_details = wait_for_run_to_complete(run_id)  # noqa F841
+    t += [dt.now()]
+
+    with open(OUTPUT_FILE, "a") as f:
+        time_deltas = [str(t[i + 1] - t[i]) for i in range(len(t) - 1)]
+        f.write(OUTPUT_SEP.join([run_name] + time_deltas) + "\n")
+
+    return run_details
+
+
+def run_concurrently(pipelinefunc_name_tuples: [(Callable, str)]) -> [(str, str)]:
+    pipeline_status = []
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=NUM_WORKERS) as executor:
+        performance_tests = (
+            executor.submit(run_single_pipeline_performance_test, func, name)
+            for (func, name) in pipelinefunc_name_tuples
+        )
+        for performance_test in concurrent.futures.as_completed(performance_tests):
+            try:
+                run_details = performance_test.result()
+                pipeline_status.append((run_details.name, run_details.status))
+            except Exception as e:
+                error = f"{e.__class__.__name__}: {str(e)}"
+                print(error)
+                pipeline_status.append(("unknown pipeline", error))
+
+    return pipeline_status
+
+
+def run_performance_tests():
+
+    with open(OUTPUT_FILE, "w") as f:
+        f.write(OUTPUT_SEP.join(["Pipeline", "Compile", "Submit", "Run"]) + "\n")
 
     pipeline_functions = load_pipeline_functions()
 
-    for func, name in pipeline_functions:
-        t = [dt.now()]
-
-        pipeline_file = compile_pipeline(func)
-        t += [dt.now()]
-
-        run_id = run_pipeline(pipeline_file, name)
-        t += [dt.now()]
-
-        run_details = wait_for_run_to_complete(run_id)  # noqa F841
-        t += [dt.now()]
-
-        with open(output_file, "a") as f:
-            time_deltas = [str(t[i + 1] - t[i]) for i in range(len(t) - 1)]
-            f.write(output_sep.join([name] + time_deltas) + "\n")
+    if NUM_WORKERS == 1:  # TODO: use `run_concurrently()` even with 1 worker
+        for func, name in pipeline_functions:
+            run_single_pipeline_performance_test(func, name)
+    else:
+        run_concurrently(pipeline_functions)
 
 
 if __name__ == '__main__':
-    run_performance_test()
+
+    run_performance_tests()
 
     # client = get_client()
-    # experiments = client.list_experiments(namespace='mlx')
-    # experiment = client.create_experiment(name='PERF_TESTS', namespace='mlx')
-    # experiment = client.get_experiment(experiment_name='PERF_TESTS')
-    # runs = client.list_runs(experiment_id=experiment.id, page_size=100)
-    # print(experiments)
+    # from kfp_server_api import ApiListExperimentsResponse, ApiExperiment, ApiListRunsResponse
+    # experiments: ApiListExperimentsResponse = client.list_experiments()
+    # experiment: ApiExperiment = client.create_experiment(name='PERF_TESTS')
+    # experiment: ApiExperiment = client.get_experiment(experiment_name='PERF_TEST')
+    # runs: ApiListRunsResponse = client.list_runs(experiment_id=experiment.id, page_size=100)
+    # print("Experiments: " + ", ".join([e.name for e in experiments.experiments]))
+    # print("Runs: " + ", ".join([r.name for r in runs.runs]))

--- a/sdk/python/tests/compiler/performance_tests.py
+++ b/sdk/python/tests/compiler/performance_tests.py
@@ -150,9 +150,10 @@ def wait_for_run_to_complete(run_id: str) -> ApiRun:
             print(f"KFP Server Exception: {e.reason}")
             time.sleep(1)
         time.sleep(0.1)
-    print(f"{run.name} took {(run.finished_at - run.created_at)}:"
-          f" started at {run.created_at.strftime('%H:%M:%S.%f')[:-3]},"
-          f" `{run.status}` at {run.finished_at.strftime('%H:%M:%S.%f')[:-3]}")
+    print(f"{run.name.ljust(20)[:20]}"
+          f" {run.status.lower().ljust(10)[:10]}"
+          f" after {(run.finished_at - run.created_at)}"
+          f" ({run.created_at.strftime('%H:%M:%S')}->{run.finished_at.strftime('%H:%M:%S')})")
     return run
 
 

--- a/sdk/python/tests/compiler/performance_tests.py
+++ b/sdk/python/tests/compiler/performance_tests.py
@@ -81,7 +81,7 @@ def record_execution_time(pipeline_name: str,
 def time_it(function):
 
     @functools.wraps(function)
-    def _function(*args, **kwargs):
+    def _timed_function(*args, **kwargs):
 
         start_time = dt.now()
 
@@ -89,9 +89,9 @@ def time_it(function):
 
         execution_time = dt.now() - start_time
 
-        if "pipeline_name" not in kwargs:
-            raise ValueError(f"The function '{function.__name__}' has to be invoked"
-                             f" with keyword argument parameter 'pipeline_name'.")
+        assert "pipeline_name" in kwargs, \
+            f"The function '{function.__name__}' has to be invoked with keyword" \
+            f" argument parameter 'pipeline_name'."
 
         record_execution_time(pipeline_name=kwargs["pipeline_name"],
                               function_name=function.__name__,
@@ -99,7 +99,7 @@ def time_it(function):
 
         return functions_result
 
-    return _function
+    return _timed_function
 
 
 # method annotation to ensure the wrapped function is executed synchronously


### PR DESCRIPTION
**Description of your changes:**

Adding a rudimentary performance test script, to be improved over time.

The script loads a small set of pipelines, currently from the compiler testdata.

For each pipeline it times ...
* pipeline compilation
* pipeline run submit
* pipeline run time

And adds the records to a CSV file:

|Pipeline|Compile|Submit|Run|
|-|-|-|-|
|sequential_pipeline|0:00:00.081066|0:00:00.322569|0:00:29.895088|
|flipcoin|0:00:00.123511|0:00:00.646792|0:01:42.271202|
|save_most_frequent_word|0:00:00.042771|0:00:00.369670|0:01:29.414623|
|retry_sample_pipeline|0:00:00.072874|0:00:00.277650|0:00:40.157533|
|pipeline|0:00:00.103826|0:00:00.322516|0:00:26.575043|
|conditions_and_loops|0:00:00.144815|0:00:00.483953|0:02:06.636966|
|...| | | |

**Environment variables to set:**

```Python
PUBLIC_IP = env.get("PUBLIC_IP", "169....")
USER_INFO = env.get("USER_INFO", '{"username":"admin", ...}')
CONNECT_SID = env.get("CONNECT_SID", "s:OerT...m3A")
NAMESPACE = 
```

**How to run it:**

```Bash
export PUBLIC_IP="169...."

# in case of multi-user deployment, specify the following env vars
export NAMESPACE=...
export USER_INFO='{"username":"...","email":"...","roles":["admin"]}' 
export CONNECT_SID="s:Oer***************fRKNm3A" 

cd sdk/python/tests/compiler
python3 performance_tests.py 
# ... wait for script to finish
cat performance_test_times_*.csv
```

Running the test script with 10 concurrent workers:

```Bash
NUM_WORKERS=10 sdk/python/tests/compiler/performance_tests.py
```

**Caveats/TODOs:**

- [ ] add script parameters instead of ENV vars
- [ ] KFP client authentication requires a browser login to scrape the auth cookie (`connect.sid` and `userinfo`)
- [ ] add script documentation
- [ ] parameterize output file path instead of creating it in current working directory
- [ ] list of pipelines is incomplete
- [x] distinguish pipeline functions that have duplicated names
- [ ] pipelines with custom tasks don't work yet -- they crash the ml-pipeline service
- [x] run pipelines in parallel
- [ ] get execution times for each task

