### PR TITLE
Add missing csi plugin for multi-user manifests

### DIFF
--- a/manifests/kustomize/env/plain-multi-user/kustomization.yaml
+++ b/manifests/kustomize/env/plain-multi-user/kustomization.yaml
@@ -10,6 +10,7 @@ bases:
   - ../../third-party/minio/base
   - ../../third-party/minio/options/istio
   - ../../third-party/metacontroller/base
+  - ../../third-party/kfp-csi-s3
 
 # Identifier for application manager to apply ownerReference.
 # The ownerReference ensures the resources get garbage collected


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
Some users reported the s3 csi is not installed by default in the multi-user deployment. Hence adding the s3 plugin as part of the default multi-user deployment.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
