### PR TITLE
fix(SDK): Update sanitization logic to sync with kfp dsl

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_k8s_helper.py
+++ b/sdk/python/kfp_tekton/compiler/_k8s_helper.py
@@ -54,9 +54,6 @@ def sanitize_k8s_name(name,
     if not allow_slash:
       k8s_name = re.sub('[/]', '-', k8s_name)
 
-    # replace duplicate dashes, strip enclosing dashes
-    k8s_name = re.sub('-+', '-', k8s_name).strip('-')
-
     # truncate if length exceeds max_length
     max_length = max_length - suffix_space
     if len(k8s_name) > max_length:
@@ -64,6 +61,9 @@ def sanitize_k8s_name(name,
         k8s_name = k8s_name[len(k8s_name) - max_length:].strip('-')
       else:
         k8s_name = k8s_name[:max_length].rstrip('-')
+
+    # replace duplicate dashes, strip enclosing dashes
+    k8s_name = re.sub('-+', '-', k8s_name).strip('-')
 
     return k8s_name
 

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -364,10 +364,12 @@ def _process_base_ops(op: BaseOp):
     """
 
     # map param's (unsanitized pattern or serialized str pattern) -> input param var str
-    map_to_tmpl_var = {
-        (param.pattern or str(param)): '$(inputs.params.%s)' % param.full_name  # Tekton change
-        for param in op.inputs
-    }
+    # Pick the shortest param full name if there's two identical params in the DSL
+    map_to_tmpl_var = {}
+    for param in op.inputs:
+        key = (param.pattern or str(param))
+        if not map_to_tmpl_var.get(key) or len('$(inputs.params.%s)' % param.full_name) < len(map_to_tmpl_var.get(key)):
+            map_to_tmpl_var[key] = '$(inputs.params.%s)' % param.full_name
 
     # process all attr with pipelineParams except inputs and outputs parameters
     for key in op.attrs_with_pipelineparams:

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -246,16 +246,16 @@ class TektonCompiler(Compiler):
 
         # get other input params, for recursion need rename the param name to the refrenced one
         for i in range(len(sub_group.inputs)):
-            input = sub_group.inputs[i]
+            g_input = sub_group.inputs[i]
             inputRef = sub_group.recursive_ref.inputs[i]
-            if input.op_name:
+            if g_input.op_name:
               params.append({
                 'name': inputRef.full_name,
-                'value': '$(tasks.%s.results.%s)' % (input.op_name, input.name)
+                'value': '$(tasks.%s.results.%s)' % (g_input.op_name, g_input.name)
               })
             else:
               params.append({
-                'name': inputRef.full_name, 'value': '$(params.%s)' % input.name
+                'name': inputRef.full_name, 'value': '$(params.%s)' % g_input.name
               })
 
         self.recursive_tasks.append({
@@ -1378,9 +1378,9 @@ class TektonCompiler(Compiler):
     args_list = []
     for arg_name in argspec.args:
       arg_type = None
-      for input in pipeline_meta.inputs or []:
-        if arg_name == input.name:
-          arg_type = input.type
+      for p_input in pipeline_meta.inputs or []:
+        if arg_name == p_input.name:
+          arg_type = p_input.type
           break
       args_list.append(dsl.PipelineParam(sanitize_k8s_name(arg_name, True), param_type=arg_type))
 

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -182,6 +182,13 @@ class TestTektonCompiler(unittest.TestCase):
     from .testdata.data_passing_pipeline_param_as_file import data_passing_pipeline
     self._test_pipeline_workflow(data_passing_pipeline, 'data_passing_pipeline_param_as_file.yaml', skip_noninlined=True)
 
+  def test_custom_task_long_name_workflow(self):
+    """
+    Test compiling a custom_task_long_name workflow with underscore and hyphen.
+    """
+    from .testdata.custom_task_long_name import main_fn
+    self._test_pipeline_workflow(main_fn, 'custom_task_long_name.yaml', skip_noninlined=True)
+
   def test_data_passing_pipeline_complete(self):
     """
     Test compiling a pipeline_param_as_file workflow.

--- a/sdk/python/tests/compiler/testdata/custom_task_long_name.py
+++ b/sdk/python/tests/compiler/testdata/custom_task_long_name.py
@@ -1,0 +1,62 @@
+# Copyright 2022 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import dsl, components
+from kfp_tekton.compiler import TektonCompiler as Compiler
+from kfp_tekton.tekton import CEL_ConditionOp
+
+
+def gcs_download_op(url):
+    return components.load_component_from_text("""
+      name: %s
+      description: download
+      inputs:
+        - {name: url, type: String}
+      outputs:
+        - {name: %s, type: String}
+      implementation:
+        container:
+          image: google/cloud-sdk:279.0.0
+          command:
+          - sh
+          - -c
+          args:
+          - |
+            gsutil cat $0 | tee $1
+          - {inputValue: url}
+          - {outputPath: %s}
+    """ % ('GCS - Download' * 4, 'Data-_123' * 100, 'Data-_123' * 100))(url=url)
+
+
+@dsl.pipeline(name="some-very-long-name-with-lots-of-words-in-it-" +
+                   "it-should-be-over-63-chars-long-in-order-to-observe-the-problem")
+def main_fn(url1: str = 'gs://ml-pipeline-playground/shakespeare1.txt'):
+    download1_task = gcs_download_op(url1)
+    printop = components.load_component_from_text("""
+      name: %s
+      description: print
+      inputs:
+        - {name: text, type: String}
+      implementation:
+        container:
+          image: alpine:3.6
+          command:
+          - echo
+          - {inputValue: text}
+    """ % ('print' * 10))(download1_task.outputs['Data-_123' * 100])
+    cel_condition = CEL_ConditionOp("'%s' == 'heads'" % download1_task.outputs['Data-_123' * 100])
+
+
+if __name__ == '__main__':
+    Compiler().compile(main_fn, __file__.replace('.py', '.yaml'))

--- a/sdk/python/tests/compiler/testdata/custom_task_long_name.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_long_name.yaml
@@ -1,0 +1,114 @@
+# Copyright 2021 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: some-very-long-name-with-lots-of-words-in-it-it-shoul
+  annotations:
+    tekton.dev/output_artifacts: '{"gcs-downloadgcs-downloadgcs-downloadgcs-download":
+      [{"key": "artifacts/$PIPELINERUN/gcs-downloadgcs-downloadgcs-downloadgcs-download/Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Dat.tgz",
+      "name": "gcs-downloadgcs-downloadgcs-downloadgcs-download-Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Dat",
+      "path": "/tmp/outputs/Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123/data"}]}'
+    tekton.dev/input_artifacts: '{"printprintprintprintprintprintprintprintprintprint":
+      [{"name": "gcs-downloadgcs-downloadgcs-downloadgcs-download-Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Dat",
+      "parent_task": "gcs-downloadgcs-downloadgcs-downloadgcs-download"}, {"name":
+      "gcs-downloadgcs-downloadgcs-downloadgcs-download-Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123",
+      "parent_task": "gcs-downloadgcs-downloadgcs-downloadgcs-download"}]}'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"gcs-downloadgcs-downloadgcs-downloadgcs-download":
+      [["Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Dat", "$(results.data-123data-123data-123data-123data-123data-123dat.path)"]],
+      "printprintprintprintprintprintprintprintprintprint": []}'
+    sidecar.istio.io/inject: "false"
+    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+    pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
+      "name": "url1", "optional": true, "type": "String"}], "name": "some-very-long-name-with-lots-of-words-in-it-it-should-be-over-63-chars-long-in-order-to-observe-the-problem"}'
+spec:
+  params:
+  - name: url1
+    value: gs://ml-pipeline-playground/shakespeare1.txt
+  pipelineSpec:
+    params:
+    - name: url1
+      default: gs://ml-pipeline-playground/shakespeare1.txt
+    tasks:
+    - name: gcs-downloadgcs-downloadgcs-downloadgcs-download
+      params:
+      - name: url1
+        value: $(params.url1)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - |
+            gsutil cat $0 | tee $1
+          - $(inputs.params.url1)
+          - $(results.data-123data-123data-123data-123data-123data-123dat.path)
+          command:
+          - sh
+          - -c
+          image: google/cloud-sdk:279.0.0
+        params:
+        - name: url1
+        results:
+        - name: data-123data-123data-123data-123data-123data-123dat
+          description: /tmp/outputs/Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123/data
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "GCS - DownloadGCS
+              - DownloadGCS - DownloadGCS - Download", "outputs": [{"name": "Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123",
+              "type": "String"}], "version": "GCS - DownloadGCS - DownloadGCS - DownloadGCS
+              - Download@sha256=bfb91851dd0cee49ec01b7c3c9653f50cf79de46288a7d1faa8bd1dc6d723209"}'
+            tekton.dev/template: ''
+      timeout: 525600m
+    - name: printprintprintprintprintprintprintprintprintprint
+      params:
+      - name: gcs-downloadgcs-downloadgcs-downloadgcs-download-Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Dat
+        value: $(tasks.gcs-downloadgcs-downloadgcs-downloadgcs-download.results.data-123data-123data-123data-123data-123data-123dat)
+      taskSpec:
+        steps:
+        - name: main
+          command:
+          - echo
+          - $(inputs.params.gcs-downloadgcs-downloadgcs-downloadgcs-download-Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Dat)
+          image: alpine:3.6
+        params:
+        - name: gcs-downloadgcs-downloadgcs-downloadgcs-download-Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Dat
+        metadata:
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "printprintprintprintprintprintprintprintprintprint",
+              "outputs": [], "version": "printprintprintprintprintprintprintprintprintprint@sha256=0c820da4b0f6e1a730ec47930324fc44ffbc0be62e903fdbcc91dc36ab9580ef"}'
+            tekton.dev/template: ''
+      timeout: 525600m
+    - name: condition-cel
+      params:
+      - name: outcome
+        value: '''$(tasks.gcs-downloadgcs-downloadgcs-downloadgcs-download.results.data-123data-123data-123data-123data-123data-123dat)''
+          == ''heads'''
+      taskRef:
+        name: cel_condition
+        apiVersion: cel.tekton.dev/v1alpha1
+        kind: CEL
+      timeout: 525600m
+  timeout: 525600m


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #914 

**Description of your changes:**
For kfp output parameter sanitization, the length is being trimmed by the original kfp dsl sanitization function by length and later on reduced the number of repeated dashes. However, in our Tekton compiler sanitization, it reduced the number of  repeated dashes first then sanitize by the length. This can make certain edge cases where long name output parameters that have multiple repeated dashes can be resulted with a different length in the Tekton results vs Tekton input parameters. Hence, we need to update the sanitization to work the same way as KFP DSL.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
