### PR TITLE
fix(sdk) add test for custom-tasks with literals. Fixes #880

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -1117,7 +1117,7 @@ class TektonCompiler(Compiler):
       op = pipeline.ops.get(task['name'])
       # Substitute task paramters to the correct Tekton variables.
       # Regular task and custom task have different parameter mapping in Tekton.
-      if task.get('orig_params', []):  # custom task
+      if 'orig_params' in task:  # custom task
         orig_params = [p['name'] for p in task.get('orig_params', [])]
         for tp in task.get('params', []):
           pipeline_params = re.findall('\$\(inputs.params.([^ \t\n.:,;{}]+)\)', tp.get('value', ''))

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -233,6 +233,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.custom_task_recur_with_cond import recursion_test
     self._test_pipeline_workflow(recursion_test, 'custom_task_recur_with_cond.yaml')
 
+  def test_custom_task_with_literals(self):
+    """
+    Test compiling custom tasks with literals as parameters.
+    """
+    from .testdata.literal_params_test import literal_params_test
+    self._test_pipeline_workflow(literal_params_test, 'literal_params_test.yaml', skip_noninlined=True)
+
   def test_break_task_pipeline(self):
     """
     Test compiling a break task pipeline.

--- a/sdk/python/tests/compiler/testdata/literal_params_test.py
+++ b/sdk/python/tests/compiler/testdata/literal_params_test.py
@@ -25,6 +25,7 @@ TEKTON_CUSTOM_TASK_IMAGES = TEKTON_CUSTOM_TASK_IMAGES.append(ARTIFACT_FETCHER_IM
 
 _artifact_fetcher_no = 0
 
+
 def artifact_fetcher(**artifact_paths: str):
   '''A containerOp template resolving some artifacts, given their paths.'''
   global _artifact_fetcher_no

--- a/sdk/python/tests/compiler/testdata/literal_params_test.py
+++ b/sdk/python/tests/compiler/testdata/literal_params_test.py
@@ -42,7 +42,7 @@ def artifact_fetcher(**artifact_paths: str):
     'implementation': {
       'container': {
         'image': ARTIFACT_FETCHER_IMAGE_NAME,
-        'command': ['sh', '-c'], # irrelevant
+        'command': ['sh', '-c'],  # irrelevant
         'args': [
           '--apiVersion', 'fetcher.tekton.dev/v1alpha1',
           '--kind', 'FETCHER',
@@ -87,7 +87,7 @@ def literal_params_test(foo: str):
   #   matches the name of a pipeline param
   _artifact_fetcher_no = 30
   op30 = artifact_fetcher(foo="foo")
-  op31 = artifact_fetcher(foo="bar") # doesn't matter what the literal is
+  op31 = artifact_fetcher(foo="bar")  # doesn't matter what the literal is
   op32 = artifact_fetcher(foo="foo", bar="bar")
   op33 = artifact_fetcher(foo="bar", bar="foo")
 

--- a/sdk/python/tests/compiler/testdata/literal_params_test.py
+++ b/sdk/python/tests/compiler/testdata/literal_params_test.py
@@ -1,0 +1,96 @@
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+from kfp import dsl, components
+from kfp_tekton.tekton import TEKTON_CUSTOM_TASK_IMAGES
+from kfp_tekton.compiler import TektonCompiler
+import yaml
+
+
+ARTIFACT_FETCHER_IMAGE_NAME = "fetcher/image:latest"
+TEKTON_CUSTOM_TASK_IMAGES = TEKTON_CUSTOM_TASK_IMAGES.append(ARTIFACT_FETCHER_IMAGE_NAME)
+
+_artifact_fetcher_no = 0
+
+def artifact_fetcher(**artifact_paths: str):
+  '''A containerOp template resolving some artifacts, given their paths.'''
+  global _artifact_fetcher_no
+  template_yaml = {
+    'name': f'artifact-fetcher-{_artifact_fetcher_no}',
+    'description': 'Artifact Fetch',
+    'inputs': [
+      {'name': name, 'type': 'String'}
+      for name in artifact_paths.keys()
+    ],
+    'outputs': [
+      {'name': name, 'type': 'Artifact'}
+      for name in artifact_paths.keys()
+    ],
+    'implementation': {
+      'container': {
+        'image': ARTIFACT_FETCHER_IMAGE_NAME,
+        'command': ['sh', '-c'], # irrelevant
+        'args': [
+          '--apiVersion', 'fetcher.tekton.dev/v1alpha1',
+          '--kind', 'FETCHER',
+          '--name', 'artifact_fetcher',
+          *itertools.chain(*[
+            (f'--{name}', {'inputValue': name})
+            for name in artifact_paths.keys()
+          ])
+        ]
+      }
+    }
+  }
+  _artifact_fetcher_no += 1
+  template_str = yaml.dump(template_yaml, Dumper=yaml.SafeDumper)
+  template = components.load_component_from_text(template_str)
+  op = template(**artifact_paths)
+  op.add_pod_annotation("valid_container", "false")
+  return op
+
+
+@dsl.pipeline("literal-params-test")
+def literal_params_test(foo: str):
+  global _artifact_fetcher_no
+
+  # no literals
+  _artifact_fetcher_no = 0
+  op00 = artifact_fetcher(bar=foo)
+  op01 = artifact_fetcher(foo=foo)
+
+  # not all inputs are literals
+  _artifact_fetcher_no = 10
+  op10 = artifact_fetcher(foo="foo", bar=foo)
+  op11 = artifact_fetcher(foo=foo, bar="bar")
+
+  # all inputs are literals but none of them
+  #   matches the name of any pipeline param
+  _artifact_fetcher_no = 20
+  op20 = artifact_fetcher(bar="bar")
+  op21 = artifact_fetcher(bar="bar", buzz="buzz")
+
+  # all inputs are literals and at least one of them
+  #   matches the name of a pipeline param
+  _artifact_fetcher_no = 30
+  op30 = artifact_fetcher(foo="foo")
+  op31 = artifact_fetcher(foo="bar") # doesn't matter what the literal is
+  op32 = artifact_fetcher(foo="foo", bar="bar")
+  op33 = artifact_fetcher(foo="bar", bar="foo")
+
+
+if __name__ == '__main__':
+  TektonCompiler().compile(literal_params_test, __file__.replace('.py', '.yaml'))

--- a/sdk/python/tests/compiler/testdata/literal_params_test.yaml
+++ b/sdk/python/tests/compiler/testdata/literal_params_test.yaml
@@ -1,0 +1,138 @@
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: literal-params-test
+  annotations:
+    tekton.dev/output_artifacts: '{}'
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{}'
+    sidecar.istio.io/inject: "false"
+    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+    pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"name": "foo", "type": "String"}],
+      "name": "literal-params-test"}'
+spec:
+  params:
+  - name: foo
+    value: ''
+  pipelineSpec:
+    params:
+    - name: foo
+    tasks:
+    - name: artifact-fetcher-0
+      params:
+      - name: bar
+        value: $(params.foo)
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-1
+      params:
+      - name: foo
+        value: $(params.foo)
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-10
+      params:
+      - name: foo
+        value: foo
+      - name: bar
+        value: $(params.foo)
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-11
+      params:
+      - name: foo
+        value: $(params.foo)
+      - name: bar
+        value: bar
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-20
+      params:
+      - name: bar
+        value: bar
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-21
+      params:
+      - name: bar
+        value: bar
+      - name: buzz
+        value: buzz
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-30
+      params:
+      - name: foo
+        value: foo
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-31
+      params:
+      - name: foo
+        value: bar
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-32
+      params:
+      - name: foo
+        value: foo
+      - name: bar
+        value: bar
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+    - name: artifact-fetcher-33
+      params:
+      - name: foo
+        value: bar
+      - name: bar
+        value: foo
+      taskRef:
+        name: artifact_fetcher
+        apiVersion: fetcher.tekton.dev/v1alpha1
+        kind: FETCHER
+      timeout: 525600m
+  timeout: 525600m


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #880.

**Description of your changes:**
Adding a test for the issue.

Changing:
```python
if task.get('orig_params', []):  # custom task
```
to:
```python
if 'orig_params' in task:  # custom task
```
...as "normal" Tekton tasks don't have `'orig_params'` key at all --- now at the moment at least. An additional parameter (e.g. `'custom_task': true`), removed at the end of this `if` could be added too.

**Environment tested:**

* Python Version (use `python --version`): 3.9.0
* Tekton Version (use `tkn version`): irrelevant
* Kubernetes Version (use `kubectl version`): irrelevant
* OS (e.g. from `/etc/os-release`): irrelevant

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
