### PR TITLE
Add caching labels for inline loops and custom tasks

### DIFF
--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -916,6 +916,11 @@ spec:
                         resources:
                           requests:
                             storage: 2Gi
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
             workspaces:
             - name: big-data-passing
           iterateParam: loop-item-param-1
@@ -929,6 +934,11 @@ spec:
                 resources:
                   requests:
                     storage: 2Gi
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
     workspaces:
     - name: big-data-passing
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/conditions_and_loops.yaml
+++ b/sdk/python/tests/compiler/testdata/conditions_and_loops.yaml
@@ -406,6 +406,11 @@ spec:
                     f.write(outcome)
                     f.close()' '$(inputs.params.operand1)' '$(inputs.params.operand2)'
                   image: python:alpine3.6
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
             - name: condition-3
               params:
               - name: operand1
@@ -440,5 +445,15 @@ spec:
                     f.write(outcome)
                     f.close()' '$(inputs.params.operand1)' '$(inputs.params.operand2)'
                   image: python:alpine3.6
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
           iterateParam: produce-numbers-Output-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/long_pipeline_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_pipeline_name.yaml
@@ -75,4 +75,9 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: arr-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_empty.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_empty.yaml
@@ -57,4 +57,9 @@ spec:
               type: string
             tasks: []
           iterateNumeric: loop-item-param-1
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_in_recursion.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_in_recursion.yaml
@@ -62,11 +62,12 @@ metadata:
       "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)", "operator":
       "in", "values": ["true"]}]}, {"name": "condition-2", "params": [{"name": "operand1",
       "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value": "heads"},
-      {"name": "operator", "value": "=="}], "taskSpec": {"params": [{"name": "operand1",
-      "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
-      "type": "string"}], "results": [{"description": "Conditional task outcome",
-      "name": "outcome"}], "steps": [{"image": "python:alpine3.6", "script": "python
-      -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
+      {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
+      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
+      ""}}, "params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
+      "type": "string"}, {"name": "operator", "type": "string"}], "results": [{"description":
+      "Conditional task outcome", "name": "outcome"}], "steps": [{"image": "python:alpine3.6",
+      "script": "python -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
       if (input1 $(inputs.params.operator) input2) else \"false\"\nf = open(\"/tekton/results/outcome\",
       \"w\")\nf.write(outcome)\nf.close()'' ''$(inputs.params.operand1)'' ''$(inputs.params.operand2)''"}]}},
       {"name": "flip-component", "params": [{"name": "flip-coin-output", "value":
@@ -79,15 +80,16 @@ metadata:
       [{"name": "flip-coin-output", "value": "$(params.flip-coin-output)"}, {"name":
       "loop-item-param-3", "value": "[{\"a\": 1, \"b\": 2}, {\"a\": 10, \"b\": 20}]"},
       {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"}], "taskSpec":
-      {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "spec":
-      {"iterateParam": "loop-item-param-3", "pipelineSpec": {"params": [{"name": "flip-coin-output",
-      "type": "string"}, {"name": "loop-item-param-3-subvar-a", "type": "string"},
-      {"name": "loop-item-param-3-subvar-b", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "tasks": [{"name": "my-in-coop1", "params": [{"name": "loop-item-param-3-subvar-a",
-      "value": "$(params.loop-item-param-3-subvar-a)"}, {"name": "my_pipe_param",
-      "value": "$(params.my_pipe_param)"}], "taskSpec": {"metadata": {"annotations":
-      {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"my-in-coop1\",
-      \"outputs\": [], \"version\": \"my-in-coop1@sha256=7cea0db49353eacc7cc6a63f30e125ca464ba08a6320ccf928eb803a1ff06ee0\"}",
+      {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "metadata":
+      {"labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "", "pipelines.kubeflow.org/pipelinename": ""}}, "spec": {"iterateParam": "loop-item-param-3",
+      "pipelineSpec": {"params": [{"name": "flip-coin-output", "type": "string"},
+      {"name": "loop-item-param-3-subvar-a", "type": "string"}, {"name": "loop-item-param-3-subvar-b",
+      "type": "string"}, {"name": "my_pipe_param", "type": "string"}], "tasks": [{"name":
+      "my-in-coop1", "params": [{"name": "loop-item-param-3-subvar-a", "value": "$(params.loop-item-param-3-subvar-a)"},
+      {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"}], "taskSpec":
+      {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
+      "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=7cea0db49353eacc7cc6a63f30e125ca464ba08a6320ccf928eb803a1ff06ee0\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
       "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
       ""}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"}, {"name":
@@ -108,8 +110,10 @@ metadata:
       "loop-item-param-3-subvar-a", "value": "$(params.loop-item-param-3-subvar-a)"},
       {"name": "loop-item-param-5", "value": "[100, 200, 300]"}, {"name": "my_pipe_param",
       "value": "$(params.my_pipe_param)"}], "taskSpec": {"apiVersion": "custom.tekton.dev/v1alpha1",
-      "kind": "PipelineLoop", "spec": {"iterateParam": "loop-item-param-5", "pipelineSpec":
-      {"params": [{"name": "flip-coin-output", "type": "string"}, {"name": "loop-item-param-3-subvar-a",
+      "kind": "PipelineLoop", "metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
+      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
+      ""}}, "spec": {"iterateParam": "loop-item-param-5", "pipelineSpec": {"params":
+      [{"name": "flip-coin-output", "type": "string"}, {"name": "loop-item-param-3-subvar-a",
       "type": "string"}, {"name": "loop-item-param-5", "type": "string"}, {"name":
       "my_pipe_param", "type": "string"}], "tasks": [{"name": "my-inner-inner-coop",
       "params": [{"name": "loop-item-param-3-subvar-a", "value": "$(params.loop-item-param-3-subvar-a)"},

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
@@ -91,4 +91,9 @@ spec:
               timeout: 525600m
           iterateParam: loop-item-param-2
           iterateParamStringSeparator: loop-item-param-3
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
@@ -97,4 +97,9 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: produce-list-data_list-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_static.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static.yaml
@@ -143,4 +143,9 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: with-item-name
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_static_with_parallelism.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static_with_parallelism.yaml
@@ -144,4 +144,9 @@ spec:
               timeout: 525600m
           parallelism: 5
           iterateParam: loop-item-param-1
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency.yaml
@@ -187,6 +187,11 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: param-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
     - runAfter:
       - print-1
       name: empty-loop-for-loop-3
@@ -231,4 +236,9 @@ spec:
               runAfter: []
               timeout: 525600m
           iterateParam: param-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric.yaml
@@ -153,5 +153,15 @@ spec:
                             tekton.dev/template: ''
                       timeout: 525600m
                   iterateNumeric: loop-item-param-3
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
           iterateNumeric: loop-item-param-1
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
@@ -239,6 +239,11 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: loop-item-param-1
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
     - name: parallelfor-pipeline-param-in-items-reso-for-loop-4
       params:
       - name: loop-item-param-3
@@ -338,6 +343,11 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: loop-item-param-3
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
     - name: parallelfor-pipeline-param-in-items-reso-for-loop-6
       params:
       - name: loop-item-param-5
@@ -437,4 +447,9 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: loop-item-param-5
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_step.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_step.yaml
@@ -160,5 +160,15 @@ spec:
                             tekton.dev/template: ''
                       timeout: 525600m
                   iterateNumeric: loop-item-param-3
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
           iterateNumeric: loop-item-param-1
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_recur_runafter.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_runafter.yaml
@@ -61,11 +61,13 @@ metadata:
       "525600m", "when": [{"input": "$(tasks.condition-4.results.outcome)", "operator":
       "in", "values": ["true"]}]}, {"name": "condition-4", "params": [{"name": "operand1",
       "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value": "tails"},
-      {"name": "operator", "value": "=="}], "runAfter": [], "taskSpec": {"params":
-      [{"name": "operand1", "type": "string"}, {"name": "operand2", "type": "string"},
-      {"name": "operator", "type": "string"}], "results": [{"description": "Conditional
-      task outcome", "name": "outcome"}], "steps": [{"image": "python:alpine3.6",
-      "script": "python -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
+      {"name": "operator", "value": "=="}], "runAfter": [], "taskSpec": {"metadata":
+      {"labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
+      "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "operand1",
+      "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
+      "type": "string"}], "results": [{"description": "Conditional task outcome",
+      "name": "outcome"}], "steps": [{"image": "python:alpine3.6", "script": "python
+      -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
       if (input1 $(inputs.params.operator) input2) else \"false\"\nf = open(\"/tekton/results/outcome\",
       \"w\")\nf.write(outcome)\nf.close()'' ''$(inputs.params.operand1)'' ''$(inputs.params.operand2)''"}]}},
       {"name": "flip-component", "params": [{"name": "flip-coin-output", "value":
@@ -104,11 +106,12 @@ metadata:
       "525600m", "when": [{"input": "$(tasks.condition-3.results.outcome)", "operator":
       "in", "values": ["true"]}]}, {"name": "condition-3", "params": [{"name": "operand1",
       "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value": "heads"},
-      {"name": "operator", "value": "=="}], "taskSpec": {"params": [{"name": "operand1",
-      "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
-      "type": "string"}], "results": [{"description": "Conditional task outcome",
-      "name": "outcome"}], "steps": [{"image": "python:alpine3.6", "script": "python
-      -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
+      {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
+      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
+      ""}}, "params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
+      "type": "string"}, {"name": "operator", "type": "string"}], "results": [{"description":
+      "Conditional task outcome", "name": "outcome"}], "steps": [{"image": "python:alpine3.6",
+      "script": "python -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
       if (input1 $(inputs.params.operator) input2) else \"false\"\nf = open(\"/tekton/results/outcome\",
       \"w\")\nf.write(outcome)\nf.close()'' ''$(inputs.params.operand1)'' ''$(inputs.params.operand2)''"}]}},
       {"name": "flip-component-b", "params": [{"name": "flip-coin-output", "value":

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -467,6 +467,11 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: produce-list-of-strings-Output-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
     - runAfter:
       - produce-list-of-ints
       name: parallelfor-item-argument-resolving-for-loop-2
@@ -569,6 +574,11 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: produce-list-of-ints-Output-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
     - runAfter:
       - produce-list-of-dicts
       name: parallelfor-item-argument-resolving-for-loop-3
@@ -671,4 +681,9 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: produce-list-of-dicts-Output-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/recur_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested.yaml
@@ -62,16 +62,19 @@ metadata:
       "525600m", "when": [{"input": "$(tasks.condition-5.results.outcome)", "operator":
       "in", "values": ["true"]}]}, {"name": "condition-2", "params": [{"name": "operand1",
       "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value": "heads"},
-      {"name": "operator", "value": "=="}], "taskSpec": {"params": [{"name": "operand1",
-      "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
-      "type": "string"}], "results": [{"description": "Conditional task outcome",
-      "name": "outcome"}], "steps": [{"image": "python:alpine3.6", "script": "python
-      -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
+      {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
+      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
+      ""}}, "params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
+      "type": "string"}, {"name": "operator", "type": "string"}], "results": [{"description":
+      "Conditional task outcome", "name": "outcome"}], "steps": [{"image": "python:alpine3.6",
+      "script": "python -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
       if (input1 $(inputs.params.operator) input2) else \"false\"\nf = open(\"/tekton/results/outcome\",
       \"w\")\nf.write(outcome)\nf.close()'' ''$(inputs.params.operand1)'' ''$(inputs.params.operand2)''"}]}},
       {"name": "condition-5", "params": [{"name": "operand1", "value": "$(params.flip-coin-output)"},
       {"name": "operand2", "value": "tails"}, {"name": "operator", "value": "=="}],
-      "taskSpec": {"params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
+      "taskSpec": {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
+      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
+      ""}}, "params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
       "type": "string"}, {"name": "operator", "type": "string"}], "results": [{"description":
       "Conditional task outcome", "name": "outcome"}], "steps": [{"image": "python:alpine3.6",
       "script": "python -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
@@ -114,11 +117,12 @@ metadata:
       "525600m", "when": [{"input": "$(tasks.condition-4.results.outcome)", "operator":
       "in", "values": ["true"]}]}, {"name": "condition-4", "params": [{"name": "operand1",
       "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value": "heads"},
-      {"name": "operator", "value": "=="}], "taskSpec": {"params": [{"name": "operand1",
-      "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
-      "type": "string"}], "results": [{"description": "Conditional task outcome",
-      "name": "outcome"}], "steps": [{"image": "python:alpine3.6", "script": "python
-      -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
+      {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
+      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
+      ""}}, "params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
+      "type": "string"}, {"name": "operator", "type": "string"}], "results": [{"description":
+      "Conditional task outcome", "name": "outcome"}], "steps": [{"image": "python:alpine3.6",
+      "script": "python -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
       if (input1 $(inputs.params.operator) input2) else \"false\"\nf = open(\"/tekton/results/outcome\",
       \"w\")\nf.write(outcome)\nf.close()'' ''$(inputs.params.operand1)'' ''$(inputs.params.operand2)''"}]}},
       {"name": "flip-component-b", "params": [{"name": "flip-coin-output", "value":

--- a/sdk/python/tests/compiler/testdata/recursion_while.yaml
+++ b/sdk/python/tests/compiler/testdata/recursion_while.yaml
@@ -60,11 +60,12 @@ metadata:
       "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)", "operator":
       "in", "values": ["true"]}]}, {"name": "condition-2", "params": [{"name": "operand1",
       "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value": "heads"},
-      {"name": "operator", "value": "=="}], "taskSpec": {"params": [{"name": "operand1",
-      "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
-      "type": "string"}], "results": [{"description": "Conditional task outcome",
-      "name": "outcome"}], "steps": [{"image": "python:alpine3.6", "script": "python
-      -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
+      {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
+      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
+      ""}}, "params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
+      "type": "string"}, {"name": "operator", "type": "string"}], "results": [{"description":
+      "Conditional task outcome", "name": "outcome"}], "steps": [{"image": "python:alpine3.6",
+      "script": "python -c ''import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
       if (input1 $(inputs.params.operator) input2) else \"false\"\nf = open(\"/tekton/results/outcome\",
       \"w\")\nf.write(outcome)\nf.close()'' ''$(inputs.params.operand1)'' ''$(inputs.params.operand2)''"}]}},
       {"name": "flip-component", "params": [{"name": "flip-coin-output", "value":

--- a/sdk/python/tests/compiler/testdata/tekton_loop_dsl.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_loop_dsl.yaml
@@ -126,4 +126,9 @@ spec:
               timeout: 525600m
           parallelism: 1
           iterateParam: loop-item-param-1
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withitem_multi_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_multi_nested.yaml
@@ -291,7 +291,27 @@ spec:
                                             tekton.dev/template: ''
                                       timeout: 525600m
                                   iterateParam: my_pipe_param3-loop-item
+                                metadata:
+                                  labels:
+                                    pipelines.kubeflow.org/pipelinename: ''
+                                    pipelines.kubeflow.org/generation: ''
+                                    pipelines.kubeflow.org/cache_enabled: "true"
                           iterateParam: loop-item-param-4
+                        metadata:
+                          labels:
+                            pipelines.kubeflow.org/pipelinename: ''
+                            pipelines.kubeflow.org/generation: ''
+                            pipelines.kubeflow.org/cache_enabled: "true"
                   iterateParam: my_pipe_param-loop-item
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
           iterateParam: loop-item-param-1
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -206,5 +206,15 @@ spec:
                             tekton.dev/template: ''
                       timeout: 525600m
                   iterateParam: loop-item-param-3
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/pipelinename: ''
+                    pipelines.kubeflow.org/generation: ''
+                    pipelines.kubeflow.org/cache_enabled: "true"
           iterateParam: loop-item-param-1
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_global.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global.yaml
@@ -141,4 +141,9 @@ spec:
               runAfter: []
               timeout: 525600m
           iterateParam: loopidy_doop-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
@@ -147,4 +147,9 @@ spec:
               runAfter: []
               timeout: 525600m
           iterateParam: loopidy_doop-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_output.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output.yaml
@@ -131,4 +131,9 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: my-out-cop0-out-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
@@ -131,4 +131,9 @@ spec:
                     tekton.dev/template: ''
               timeout: 525600m
           iterateParam: my-out-cop0-out-loop-item
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #853

**Description of your changes:**
Add caching labels for inline loops and custom tasks. This can enable the new custom task caching features as well as passing any missing labels in the sub-pipelines. So all the pod/controller workloads that are from KFP can be cached.

**Environment tested:**

* Python Version (use `python --version`): 3.8
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
