### PR TITLE
Add option to produce pipelinerun taskspec as taskref

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
@@ -54,6 +54,7 @@ rules:
   - taskruns
   - conditions
   - runs
+  - tasks
   verbs:
   - create
   - get

--- a/manifests/kustomize/base/installs/multi-user/pipelines-ui/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-ui/cluster-role.yaml
@@ -46,6 +46,7 @@ rules:
   - pipelineruns
   - taskruns
   - conditions
+  - tasks
   verbs:
   - create
   - get

--- a/manifests/kustomize/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
@@ -41,6 +41,7 @@ rules:
   - taskruns
   - conditions
   - runs
+  - tasks
   verbs:
   - create
   - get

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-role.yaml
@@ -33,6 +33,7 @@ rules:
   - taskruns
   - conditions
   - runs
+  - tasks
   verbs:
   - create
   - get

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
@@ -43,6 +43,7 @@ rules:
   - taskruns
   - conditions
   - runs
+  - tasks
   verbs:
   - create
   - get

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
@@ -48,6 +48,7 @@ rules:
   - pipelineruns
   - taskruns
   - conditions
+  - tasks
   verbs:
   - create
   - get

--- a/manifests/kustomize/base/pipeline/pipeline-runner-role.yaml
+++ b/manifests/kustomize/base/pipeline/pipeline-runner-role.yaml
@@ -85,6 +85,7 @@ rules:
   - taskruns
   - conditions
   - runs
+  - tasks
   verbs:
   - create
   - get

--- a/samples/flip-coin/condition-with-taskref.py
+++ b/samples/flip-coin/condition-with-taskref.py
@@ -1,0 +1,69 @@
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import dsl
+from kfp import components
+
+def random_num(low:int, high:int) -> int:
+    """Generate a random number between low and high."""
+    import random
+    result = random.randint(low, high)
+    print(result)
+    return result
+
+def flip_coin() -> str:
+    """Flip a coin and output heads or tails randomly."""
+    import random
+    result = 'heads' if random.randint(0, 1) == 0 else 'tails'
+    print(result)
+    return result
+
+def print_msg(msg: str):
+    """Print a message."""
+    print(msg)
+
+
+flip_coin_op = components.create_component_from_func(
+    flip_coin, base_image='python:alpine3.6')
+print_op = components.create_component_from_func(
+    print_msg, base_image='python:alpine3.6')
+random_num_op = components.create_component_from_func(
+    random_num, base_image='python:alpine3.6')
+
+@dsl.pipeline(
+    name='conditional-execution-pipeline',
+    description='Shows how to use dsl.Condition().'
+)
+def flipcoin_pipeline():
+    flip = flip_coin_op()
+    with dsl.Condition(flip.output == 'heads'):
+        random_num_head = random_num_op(0, 9)
+        with dsl.Condition(random_num_head.output > 5):
+            print_op('heads and %s > 5!' % random_num_head.output)
+        with dsl.Condition(random_num_head.output <= 5):
+            print_op('heads and %s <= 5!' % random_num_head.output)
+
+    with dsl.Condition(flip.output == 'tails'):
+        random_num_tail = random_num_op(10, 19)
+        with dsl.Condition(random_num_tail.output > 15):
+            print_op('tails and %s > 15!' % random_num_tail.output)
+        with dsl.Condition(random_num_tail.output <= 15):
+            print_op('tails and %s <= 15!' % random_num_tail.output)
+
+
+if __name__ == '__main__':
+    from kfp_tekton.compiler import TektonCompiler
+    compiler = TektonCompiler()
+    compiler.produce_taskspec = False
+    compiler.compile(flipcoin_pipeline, __file__.replace('.py', '.yaml'))


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #804 

**Description of your changes:**
Have an alternative option to convert taskspec to taskref for reducing maximum yaml size. For kfp-tekton, the default behavior will stay with a single pipelinerun yaml spec because KFP cannot manage tasks on a namespace level.

The original issue here listed the cons for using taskref, such as:
https://github.com/kubeflow/kfp-tekton/issues/143
- KFP UI and API cannot manage and render taskref resources
- Task templates are shared with all users in the same namespace (used sha1 to encode the spec as task template name in order to minimize the conflict)

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
