### PR TITLE
pass down the podTemplate and serviceAccount from run to loopSpec

### DIFF
--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
@@ -577,6 +577,13 @@ func (c *Reconciler) getPipelineLoop(ctx context.Context, run *v1alpha1.Run) (*m
 			run.Namespace, run.Name)
 		return nil, nil, fmt.Errorf("Missing spec.ref.name for Run %s", fmt.Sprintf("%s/%s", run.Namespace, run.Name))
 	}
+	// pass down the run's serviceAccountName and podTemplate if they were not configured in the loop spec
+	if pipelineLoopSpec.PodTemplate == nil && run.Spec.PodTemplate != nil {
+		pipelineLoopSpec.PodTemplate = run.Spec.PodTemplate
+	}
+	if pipelineLoopSpec.ServiceAccountName == "" && run.Spec.ServiceAccountName != "" && run.Spec.ServiceAccountName != "default" {
+		pipelineLoopSpec.ServiceAccountName = run.Spec.ServiceAccountName
+	}
 	return &pipelineLoopMeta, &pipelineLoopSpec, nil
 }
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #
For our use case, we don't set `podTemplate` and `serviceAccount` in the loopSpec, we only set them for the parent pipelinerun. The run created by Tekton controller will inherit the above two fields from the pipelinerun.
But the loop controller doesn't pass the above two fields to pipelineLoopSpec.

**Description of your changes:**
get `podTemplate` and `serviceAccount` from `run` and set them to pipelineLoopSpec if they are not configured.

**Environment tested:**
All unit tests passed.