### PR TITLE
update pipelineloop operator to check break tasks with taskrun

### DIFF
--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
@@ -580,6 +580,17 @@ func (c *Reconciler) updatePipelineRunStatus(logger *zap.SugaredLogger, run *v1a
 				}}
 			}
 		}
+		for _, taskRunStatus := range pr.Status.TaskRuns {
+			if strings.HasPrefix(taskRunStatus.PipelineTaskName, "pipelineloop-break-operation") {
+				// Mark run successful and stop the loop pipelinerun
+				run.Status.MarkRunSucceeded(pipelineloopv1alpha1.PipelineLoopRunReasonSucceeded.String(),
+					"PipelineRuns completed successfully with the conditions are met")
+				run.Status.Results = []runv1alpha1.RunResult{{
+					Name:  "condition",
+					Value: "pass",
+				}}
+			}
+		}
 
 		status.PipelineRuns[pr.Name] = &pipelineloopv1alpha1.PipelineLoopPipelineRunStatus{
 			Iteration: iteration,


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #807 

**Description of your changes:**
PR #807 only checks "run" name with the break task "pipelineloop-break-operation", we should also check "taskrun" name to find the break task as well.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
