### PR TITLE
Fix archived logs for custom tasks

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1511,68 +1511,70 @@ func (r *ResourceManager) injectArchivalStep(workflow util.Workflow, artifactIte
 		injectDefaultScript := common.IsInjectDefaultScript()
 		copyStepTemplate := common.GetCopyStepTemplate()
 
-		if (hasArtifacts && len(artifacts) > 0 && trackArtifacts) || archiveLogs || (hasArtifacts && len(artifacts) > 0 && stripEOF) {
-			artifactScript := common.GetArtifactScript()
-			if archiveLogs {
-				// Logging volumes
-				if task.TaskSpec.Volumes == nil {
-					task.TaskSpec.Volumes = []corev1.Volume{}
-				}
-				loggingVolumes := []corev1.Volume{
-					r.getHostPathVolumeSource("varlog", "/var/log"),
-					r.getHostPathVolumeSource("varlibdockercontainers", "/var/lib/docker/containers"),
-					r.getHostPathVolumeSource("varlibkubeletpods", "/var/lib/kubelet/pods"),
-					r.getHostPathVolumeSource("varlogpods", "/var/log/pods"),
-				}
-				task.TaskSpec.Volumes = append(task.TaskSpec.Volumes, loggingVolumes...)
+		if task.TaskSpec != nil {
+			if (hasArtifacts && len(artifacts) > 0 && trackArtifacts) || archiveLogs || (hasArtifacts && len(artifacts) > 0 && stripEOF) {
+				artifactScript := common.GetArtifactScript()
+				if archiveLogs {
+					// Logging volumes
+					if task.TaskSpec.Volumes == nil {
+						task.TaskSpec.Volumes = []corev1.Volume{}
+					}
+					loggingVolumes := []corev1.Volume{
+						r.getHostPathVolumeSource("varlog", "/var/log"),
+						r.getHostPathVolumeSource("varlibdockercontainers", "/var/lib/docker/containers"),
+						r.getHostPathVolumeSource("varlibkubeletpods", "/var/lib/kubelet/pods"),
+						r.getHostPathVolumeSource("varlogpods", "/var/log/pods"),
+					}
+					task.TaskSpec.Volumes = append(task.TaskSpec.Volumes, loggingVolumes...)
 
-				// Logging volumeMounts
-				if task.TaskSpec.StepTemplate == nil {
-					task.TaskSpec.StepTemplate = &corev1.Container{}
+					// Logging volumeMounts
+					if task.TaskSpec.StepTemplate == nil {
+						task.TaskSpec.StepTemplate = &corev1.Container{}
+					}
+					if task.TaskSpec.StepTemplate.VolumeMounts == nil {
+						task.TaskSpec.StepTemplate.VolumeMounts = []corev1.VolumeMount{}
+					}
+					loggingVolumeMounts := []corev1.VolumeMount{
+						{Name: "varlog", MountPath: "/var/log"},
+						{Name: "varlibdockercontainers", MountPath: "/var/lib/docker/containers", ReadOnly: true},
+						{Name: "varlibkubeletpods", MountPath: "/var/lib/kubelet/pods", ReadOnly: true},
+						{Name: "varlogpods", MountPath: "/var/log/pods", ReadOnly: true},
+					}
+					task.TaskSpec.StepTemplate.VolumeMounts = append(task.TaskSpec.StepTemplate.VolumeMounts, loggingVolumeMounts...)
 				}
-				if task.TaskSpec.StepTemplate.VolumeMounts == nil {
-					task.TaskSpec.StepTemplate.VolumeMounts = []corev1.VolumeMount{}
+
+				// Process the artifacts into minimum sh commands if running with minimum linux kernel
+				if injectDefaultScript {
+					artifactScript = r.injectDefaultScript(workflow, artifactScript, artifacts, hasArtifacts, archiveLogs, trackArtifacts, stripEOF)
 				}
-				loggingVolumeMounts := []corev1.VolumeMount{
-					{Name: "varlog", MountPath: "/var/log"},
-					{Name: "varlibdockercontainers", MountPath: "/var/lib/docker/containers", ReadOnly: true},
-					{Name: "varlibkubeletpods", MountPath: "/var/lib/kubelet/pods", ReadOnly: true},
-					{Name: "varlogpods", MountPath: "/var/log/pods", ReadOnly: true},
+
+				// Define post-processing step
+				container := *copyStepTemplate
+				if container.Name == "" {
+					container.Name = "copy-artifacts"
 				}
-				task.TaskSpec.StepTemplate.VolumeMounts = append(task.TaskSpec.StepTemplate.VolumeMounts, loggingVolumeMounts...)
-			}
+				if container.Image == "" {
+					container.Image = common.GetArtifactImage()
+				}
+				container.Env = append(container.Env,
+					r.getObjectFieldSelector("ARTIFACT_BUCKET", "metadata.annotations['tekton.dev/artifact_bucket']"),
+					r.getObjectFieldSelector("ARTIFACT_ENDPOINT", "metadata.annotations['tekton.dev/artifact_endpoint']"),
+					r.getObjectFieldSelector("ARTIFACT_ENDPOINT_SCHEME", "metadata.annotations['tekton.dev/artifact_endpoint_scheme']"),
+					r.getObjectFieldSelector("ARTIFACT_ITEMS", "metadata.annotations['tekton.dev/artifact_items']"),
+					r.getObjectFieldSelector("PIPELINETASK", "metadata.labels['tekton.dev/pipelineTask']"),
+					r.getObjectFieldSelector("PIPELINERUN", "metadata.labels['tekton.dev/pipelineRun']"),
+					r.getObjectFieldSelector("PODNAME", "metadata.name"),
+					r.getObjectFieldSelector("NAMESPACE", "metadata.namespace"),
+					r.getSecretKeySelector("AWS_ACCESS_KEY_ID", "mlpipeline-minio-artifact", "accesskey"),
+					r.getSecretKeySelector("AWS_SECRET_ACCESS_KEY", "mlpipeline-minio-artifact", "secretkey"),
+					r.getEnvVar("ARCHIVE_LOGS", strconv.FormatBool(archiveLogs)),
+					r.getEnvVar("TRACK_ARTIFACTS", strconv.FormatBool(trackArtifacts)),
+					r.getEnvVar("STRIP_EOF", strconv.FormatBool(stripEOF)),
+				)
 
-			// Process the artifacts into minimum sh commands if running with minimum linux kernel
-			if injectDefaultScript {
-				artifactScript = r.injectDefaultScript(workflow, artifactScript, artifacts, hasArtifacts, archiveLogs, trackArtifacts, stripEOF)
+				step := workflowapi.Step{Container: container, Script: artifactScript}
+				task.TaskSpec.Steps = append(task.TaskSpec.Steps, step)
 			}
-
-			// Define post-processing step
-			container := *copyStepTemplate
-			if container.Name == "" {
-				container.Name = "copy-artifacts"
-			}
-			if container.Image == "" {
-				container.Image = common.GetArtifactImage()
-			}
-			container.Env = append(container.Env,
-				r.getObjectFieldSelector("ARTIFACT_BUCKET", "metadata.annotations['tekton.dev/artifact_bucket']"),
-				r.getObjectFieldSelector("ARTIFACT_ENDPOINT", "metadata.annotations['tekton.dev/artifact_endpoint']"),
-				r.getObjectFieldSelector("ARTIFACT_ENDPOINT_SCHEME", "metadata.annotations['tekton.dev/artifact_endpoint_scheme']"),
-				r.getObjectFieldSelector("ARTIFACT_ITEMS", "metadata.annotations['tekton.dev/artifact_items']"),
-				r.getObjectFieldSelector("PIPELINETASK", "metadata.labels['tekton.dev/pipelineTask']"),
-				r.getObjectFieldSelector("PIPELINERUN", "metadata.labels['tekton.dev/pipelineRun']"),
-				r.getObjectFieldSelector("PODNAME", "metadata.name"),
-				r.getObjectFieldSelector("NAMESPACE", "metadata.namespace"),
-				r.getSecretKeySelector("AWS_ACCESS_KEY_ID", "mlpipeline-minio-artifact", "accesskey"),
-				r.getSecretKeySelector("AWS_SECRET_ACCESS_KEY", "mlpipeline-minio-artifact", "secretkey"),
-				r.getEnvVar("ARCHIVE_LOGS", strconv.FormatBool(archiveLogs)),
-				r.getEnvVar("TRACK_ARTIFACTS", strconv.FormatBool(trackArtifacts)),
-				r.getEnvVar("STRIP_EOF", strconv.FormatBool(stripEOF)),
-			)
-
-			step := workflowapi.Step{Container: container, Script: artifactScript}
-			task.TaskSpec.Steps = append(task.TaskSpec.Steps, step)
 		}
 	}
 }


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #774 

**Description of your changes:**
The current archived logs has to mount on kubelet in order to get the log files. However, in custom tasks, all workloads are ran inside the same controller that shares the same log file. Archived logs for custom task probably needs to be controller specific because only the controller knows how to capture the logs inside the reconciler and push them to object storage for archive. 

Remove kubelet mounting from custom task to prevent potential conflicts because custom tasks are not pods. They are just another entry in the k8s etcd. 

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
