### PR TITLE
wait for pipelineloop-break-operation task final status

### DIFF
--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
@@ -748,36 +748,40 @@ func (c *Reconciler) updatePipelineRunStatus(ctx context.Context, iterationEleme
 		}
 		for _, runStatus := range pr.Status.Runs {
 			if strings.HasPrefix(runStatus.PipelineTaskName, "pipelineloop-break-operation") {
-				err = c.cancelAllPipelineRuns(ctx, run)
-				if err != nil {
-					return 0, nil, nil, fmt.Errorf("could not cancel PipelineRuns belonging to Run %s."+
-						" %#v", run.Name, err)
+				if !runStatus.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
+					err = c.cancelAllPipelineRuns(ctx, run)
+					if err != nil {
+						return 0, nil, nil, fmt.Errorf("could not cancel PipelineRuns belonging to Run %s."+
+							" %#v", run.Name, err)
+					}
+					// Mark run successful and stop the loop pipelinerun
+					run.Status.MarkRunSucceeded(pipelineloopv1alpha1.PipelineLoopRunReasonSucceeded.String(),
+						"PipelineRuns completed successfully with the conditions are met")
+					run.Status.Results = []runv1alpha1.RunResult{{
+						Name:  "condition",
+						Value: "pass",
+					}}
+					break
 				}
-				// Mark run successful and stop the loop pipelinerun
-				run.Status.MarkRunSucceeded(pipelineloopv1alpha1.PipelineLoopRunReasonSucceeded.String(),
-					"PipelineRuns completed successfully with the conditions are met")
-				run.Status.Results = []runv1alpha1.RunResult{{
-					Name:  "condition",
-					Value: "pass",
-				}}
-				break
 			}
 		}
 		for _, taskRunStatus := range pr.Status.TaskRuns {
 			if strings.HasPrefix(taskRunStatus.PipelineTaskName, "pipelineloop-break-operation") {
-				err = c.cancelAllPipelineRuns(ctx, run)
-				if err != nil {
-					return 0, nil, nil, fmt.Errorf("could not cancel PipelineRuns belonging to task run %s."+
-						" %#v", run.Name, err)
+				if !taskRunStatus.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
+					err = c.cancelAllPipelineRuns(ctx, run)
+					if err != nil {
+						return 0, nil, nil, fmt.Errorf("could not cancel PipelineRuns belonging to task run %s."+
+							" %#v", run.Name, err)
+					}
+					// Mark run successful and stop the loop pipelinerun
+					run.Status.MarkRunSucceeded(pipelineloopv1alpha1.PipelineLoopRunReasonSucceeded.String(),
+						"PipelineRuns completed successfully with the conditions are met")
+					run.Status.Results = []runv1alpha1.RunResult{{
+						Name:  "condition",
+						Value: "pass",
+					}}
+					break
 				}
-				// Mark run successful and stop the loop pipelinerun
-				run.Status.MarkRunSucceeded(pipelineloopv1alpha1.PipelineLoopRunReasonSucceeded.String(),
-					"PipelineRuns completed successfully with the conditions are met")
-				run.Status.Results = []runv1alpha1.RunResult{{
-					Name:  "condition",
-					Value: "pass",
-				}}
-				break
 			}
 		}
 	}


### PR DESCRIPTION
Wait for pipelineloop-break-operation task final status before breaking the loop.

**Which issue is resolved by this Pull Request:** 
Resolves #
https://github.com/kubeflow/kfp-tekton/issues/800#issuecomment-1123277062

**Description of your changes:**
wait until the break operation task is done, then cancel the looprun and break the loop.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
