### PR TITLE
fix(backend): refine copy-artifacts step

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -45,6 +45,7 @@ const (
 	InjectDefaultScript                     string = "INJECT_DEFAULT_SCRIPT"
 	ApplyTektonCustomResource               string = "APPLY_TEKTON_CUSTOM_RESOURCE"
 	TerminateStatus                         string = "TERMINATE_STATUS"
+	Path4InternalResults                    string = "PATH_FOR_INTERNAL_RESULTS"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {
@@ -191,4 +192,8 @@ func GetArtifactScript() string {
 
 func GetTerminateStatus() string {
 	return GetStringConfigWithDefault(TerminateStatus, DefaultTerminateStatus)
+}
+
+func GetPath4InternalResults() string {
+	return GetStringConfigWithDefault(Path4InternalResults, DefaultPath4InternalResults)
 }

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -83,8 +83,7 @@ const (
 )
 
 // For backward compatibility. Remove after 0.3 release
-const DefaultArtifactScript string = "#!/usr/bin/env sh\n" +
-	"push_artifact() {\n" +
+const DefaultArtifactScript string = "push_artifact() {\n" +
 	"    tar -cvzf $1.tgz $2\n" +
 	"    mc cp $1.tgz storage/$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz\n" +
 	"}\n" +
@@ -99,6 +98,8 @@ const DefaultArtifactScript string = "#!/usr/bin/env sh\n" +
 
 // Default Tekton 0.25.0+ Terminate Status.
 const DefaultTerminateStatus string = "Cancelled"
+
+const DefaultPath4InternalResults string = "/tekton/home/tep-results"
 
 func ToModelResourceType(apiType api.ResourceType) (model.ResourceType, error) {
 	switch apiType {

--- a/backend/src/apiserver/template/tekton_template.go
+++ b/backend/src/apiserver/template/tekton_template.go
@@ -294,9 +294,24 @@ func (t *Tekton) injectArchivalStep(workflow util.Workflow, artifactItemsJSON ma
 					task.TaskSpec.StepTemplate.VolumeMounts = append(task.TaskSpec.StepTemplate.VolumeMounts, loggingVolumeMounts...)
 				}
 
+				moveStep := false
+				if task.TaskSpec.Results != nil && len(task.TaskSpec.Results) > 0 {
+					// move all results to /tekton/home/tep-results to avoid result duplication in copy-artifacts step
+					// TODO: disable eof strip, since no results under /tekton/results after this step
+					moveResults := workflowapi.Step{Container: corev1.Container{
+						Image:   "busybox",
+						Name:    "move-all-results-to-tekton-home",
+						Command: []string{"sh", "-c"},
+						Args: []string{fmt.Sprintf("if [ -d /tekton/results ]; then mkdir -p %s; mv /tekton/results/* %s/ || true; fi\n",
+							common.GetPath4InternalResults(), common.GetPath4InternalResults())},
+					}}
+					moveStep = true
+					task.TaskSpec.Steps = append(task.TaskSpec.Steps, moveResults)
+				}
+
 				// Process the artifacts into minimum sh commands if running with minimum linux kernel
 				if injectDefaultScript {
-					artifactScript = t.injectDefaultScript(workflow, artifactScript, artifacts, hasArtifacts, archiveLogs, trackArtifacts, stripEOF)
+					artifactScript = t.injectDefaultScript(workflow, artifactScript, artifacts, hasArtifacts, archiveLogs, trackArtifacts, stripEOF, moveStep)
 				}
 
 				// Define post-processing step
@@ -327,19 +342,6 @@ func (t *Tekton) injectArchivalStep(workflow util.Workflow, artifactItemsJSON ma
 
 				step := workflowapi.Step{Container: container}
 
-				if task.TaskSpec.Results != nil && len(task.TaskSpec.Results) > 0 {
-					// move all results to /tekton/home/tep-results to avoid result duplication in copy-artifacts step
-					// TODO: this causes eof strip fails, since no results under /tekton/results after this step
-					moveResults := workflowapi.Step{Container: corev1.Container{
-						Image:   "busybox",
-						Name:    "move-all-results-to-tekton-home",
-						Command: []string{"sh", "-c"},
-						Args: []string{fmt.Sprintf("if [ -d /tekton/results ]; then mkdir -p %s; mv /tekton/results/* %s/ || true; fi\n",
-							common.GetPath4InternalResults(), common.GetPath4InternalResults())},
-					}}
-					task.TaskSpec.Steps = append(task.TaskSpec.Steps, moveResults)
-				}
-
 				task.TaskSpec.Steps = append(task.TaskSpec.Steps, step)
 			}
 		}
@@ -347,7 +349,7 @@ func (t *Tekton) injectArchivalStep(workflow util.Workflow, artifactItemsJSON ma
 }
 
 func (t *Tekton) injectDefaultScript(workflow util.Workflow, artifactScript string,
-	artifacts [][]interface{}, hasArtifacts bool, archiveLogs bool, trackArtifacts bool, stripEOF bool) string {
+	artifacts [][]interface{}, hasArtifacts, archiveLogs, trackArtifacts, stripEOF, hasMoveStep bool) string {
 	// Need to represent as Raw String Literals
 	artifactScript += "\n"
 	if archiveLogs {
@@ -367,7 +369,7 @@ func (t *Tekton) injectDefaultScript(workflow util.Workflow, artifactScript stri
 	}
 
 	// Strip EOF if enabled, do it after artifact upload since it only applies to parameter outputs
-	if hasArtifacts && len(artifacts) > 0 && stripEOF {
+	if !hasMoveStep && hasArtifacts && len(artifacts) > 0 && stripEOF {
 		for _, artifact := range artifacts {
 			if len(artifact) == 2 {
 				// The below solution is in experimental stage and didn't cover all edge cases.

--- a/manifests/kustomize/base/pipeline/kfp-pipeline-config.yaml
+++ b/manifests/kustomize/base/pipeline/kfp-pipeline-config.yaml
@@ -14,10 +14,9 @@ data:
   apply_tekton_custom_resource: "true"
   terminate_status: "Cancelled"
   artifact_script: |-
-    #!/usr/bin/env sh
     push_artifact() {
         if [ -f "$2" ]; then
-            tar -cvzf $1.tgz $2
+            tar -cvzf $1.tgz -C $(dirname $2) $(basename $2)
             mc cp $1.tgz storage/$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"


### PR DESCRIPTION
to avoid result duplication in the copy-artifacts step, add a step
to move result files to /tekton/home/tep-results.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

