### PR TITLE
Add support to parse pipeline param in json string

### DIFF
--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -84,6 +84,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.condition_custom_task import flipcoin_pipeline
     self._test_pipeline_workflow(flipcoin_pipeline, 'condition_custom_task.yaml', skip_noninlined=True)
 
+  def test_loop_with_params_in_json_workflow(self):
+    """
+    Test compiling a loop workflow with pipeline params in json
+    """
+    from .testdata.loop_with_params_in_json import parallelfor_pipeline_param_in_items_resolving
+    self._test_pipeline_workflow(parallelfor_pipeline_param_in_items_resolving, 'loop_with_params_in_json.yaml', skip_noninlined=True)
+
   def test_condition_dependency(self):
     """
     Test dependency on Tekton conditional task.

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 kubeflow.org
+# Copyright 2021 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator_noninlined.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 kubeflow.org
+# Copyright 2021 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,11 +38,11 @@ metadata:
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
       "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-2", "type": "string"},
-      {"name": "my_pipe_param", "type": "string"}], "steps": [{"args": ["set -e\necho
-      op1 \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-2)", "$(inputs.params.my_pipe_param)"],
-      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
-      "timeout": "525600m"}]}}}]'
+      ""}}, "params": [{"name": "loop-item-param-2", "type": "string"}, {"name": "my_pipe_param",
+      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
+      "$(inputs.params.loop-item-param-2)", "$(inputs.params.my_pipe_param)"], "command":
+      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
+      "525600m"}]}}}]'
 spec:
   params:
   - name: my_pipe_param

--- a/sdk/python/tests/compiler/testdata/loop_with_params_in_json.py
+++ b/sdk/python/tests/compiler/testdata/loop_with_params_in_json.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The Kubeflow Authors
+# Copyright 2022 kubeflow.org
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/tests/compiler/testdata/loop_with_params_in_json.py
+++ b/sdk/python/tests/compiler/testdata/loop_with_params_in_json.py
@@ -1,0 +1,64 @@
+# Copyright 2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kfp
+from kfp.components import func_to_container_op
+
+
+@func_to_container_op
+def produce_message(fname1: str) -> str:
+    return "My name is %s" % fname1
+
+
+@func_to_container_op
+def consume(param1):
+    print(param1)
+
+
+@kfp.dsl.pipeline()
+def parallelfor_pipeline_param_in_items_resolving(fname1: str, fname2: str):
+
+    simple_list = ["My name is %s" % fname1, "My name is %s" % fname2]
+
+    list_of_dict = [{
+        "first_name": fname1,
+        "message": "My name is %s" % fname1
+    }, {
+        "first_name": fname2,
+        "message": "My name is %s" % fname2
+    }]
+
+    list_of_complex_dict = [{
+        "first_name": fname1,
+        "message": produce_message(fname1).output
+    }, {
+        "first_name": fname2,
+        "message": produce_message(fname2).output
+    }]
+
+    with kfp.dsl.ParallelFor(simple_list) as loop_item:
+        consume(loop_item)
+
+    with kfp.dsl.ParallelFor(list_of_dict) as loop_item2:
+        consume(loop_item2.first_name)
+        consume(loop_item2.message)
+
+    with kfp.dsl.ParallelFor(list_of_complex_dict) as loop_item:
+        consume(loop_item.first_name)
+        consume(loop_item.message)
+
+
+if __name__ == '__main__':
+    from kfp_tekton.compiler import TektonCompiler
+    TektonCompiler().compile(parallelfor_pipeline_param_in_items_resolving, __file__.replace('.py', '.yaml'))

--- a/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
@@ -1,0 +1,438 @@
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: parallelfor-pipeline-param-in-items-resolving
+  annotations:
+    tekton.dev/output_artifacts: '{"produce-message": [{"key": "artifacts/$PIPELINERUN/produce-message/Output.tgz",
+      "name": "produce-message-Output", "path": "/tmp/outputs/Output/data"}], "produce-message-2":
+      [{"key": "artifacts/$PIPELINERUN/produce-message-2/Output.tgz", "name": "produce-message-2-Output",
+      "path": "/tmp/outputs/Output/data"}]}'
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"consume": [], "consume-2": [], "consume-3": [],
+      "consume-4": [], "consume-5": [], "produce-message": [["Output", "$(results.output.path)"]],
+      "produce-message-2": [["Output", "$(results.output.path)"]]}'
+    sidecar.istio.io/inject: "false"
+    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+    pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"name": "fname1", "type":
+      "String"}, {"name": "fname2", "type": "String"}], "name": "Parallelfor pipeline
+      param in items resolving"}'
+spec:
+  params:
+  - name: fname1
+    value: ''
+  - name: fname2
+    value: ''
+  pipelineSpec:
+    params:
+    - name: fname1
+    - name: fname2
+    tasks:
+    - name: produce-message
+      params:
+      - name: fname1
+        value: $(params.fname1)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --fname1
+          - $(inputs.params.fname1)
+          - '----output-paths'
+          - $(results.output.path)
+          command:
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def produce_message(fname1):
+                return "My name is %s" % fname1
+
+            def _serialize_str(str_value: str) -> str:
+                if not isinstance(str_value, str):
+                    raise TypeError('Value "{}" has type "{}" instead of str.'.format(str(str_value), str(type(str_value))))
+                return str_value
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Produce message', description='')
+            _parser.add_argument("--fname1", dest="fname1", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+            _parsed_args = vars(_parser.parse_args())
+            _output_files = _parsed_args.pop("_output_paths", [])
+
+            _outputs = produce_message(**_parsed_args)
+
+            _outputs = [_outputs]
+
+            _output_serializers = [
+                _serialize_str,
+
+            ]
+
+            import os
+            for idx, output_file in enumerate(_output_files):
+                try:
+                    os.makedirs(os.path.dirname(output_file))
+                except OSError:
+                    pass
+                with open(output_file, 'w') as f:
+                    f.write(_output_serializers[idx](_outputs[idx]))
+          image: python:3.7
+        params:
+        - name: fname1
+        results:
+        - name: output
+          description: /tmp/outputs/Output/data
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce message",
+              "outputs": [{"name": "Output", "type": "String"}], "version": "Produce
+              message@sha256=8b1a730905b7cb192c0dd1906d4332c8d3533193a3b8defef1adc2f15706e7ed"}'
+            tekton.dev/template: ''
+      timeout: 525600m
+    - name: produce-message-2
+      params:
+      - name: fname2
+        value: $(params.fname2)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --fname1
+          - $(inputs.params.fname2)
+          - '----output-paths'
+          - $(results.output.path)
+          command:
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def produce_message(fname1):
+                return "My name is %s" % fname1
+
+            def _serialize_str(str_value: str) -> str:
+                if not isinstance(str_value, str):
+                    raise TypeError('Value "{}" has type "{}" instead of str.'.format(str(str_value), str(type(str_value))))
+                return str_value
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Produce message', description='')
+            _parser.add_argument("--fname1", dest="fname1", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+            _parsed_args = vars(_parser.parse_args())
+            _output_files = _parsed_args.pop("_output_paths", [])
+
+            _outputs = produce_message(**_parsed_args)
+
+            _outputs = [_outputs]
+
+            _output_serializers = [
+                _serialize_str,
+
+            ]
+
+            import os
+            for idx, output_file in enumerate(_output_files):
+                try:
+                    os.makedirs(os.path.dirname(output_file))
+                except OSError:
+                    pass
+                with open(output_file, 'w') as f:
+                    f.write(_output_serializers[idx](_outputs[idx]))
+          image: python:3.7
+        params:
+        - name: fname2
+        results:
+        - name: output
+          description: /tmp/outputs/Output/data
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce message",
+              "outputs": [{"name": "Output", "type": "String"}], "version": "Produce
+              message@sha256=8b1a730905b7cb192c0dd1906d4332c8d3533193a3b8defef1adc2f15706e7ed"}'
+            tekton.dev/template: ''
+      timeout: 525600m
+    - name: parallelfor-pipeline-param-in-items-reso-for-loop-2
+      params:
+      - name: loop-item-param-1
+        value: '["My name is $(params.fname1)", "My name is $(params.fname2)"]'
+      taskSpec:
+        apiVersion: custom.tekton.dev/v1alpha1
+        kind: PipelineLoop
+        spec:
+          pipelineSpec:
+            params:
+            - name: loop-item-param-1
+              type: string
+            tasks:
+            - name: consume
+              params:
+              - name: loop-item-param-1
+                value: $(params.loop-item-param-1)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --param1
+                  - $(inputs.params.loop-item-param-1)
+                  command:
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def consume(param1):
+                        print(param1)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Consume', description='')
+                    _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = consume(**_parsed_args)
+                  image: python:3.7
+                params:
+                - name: loop-item-param-1
+                  type: string
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
+                      "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
+                    tekton.dev/template: ''
+              timeout: 525600m
+          iterateParam: loop-item-param-1
+    - name: parallelfor-pipeline-param-in-items-reso-for-loop-4
+      params:
+      - name: loop-item-param-3
+        value: '[{"first_name": "$(params.fname1)", "message": "My name is $(params.fname1)"},
+          {"first_name": "$(params.fname2)", "message": "My name is $(params.fname2)"}]'
+      taskSpec:
+        apiVersion: custom.tekton.dev/v1alpha1
+        kind: PipelineLoop
+        spec:
+          pipelineSpec:
+            params:
+            - name: loop-item-param-3-subvar-first_name
+              type: string
+            - name: loop-item-param-3-subvar-message
+              type: string
+            tasks:
+            - name: consume-2
+              params:
+              - name: loop-item-param-3-subvar-first_name
+                value: $(params.loop-item-param-3-subvar-first_name)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --param1
+                  - $(inputs.params.loop-item-param-3-subvar-first_name)
+                  command:
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def consume(param1):
+                        print(param1)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Consume', description='')
+                    _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = consume(**_parsed_args)
+                  image: python:3.7
+                params:
+                - name: loop-item-param-3-subvar-first_name
+                  type: string
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
+                      "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
+                    tekton.dev/template: ''
+              timeout: 525600m
+            - name: consume-3
+              params:
+              - name: loop-item-param-3-subvar-message
+                value: $(params.loop-item-param-3-subvar-message)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --param1
+                  - $(inputs.params.loop-item-param-3-subvar-message)
+                  command:
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def consume(param1):
+                        print(param1)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Consume', description='')
+                    _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = consume(**_parsed_args)
+                  image: python:3.7
+                params:
+                - name: loop-item-param-3-subvar-message
+                  type: string
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
+                      "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
+                    tekton.dev/template: ''
+              timeout: 525600m
+          iterateParam: loop-item-param-3
+    - name: parallelfor-pipeline-param-in-items-reso-for-loop-6
+      params:
+      - name: loop-item-param-5
+        value: '[{"first_name": "$(params.fname1)", "message": "$(tasks.produce-message.results.output)"},
+          {"first_name": "$(params.fname2)", "message": "$(tasks.produce-message-2.results.output)"}]'
+      taskSpec:
+        apiVersion: custom.tekton.dev/v1alpha1
+        kind: PipelineLoop
+        spec:
+          pipelineSpec:
+            params:
+            - name: loop-item-param-5-subvar-first_name
+              type: string
+            - name: loop-item-param-5-subvar-message
+              type: string
+            tasks:
+            - name: consume-4
+              params:
+              - name: loop-item-param-5-subvar-first_name
+                value: $(params.loop-item-param-5-subvar-first_name)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --param1
+                  - $(inputs.params.loop-item-param-5-subvar-first_name)
+                  command:
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def consume(param1):
+                        print(param1)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Consume', description='')
+                    _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = consume(**_parsed_args)
+                  image: python:3.7
+                params:
+                - name: loop-item-param-5-subvar-first_name
+                  type: string
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
+                      "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
+                    tekton.dev/template: ''
+              timeout: 525600m
+            - name: consume-5
+              params:
+              - name: loop-item-param-5-subvar-message
+                value: $(params.loop-item-param-5-subvar-message)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --param1
+                  - $(inputs.params.loop-item-param-5-subvar-message)
+                  command:
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def consume(param1):
+                        print(param1)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Consume', description='')
+                    _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = consume(**_parsed_args)
+                  image: python:3.7
+                params:
+                - name: loop-item-param-5-subvar-message
+                  type: string
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
+                      "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
+                    tekton.dev/template: ''
+              timeout: 525600m
+          iterateParam: loop-item-param-5
+  timeout: 525600m

--- a/sdk/python/tests/test_kfp_samples_report.txt
+++ b/sdk/python/tests/test_kfp_samples_report.txt
@@ -9,7 +9,7 @@ SUCCESS: input_artifact_raw_value.py
 SUCCESS: loop_over_lightweight_output.py
 SUCCESS: opsgroups.py
 SUCCESS: parallelfor_item_argument_resolving.py
-FAILURE: parallelfor_pipeline_param_in_items_resolving.py
+SUCCESS: parallelfor_pipeline_param_in_items_resolving.py
 SUCCESS: param_op_transform.py
 SUCCESS: param_substitutions.py
 SUCCESS: pipelineparams.py


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
Parsing pipeline params in json string was not supported for loops in KFP-Tekton SDK. Thus we need to add regular expression to parse the pipeline params inside the json string and replace them with Tekton variable.

This also help covering one new test case from KFP.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
