### PR TITLE
[build] update github workflow to use go v1.17

### DIFF
--- a/.github/workflows/kfp-tekton-unittests.yml
+++ b/.github/workflows/kfp-tekton-unittests.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.17.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: "run go unit tests"
@@ -104,7 +104,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: "run go pipelineLoop unit tests"

--- a/tekton-catalog/pipeline-loops/Makefile
+++ b/tekton-catalog/pipeline-loops/Makefile
@@ -21,7 +21,7 @@ ko: PACKAGE=github.com/google/ko/cmd/ko
 apply: $(info apply: Apply PipelineLoop controller to the k8s cluster )
 	$(KO) apply -f config
 
-test-all:  $(info test-all: run unit tests )
+test-all: update init $(info test-all: run unit tests )
 	go test -v -cover -timeout=${TIMEOUT_TESTS} ./...
 
 .PHONY: init
@@ -40,12 +40,12 @@ validate-testdata-python-sdk: cli $(info validate-testdata-python-sdk: validate 
 		\( -type f -name "*yaml" -not -path "*\test_data\*" -not -name "*component.yaml" \) \
 		-print0 | xargs -0 -n1 ${BIN_DIR}/pipelineloop-cli -f
 
-local: init
+local: update init
 	go build -o=${BIN_DIR}/pipelineloop-controller ./cmd/controller
 	go build -o=${BIN_DIR}/pipelineloop-webhook ./cmd/webhook
 	go build -o=${BIN_DIR}/pipelineloop-cli ./cmd/cli
 
-build-linux: init
+build-linux: update init
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o=${BIN_DIR}/pipelineloop-controller ./cmd/controller
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o=${BIN_DIR}/pipelineloop-webhook ./cmd/webhook
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o=${BIN_DIR}/pipelineloop-cli ./cmd/cli


### PR DESCRIPTION
the whole repo needs go v1.17 now.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>
