### PR TITLE
Add current iteration item to the PipelineLoopPipelineRunStatus

### DIFF
--- a/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop/v1alpha1/pipelineloop_types.go
+++ b/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop/v1alpha1/pipelineloop_types.go
@@ -144,6 +144,8 @@ type PipelineLoopRunStatus struct {
 type PipelineLoopPipelineRunStatus struct {
 	// iteration number
 	Iteration int `json:"iteration,omitempty"`
+	// the current iteration item
+	IterationItem interface{} `json:"iterationItem,omitempty"`
 	// Status is the TaskRunStatus for the corresponding TaskRun
 	// +optional
 	Status *v1beta1.PipelineRunStatus `json:"status,omitempty"`

--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun_test.go
@@ -257,6 +257,12 @@ func checkRunStatus(t *testing.T, run *v1alpha1.Run, expectedStatus map[string]p
 			t.Errorf("Run status for PipelineRun %s has iteration number %d instead of %d",
 				expectedPipelineRunName, actualPipelineRunStatus.Iteration, expectedPipelineRunStatus.Iteration)
 		}
+		acturalIterationItem, error := json.Marshal(actualPipelineRunStatus.IterationItem)
+		expectedIterationItem, _ := json.Marshal(expectedPipelineRunStatus.IterationItem)
+		if error != nil || string(acturalIterationItem) != string(expectedIterationItem) {
+			t.Errorf("Run status for PipelineRun %s has iteration item %v instead of %v",
+				expectedPipelineRunName, actualPipelineRunStatus.IterationItem, expectedPipelineRunStatus.IterationItem)
+		}
 		if d := cmp.Diff(expectedPipelineRunStatus.Status, actualPipelineRunStatus.Status, cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); d != "" {
 			t.Errorf("Run status for PipelineRun %s is incorrect. Diff %s", expectedPipelineRunName, diff.PrintWantGot(d))
 		}
@@ -1599,10 +1605,11 @@ func TestReconcilePipelineLoopRun(t *testing.T) {
 			}
 
 			// Verify Run status contains status for all PipelineRuns.
+			_, iterationElements, _ := computeIterations(tc.run, &tc.pipelineloop.Spec)
 			expectedPipelineRuns := map[string]pipelineloopv1alpha1.PipelineLoopPipelineRunStatus{}
 			i := 1
 			for _, pr := range tc.expectedPipelineruns {
-				expectedPipelineRuns[pr.Name] = pipelineloopv1alpha1.PipelineLoopPipelineRunStatus{Iteration: i, Status: &pr.Status}
+				expectedPipelineRuns[pr.Name] = pipelineloopv1alpha1.PipelineLoopPipelineRunStatus{Iteration: i, IterationItem: iterationElements[i-1], Status: &pr.Status}
 				if pr.Labels["deleted"] != "True" {
 					i = i + 1 // iteration remain same, incase previous pr was a retry.
 				}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
The current `PipelineLoopPipelineRunStatus` only has the `Iteration` which is an integer value, sometimes it is meaningless for the user.  We should have IterationItem in the status as well. 
**Environment tested:**
Unit test passed.

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
