### PR TITLE
expose current iteration item to pipelinerun's annotation

### DIFF
--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
@@ -69,6 +69,9 @@ const (
 	// pipelineLoopIterationLabelKey is the label identifier for the iteration number.  This label is added to the Run's PipelineRuns.
 	pipelineLoopIterationLabelKey = "/pipelineLoopIteration"
 
+	// pipelineLoopCurrentIterationItemAnnotationKey is the annotation identifier for the iteration items (string array). This annotation is added to the Run's PipelineRuns.
+	pipelineLoopCurrentIterationItemAnnotationKey = "/pipelineLoopCurrentIterationItem"
+
 	// LabelKeyWorkflowRunId is the label identifier a pipelinerun is managed by the Kubeflow Pipeline persistent agent.
 	LabelKeyWorkflowRunId = "pipeline/runid"
 )
@@ -191,7 +194,7 @@ func EnableCustomTaskFeatureFlag(ctx context.Context) context.Context {
 	defaults, _ := config.NewDefaultsFromMap(map[string]string{})
 	featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{
 		"enable-custom-tasks": "true",
-		"enable-api-fields" : "alpha",
+		"enable-api-fields":   "alpha",
 	})
 	artifactBucket, _ := config.NewArtifactBucketFromMap(map[string]string{})
 	artifactPVC, _ := config.NewArtifactPVCFromMap(map[string]string{})
@@ -230,7 +233,7 @@ func (c *Reconciler) reconcile(ctx context.Context, run *v1alpha1.Run, status *p
 	}
 
 	// Determine how many iterations of the Task will be done.
-	totalIterations, err := computeIterations(run, pipelineLoopSpec)
+	totalIterations, interationElements, err := computeIterations(run, pipelineLoopSpec)
 	if err != nil {
 		run.Status.MarkRunFailed(pipelineloopv1alpha1.PipelineLoopRunReasonFailedValidation.String(),
 			"Cannot determine number of iterations: %s", err)
@@ -325,7 +328,7 @@ func (c *Reconciler) reconcile(ctx context.Context, run *v1alpha1.Run, status *p
 
 	// Create PipelineRun to run this iteration based on parallelism
 	for i := 0; i < actualParallelism-len(currentRunningPrs); i++ {
-		pr, err := c.createPipelineRun(ctx, logger, pipelineLoopSpec, run, nextIteration)
+		pr, err := c.createPipelineRun(ctx, logger, pipelineLoopSpec, run, nextIteration, interationElements)
 		if err != nil {
 			return fmt.Errorf("error creating PipelineRun from Run %s: %w", run.Name, err)
 		}
@@ -385,10 +388,18 @@ func (c *Reconciler) getPipelineLoop(ctx context.Context, run *v1alpha1.Run) (*m
 	return &pipelineLoopMeta, &pipelineLoopSpec, nil
 }
 
-func (c *Reconciler) createPipelineRun(ctx context.Context, logger *zap.SugaredLogger, tls *pipelineloopv1alpha1.PipelineLoopSpec, run *v1alpha1.Run, iteration int) (*v1beta1.PipelineRun, error) {
+func (c *Reconciler) createPipelineRun(ctx context.Context, logger *zap.SugaredLogger, tls *pipelineloopv1alpha1.PipelineLoopSpec, run *v1alpha1.Run, iteration int, interationElements []interface{}) (*v1beta1.PipelineRun, error) {
 
 	// Create name for PipelineRun from Run name plus iteration number.
 	prName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%s", run.Name, fmt.Sprintf("%05d", iteration)))
+	pipelineRunAnnotations := getPipelineRunAnnotations(run)
+	currentIndex := iteration - 1
+	if currentIndex > len(interationElements) {
+		currentIndex = len(interationElements) - 1
+	}
+	currentIterationItemBytes, _ := json.Marshal(interationElements[currentIndex])
+	pipelineRunAnnotations[pipelineloop.GroupName+pipelineLoopCurrentIterationItemAnnotationKey] = string(currentIterationItemBytes)
+
 	pr := &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      prName,
@@ -396,7 +407,7 @@ func (c *Reconciler) createPipelineRun(ctx context.Context, logger *zap.SugaredL
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(run,
 				schema.GroupVersionKind{Group: "tekton.dev", Version: "v1alpha1", Kind: "Run"})},
 			Labels:      getPipelineRunLabels(run, strconv.Itoa(iteration)),
-			Annotations: getPipelineRunAnnotations(run),
+			Annotations: pipelineRunAnnotations,
 		},
 		Spec: v1beta1.PipelineRunSpec{
 			Params:             getParameters(run, tls, iteration),
@@ -525,12 +536,13 @@ func (c *Reconciler) updatePipelineRunStatus(logger *zap.SugaredLogger, run *v1a
 	return highestIteration, currentRunningPrs, failedPrs, nil
 }
 
-func computeIterations(run *v1alpha1.Run, tls *pipelineloopv1alpha1.PipelineLoopSpec) (int, error) {
+func computeIterations(run *v1alpha1.Run, tls *pipelineloopv1alpha1.PipelineLoopSpec) (int, []interface{}, error) {
 	// Find the iterate parameter.
 	numberOfIterations := -1
 	from := -1
 	step := -1
 	to := -1
+	interationElements := []interface{}{}
 	for _, p := range run.Spec.Params {
 		if tls.IterateNumeric != "" {
 			if p.Name == "from" {
@@ -554,42 +566,60 @@ func computeIterations(run *v1alpha1.Run, tls *pipelineloopv1alpha1.PipelineLoop
 				errDictString := json.Unmarshal([]byte(p.Value.StringVal), &dictsString)
 				errDictInt := json.Unmarshal([]byte(p.Value.StringVal), &dictsInt)
 				if errString != nil && errInt != nil && errDictString != nil && errDictInt != nil {
-					return 0, fmt.Errorf("The value of the iterate parameter %q can not transfer to array", tls.IterateParam)
+					return 0, interationElements, fmt.Errorf("The value of the iterate parameter %q can not transfer to array", tls.IterateParam)
 				}
 
 				if errString == nil {
 					numberOfIterations = len(strings)
+					for _, v := range strings {
+						interationElements = append(interationElements, v)
+					}
 					break
 				} else if errInt == nil {
 					numberOfIterations = len(ints)
+					for _, v := range ints {
+						interationElements = append(interationElements, v)
+					}
 					break
 				} else if errDictString == nil {
 					numberOfIterations = len(dictsString)
+					for _, v := range dictsString {
+						interationElements = append(interationElements, v)
+					}
 					break
 				} else if errDictInt == nil {
 					numberOfIterations = len(dictsInt)
+					for _, v := range dictsInt {
+						interationElements = append(interationElements, v)
+					}
 					break
 				}
 			}
 			if p.Value.Type == v1beta1.ParamTypeArray {
 				numberOfIterations = len(p.Value.ArrayVal)
+				for _, v := range p.Value.ArrayVal {
+					interationElements = append(interationElements, v)
+				}
 				break
 			}
 		}
 	}
 	if tls.IterateNumeric != "" {
 		if from == -1 || to == -1 {
-			return 0, fmt.Errorf("The from or to parameters was not found in runs")
+			return 0, interationElements, fmt.Errorf("The from or to parameters was not found in runs")
 		}
 		if step == -1 {
 			step = 1
 		}
 		// numberOfIterations is the number of (to - from) / step + 1
 		numberOfIterations = (to-from)/step + 1
+		for i := 0; i < numberOfIterations; i++ {
+			interationElements = append(interationElements, step*i+from)
+		}
 	} else if numberOfIterations == -1 {
-		return 0, fmt.Errorf("The iterate parameter %q was not found", tls.IterateParam)
+		return 0, interationElements, fmt.Errorf("The iterate parameter %q was not found", tls.IterateParam)
 	}
-	return numberOfIterations, nil
+	return numberOfIterations, interationElements, nil
 }
 
 func getParameters(run *v1alpha1.Run, tls *pipelineloopv1alpha1.PipelineLoopSpec, iteration int) []v1beta1.Param {

--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go
@@ -711,6 +711,7 @@ var expectedPipelineRunIterationDict = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation": "myTestAnnotationValue",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": "{\"a\":1,\"b\":2}",
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{
@@ -749,6 +750,7 @@ var expectedParaPipelineRun = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation": "myTestAnnotationValue",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": `"item1"`,
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{
@@ -784,6 +786,7 @@ var expectedParaPipelineRun1 = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation": "myTestAnnotationValue",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": `"item2"`,
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{
@@ -819,6 +822,7 @@ var expectedPipelineRunIteration1 = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation": "myTestAnnotationValue",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": `"item1"`,
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{
@@ -854,6 +858,7 @@ var expectedPipelineRunIterateNumeric1 = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation": "myTestAnnotationValue",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": "1",
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{
@@ -890,6 +895,7 @@ var expectedPipelineRunIteration2 = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation": "myTestAnnotationValue",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": `"item2"`,
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{
@@ -925,6 +931,7 @@ var expectedPipelineRunWithInlineTaskIteration1 = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation": "myTestAnnotationValue",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": `"item1"`,
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{
@@ -978,6 +985,7 @@ var expectedNestedPipelineRun = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation12": "myTestAnnotationValue12",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": `"item1"`,
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{
@@ -1042,6 +1050,7 @@ var expectedConditionPipelineRunIteration1 = &v1beta1.PipelineRun{
 		},
 		Annotations: map[string]string{
 			"myTestAnnotation": "myTestAnnotationValue",
+			"custom.tekton.dev/pipelineLoopCurrentIterationItem": `"item1"`,
 		},
 	},
 	Spec: v1beta1.PipelineRunSpec{


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #
We want to get the current iteration item in the pipeline's task node for condition check and any other purpose.
Any task run created by this pipeline will inherit the annotation list.  In our customer run we can get the item value and to our logic.

**Description of your changes:**
Get the current iteration item and add it to the pipelinerun's annotation list.

