### PR TITLE
Update pipelineloop and manifests with k8s 1.22 API

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/api-service/cluster-role-binding.yaml
+++ b/manifests/kustomize/base/installs/multi-user/api-service/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ml-pipeline

--- a/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: ml-pipeline

--- a/manifests/kustomize/base/pipeline/cluster-scoped/scheduled-workflow-crd.yaml
+++ b/manifests/kustomize/base/pipeline/cluster-scoped/scheduled-workflow-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: scheduledworkflows.kubeflow.org
@@ -8,11 +8,32 @@ spec:
     kind: ScheduledWorkflow
     listKind: ScheduledWorkflowList
     plural: scheduledworkflows
+    singular: scheduledworkflow
     shortNames:
     - swf
-    singular: scheduledworkflow
   scope: Namespaced
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            x-kubernetes-map-type: atomic
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            x-kubernetes-map-type: atomic
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true

--- a/manifests/kustomize/base/pipeline/cluster-scoped/viewer-crd.yaml
+++ b/manifests/kustomize/base/pipeline/cluster-scoped/viewer-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: viewers.kubeflow.org
@@ -8,11 +8,27 @@ spec:
     kind: Viewer
     listKind: ViewerList
     plural: viewers
+    singular: viewer
     shortNames:
     - vi
-    singular: viewer
   scope: Namespaced
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            x-kubernetes-map-type: atomic
+        required:
+        - spec
+        type: object
     served: true
     storage: true

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/201-rolebinding.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/201-rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-pipelineloop-controller
@@ -16,7 +16,7 @@ roleRef:
   name: tekton-pipelineloop-controller
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-pipelineloop-webhook

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/202-clusterrolebinding.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/202-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelineloop-controller-cluster-access
@@ -19,7 +19,7 @@ roleRef:
 # then the ClusterRole would be namespaced. The access described by
 # the tekton-pipelineloop-controller-tenant-access ClusterRole would
 # be scoped to individual tenant namespaces.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelineloop-controller-tenant-access
@@ -70,7 +70,7 @@ roleRef:
   name: tekton-pipelineloop-webhook-cluster-access
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelineloop-webhook-leaderelection

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/300-pipelineloop.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/300-pipelineloop.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: pipelineloops.custom.tekton.dev
@@ -10,21 +10,25 @@ metadata:
 spec:
   group: custom.tekton.dev
   preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # One can use x-kubernetes-preserve-unknown-fields: true
-      # at the root of the schema (and inside any properties, additionalProperties)
-      # to get the traditional CRD behaviour that nothing is pruned, despite
-      # setting spec.preserveUnknownProperties: false.
-      #
-      # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-      # See issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
   names:
     kind: PipelineLoop
     plural: pipelineloops
@@ -32,7 +36,3 @@ spec:
     - tekton
     - tekton-pipelines
   scope: Namespaced
-  # Opt into the status subresource so metadata.generation
-  # starts to increment
-  subresources:
-    status: {}

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/300-pipelineloop.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/300-pipelineloop.yaml
@@ -9,7 +9,6 @@ metadata:
     version: "devel"
 spec:
   group: custom.tekton.dev
-  preserveUnknownFields: false
   versions:
   - name: v1alpha1
     served: true

--- a/tekton-catalog/pipeline-loops/config/201-rolebinding.yaml
+++ b/tekton-catalog/pipeline-loops/config/201-rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-pipelineloop-controller
@@ -30,7 +30,7 @@ roleRef:
   name: tekton-pipelineloop-controller
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-pipelineloop-webhook

--- a/tekton-catalog/pipeline-loops/config/202-clusterrolebinding.yaml
+++ b/tekton-catalog/pipeline-loops/config/202-clusterrolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelineloop-controller-cluster-access
@@ -33,7 +33,7 @@ roleRef:
 # then the ClusterRole would be namespaced. The access described by
 # the tekton-pipelineloop-controller-tenant-access ClusterRole would
 # be scoped to individual tenant namespaces.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelineloop-controller-tenant-access
@@ -84,7 +84,7 @@ roleRef:
   name: tekton-pipelineloop-webhook-cluster-access
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelineloop-webhook-leaderelection

--- a/tekton-catalog/pipeline-loops/config/300-pipelineloop.yaml
+++ b/tekton-catalog/pipeline-loops/config/300-pipelineloop.yaml
@@ -23,7 +23,6 @@ metadata:
     version: "devel"
 spec:
   group: custom.tekton.dev
-  preserveUnknownFields: false
   versions:
   - name: v1alpha1
     served: true

--- a/tekton-catalog/pipeline-loops/config/300-pipelineloop.yaml
+++ b/tekton-catalog/pipeline-loops/config/300-pipelineloop.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: pipelineloops.custom.tekton.dev
@@ -24,21 +24,25 @@ metadata:
 spec:
   group: custom.tekton.dev
   preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # One can use x-kubernetes-preserve-unknown-fields: true
-      # at the root of the schema (and inside any properties, additionalProperties)
-      # to get the traditional CRD behaviour that nothing is pruned, despite
-      # setting spec.preserveUnknownProperties: false.
-      #
-      # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-      # See issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
   names:
     kind: PipelineLoop
     plural: pipelineloops
@@ -46,7 +50,3 @@ spec:
     - tekton
     - tekton-pipelines
   scope: Namespaced
-  # Opt into the status subresource so metadata.generation
-  # starts to increment
-  subresources:
-    status: {}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
The current pipelineloop and some manifests are still using v1beta1, we need to update them to work on k8s 1.22+.
This should make standalone deployment works on k8s 1.22. 

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
