### PR TITLE
Update KFP-Tekton installation to give guidance on GPU worker nodes.

### DIFF
--- a/guides/kfp_tekton_install.md
+++ b/guides/kfp_tekton_install.md
@@ -64,8 +64,14 @@ To install the standalone Kubeflow Pipelines with Tekton, run the following step
     ```shell
     kubectl get svc ml-pipeline-ui -n kubeflow -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
+    
+6. (GPU worker nodes only) If your Kubernetes cluster has a mixture of CPU and GPU worker nodes, it's recommended to disable the Tekton default affinity assistant so that Tekton won't schedule too many CPU workloads on the GPU nodes.
+    ```shell
+    kubectl patch cm feature-flags -n tekton-pipelines \
+      -p '{"data":{"disable-affinity-assistant": "true"}}'
+    ```
 
-6. (OpenShift only) If you are running the standalone KFP-Tekton on OpenShift, apply the necessary security context constraint below
+7. (OpenShift only) If you are running the standalone KFP-Tekton on OpenShift, apply the necessary security context constraint below
    ```shell
    oc apply -k manifests/kustomize/third-party/openshift/standalone
    ```


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
When running Tekton pipelines with mixture of GPU and CPU workloads, our users gave feedbacks that the Tekton affinity assistant schedule too many workloads on the GPU nodes. Thus update the installation guide to disable affinity assistant for GPU clusters.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
