### PR TITLE
Add missing openshift standalone permission

### DIFF
--- a/manifests/kustomize/third-party/openshift/standalone/anyuid-scc.yaml
+++ b/manifests/kustomize/third-party/openshift/standalone/anyuid-scc.yaml
@@ -34,8 +34,8 @@ users:
 #Minio accesses files owned by root
 - system:serviceaccount:kubeflow:minio
 #Katib injects container into pods which does not run as non-root user, trying to find Dockerfile for that image and fix it
-#- system:serviceaccount:kubeflow:default
 - system:serviceaccount:kubeflow:default
+- system:serviceaccount:kubeflow:pipeline-runner
 - system:serviceaccount:kubeflow:kubeflow-pipelines-cache
 - system:serviceaccount:kubeflow:kubeflow-pipelines-cache-deployer-sa
 - system:serviceaccount:kubeflow:metadata-grpc-server

--- a/manifests/kustomize/third-party/openshift/standalone/privileged-scc.yaml
+++ b/manifests/kustomize/third-party/openshift/standalone/privileged-scc.yaml
@@ -34,8 +34,8 @@ users:
 #Minio accesses files owned by root
 - system:serviceaccount:kubeflow:minio
 #Katib injects container into pods which does not run as non-root user, trying to find Dockerfile for that image and fix it
-#- system:serviceaccount:kubeflow:default
 - system:serviceaccount:kubeflow:default
+- system:serviceaccount:kubeflow:pipeline-runner
 - system:serviceaccount:kubeflow:kubeflow-pipelines-cache
 - system:serviceaccount:kubeflow:kubeflow-pipelines-cache-deployer-sa
 - system:serviceaccount:kubeflow:metadata-grpc-server


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
There are reports that the standalone Tekton deployment needs the privilege and anyuid permission on the worker service account, thus adding standalone deployment service account `pipeline-runner` to the list of scc.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
