### PR TITLE
fix(sdk) separator param. Part of #791

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_tekton_handler.py
+++ b/sdk/python/kfp_tekton/compiler/_tekton_handler.py
@@ -223,7 +223,7 @@ def _handle_tekton_custom_task(custom_task: dict, workflow: dict, recursive_task
                     'type': 'string'
                 } for sub_param in custom_task[custom_task_key]['loop_sub_args']])
 
-            # add loop special filed
+            # add loop special fields
             custom_task_cr['kind'] = 'PipelineLoop'
             if custom_task[custom_task_key]['spec'].get('parallelism') is not None:
                 custom_task_cr['spec']['parallelism'] = custom_task[custom_task_key]['spec']['parallelism']

--- a/sdk/python/kfp_tekton/compiler/_tekton_handler.py
+++ b/sdk/python/kfp_tekton/compiler/_tekton_handler.py
@@ -238,6 +238,15 @@ def _handle_tekton_custom_task(custom_task: dict, workflow: dict, recursive_task
                     custom_task_cr = json.loads(
                         json.dumps(custom_task_cr).replace(custom_task_param['value'], '$(params.%s)' % custom_task_param['name']))
 
+            # remove separator from CR params
+            if custom_task[custom_task_key].get('separator') is not None:
+                separator_param = custom_task[custom_task_key]['separator']
+                custom_task_cr['spec']['pipelineSpec']['params'] = [
+                    param
+                    for param in custom_task_cr['spec']['pipelineSpec']['params']
+                    if param['name'] != separator_param
+                ]
+
         # need to process task parameters to replace out of scope results
         # because nested graph cannot refer to task results outside of the sub-pipeline.
         custom_task_cr_task_names = [custom_task_cr_task['name'] for custom_task_cr_task in custom_task_cr['spec']['pipelineSpec']['tasks']]

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
@@ -52,8 +52,6 @@ spec:
             params:
             - name: loop-item-param-2
               type: string
-            - name: loop-item-param-3
-              type: string
             - name: my_pipe_param
               type: string
             tasks:

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator_noninlined.yaml
@@ -31,10 +31,10 @@ metadata:
       "kind": "PipelineLoop", "metadata": {"name": "my-pipeline-for-loop-4"}, "spec":
       {"iterateParam": "loop-item-param-2", "iterateParamStringSeparator": "loop-item-param-3",
       "pipelineSpec": {"params": [{"name": "loop-item-param-2", "type": "string"},
-      {"name": "loop-item-param-3", "type": "string"}, {"name": "my_pipe_param", "type":
-      "string"}], "tasks": [{"name": "my-in-coop1", "params": [{"name": "loop-item-param-2",
-      "value": "$(params.loop-item-param-2)"}, {"name": "my_pipe_param", "value":
-      "$(params.my_pipe_param)"}], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
+      {"name": "my_pipe_param", "type": "string"}], "tasks": [{"name": "my-in-coop1",
+      "params": [{"name": "loop-item-param-2", "value": "$(params.loop-item-param-2)"},
+      {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"}], "taskSpec":
+      {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
       "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
A fix to the previous partial solution (PR #837) of #791.

**Description of your changes:**
Remove separator field from params inside of the loop spec. Separator shouldn't be available inside of the spec.

As noted by Tommy Li in PR #838 for range-loop support, and as confirmed by checking the PipelineLoop [test for text-separator](https://github.com/kubeflow/kfp-tekton/tree/master/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go#L251-L281):
```go
var aPipeline = &v1beta1.Pipeline{
	ObjectMeta: metav1.ObjectMeta{Name: "a-pipeline", Namespace: "foo"},
	Spec: v1beta1.PipelineSpec{
		Params: []v1beta1.ParamSpec{{
			Name: "current-item",
			Type: v1beta1.ParamTypeString,
		}, {
			Name: "additional-parameter",
			Type: v1beta1.ParamTypeString,
		}},
		Tasks: []v1beta1.PipelineTask{{
			Name: "mytask",
			TaskSpec: &v1beta1.EmbeddedTask{
				TaskSpec: v1beta1.TaskSpec{
					Steps: []v1beta1.Step{{
						Container: corev1.Container{Name: "foo", Image: "bar"},
					}},
				},
			},
		}},
	},
}

var aPipelineLoop = &pipelineloopv1alpha1.PipelineLoop{
	ObjectMeta: metav1.ObjectMeta{Name: "a-pipelineloop", Namespace: "foo"},
	Spec: pipelineloopv1alpha1.PipelineLoopSpec{
		PipelineRef:           &v1beta1.PipelineRef{Name: "a-pipeline"},
		IterateParam:          "current-item",
		IterateParamSeparator: "separator",
	},
}
```
...the param is absent in the pipeline spec, despite being there in the [custom task call](https://github.com/kubeflow/kfp-tekton/blob/master/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go#L640-L672):
```go
var runPipelineLoopWithInStringSeparatorParams = &v1alpha1.Run{
	ObjectMeta: metav1.ObjectMeta{
		Name:      "run-pipelineloop",
		Namespace: "foo",
		Labels: map[string]string{
			"myTestLabel":                    "myTestLabelValue",
			"custom.tekton.dev/pipelineLoop": "a-pipelineloop",
			"tekton.dev/pipeline":            "pr-loop-example",
			"tekton.dev/pipelineRun":         "pr-loop-example",
			"tekton.dev/pipelineTask":        "loop-task",
		},
		Annotations: map[string]string{
			"myTestAnnotation": "myTestAnnotationValue",
		},
	},
	Spec: v1alpha1.RunSpec{
		Params: []v1beta1.Param{{
			Name:  "current-item",
			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "item1|item2"},
		}, {
			Name:  "separator",
			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "|"},
		}, {
			Name:  "additional-parameter",
			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "stuff"},
		}},
		Ref: &v1alpha1.TaskRef{
			APIVersion: pipelineloopv1alpha1.SchemeGroupVersion.String(),
			Kind:       pipelineloop.PipelineLoopControllerName,
			Name:       "a-pipelineloop",
		},
	},
}
```

So this PR removes that param from pipeline spec inside of the loop.


**Environment tested:**

* Python Version (use `python --version`): python 3.9
* Tekton Version (use `tkn version`): irrelevant
* Kubernetes Version (use `kubectl version`): irrelevant
* OS (e.g. from `/etc/os-release`): irrelevant

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
