### PR TITLE
Enable pipelineparam for container env

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_k8s_helper.py
+++ b/sdk/python/kfp_tekton/compiler/_k8s_helper.py
@@ -192,6 +192,8 @@ def sanitize_k8s_object(k8s_obj, type=None):
                     for sub_obj in k8s_obj)
     elif isinstance(k8s_obj, (datetime, date)):
       return k8s_obj
+    elif isinstance(k8s_obj, dsl.PipelineParam):
+      return k8s_obj
 
     if isinstance(k8s_obj, dict):
       return k8s_obj

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -387,6 +387,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.pipelineparams import pipelineparams_pipeline
     self._test_pipeline_workflow(pipelineparams_pipeline, 'pipelineparams.yaml', skip_noninlined=True)
 
+  def test_pipelineparam_env_workflow(self):
+    """
+    Test compiling a pipelineparams workflow.
+    """
+    from .testdata.pipelineparam_env import echo_pipeline
+    self._test_pipeline_workflow(echo_pipeline, 'pipelineparam_env.yaml', skip_noninlined=True)
+
   def test_retry_workflow(self):
     """
     Test compiling a retry task in workflow.

--- a/sdk/python/tests/compiler/testdata/pipelineparam_env.py
+++ b/sdk/python/tests/compiler/testdata/pipelineparam_env.py
@@ -1,0 +1,41 @@
+# Copyright 2022 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from kubernetes.client.models import V1EnvVar
+from kfp import dsl
+
+
+def echo_op(port_number):
+    return dsl.ContainerOp(
+        name='echo',
+        image='busybox',
+        command=['sh', '-c'],
+        arguments=['echo "Got scheduled"']
+    ).container.add_env_variable(V1EnvVar(name='PORT', value=port_number))
+
+
+@dsl.pipeline(
+    name='echo',
+    description='echo pipeline'
+)
+def echo_pipeline(
+    port_number=80
+):
+    echo = echo_op(port_number)
+
+
+if __name__ == '__main__':
+    from kfp_tekton.compiler import TektonCompiler
+    TektonCompiler().compile(echo_pipeline, 'echo_pipeline.yaml')

--- a/sdk/python/tests/compiler/testdata/pipelineparam_env.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparam_env.yaml
@@ -1,0 +1,65 @@
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: echo
+  annotations:
+    tekton.dev/output_artifacts: '{}'
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"echo": []}'
+    sidecar.istio.io/inject: "false"
+    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "echo pipeline", "inputs":
+      [{"default": "80", "name": "port_number", "optional": true}], "name": "echo"}'
+spec:
+  params:
+  - name: port_number
+    value: '80'
+  pipelineSpec:
+    params:
+    - name: port_number
+      default: '80'
+    tasks:
+    - name: echo
+      params:
+      - name: port_number
+        value: $(params.port_number)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - echo "Got scheduled"
+          command:
+          - sh
+          - -c
+          env:
+          - name: PORT
+            value: $(inputs.params.port_number)
+          image: busybox
+        params:
+        - name: port_number
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            tekton.dev/template: ''
+      timeout: 525600m
+  timeout: 525600m


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
When `sanitize_k8s_object` first introduced to sanitize k8s object for Tekton, Tekton's variable substitution wasn't allow. Now that limitation has been fixed, so we should enable pipelineparam for container env in Tekton.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
