### PR TITLE
feature(backend): support embedded-status: minimal

### DIFF
--- a/backend/src/agent/persistence/main.go
+++ b/backend/src/agent/persistence/main.go
@@ -110,6 +110,7 @@ func main() {
 	controller := NewPersistenceAgent(
 		swfInformerFactory,
 		workflowInformerFactory,
+		workflowClient,
 		pipelineClient,
 		util.NewRealTime())
 

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -266,7 +266,8 @@ export default class WorkflowParser {
       // Find the output that matches this input and pull the value
       if (
         statusMap.get(component['name']) &&
-        statusMap.get(component['name'])['status']['taskSpec']
+        statusMap.get(component['name'])['status']['taskSpec'] &&
+        statusMap.get(component['name'])['status']['taskSpec']['params']
       ) {
         for (const statusParam of statusMap.get(component['name'])!['status']['taskSpec']['params'])
           if (statusParam['name'] === param['name']) statusParam['value'] = paramValue;

--- a/guides/advanced_user_guide.md
+++ b/guides/advanced_user_guide.md
@@ -11,6 +11,7 @@ This page is an advanced KFP-Tekton guide on how to use Tekton specific features
     - [Custom Task Limitations](#custom-task-limitations)
     - [Custom Task for OpsGroup](#custom-task-for-opsgroup)
   - [Tekton Pipeline Config for PodTemplate](#tekton-pipeline-config-for-podtemplate)
+  - [Tekton Feature Flags](#tekton-feature-flags)
 
 ## Using Tekton Custom Task on KFP-Tekton
 
@@ -202,3 +203,17 @@ self._test_pipeline_workflow(test_pipeline, 'test.yaml', tekton_pipeline_conf=pi
 ```
 
 For more details on how this can be used in a real pipeline, visit the [Tekton Pipeline Conf example](/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.py).
+
+## Tekton Feature Flags
+Tekton provides some features that you can configure via `feature-flgas` configmap under `tekton-pipelines`
+namespace. Use these tekton features may impact kfp-tekton backend. Here is the list of features that
+impact kfp-tekton backend:
+- enable-custom-tasks: You can turn on/off custom task support by setting its value to true/false.
+  The default value for kfp-tekton deployment is `true`. If you are using custom tasks and set the flag value
+  to `false`, the pipeline will be in the running state until timeout. Because custom tasks inside the pipeline
+  are not able to be handled properly.
+- embedded-status: You can find details for this feature flag [here](https://github.com/tektoncd/community/blob/main/teps/0100-embedded-taskruns-and-runs-status-in-pipelineruns.md).
+  The default value for kfp-tekton deployment is `full`, which stores all TaskRuns/Runs statuses under PipelineRun's status.
+  kfp-tekton backend also supports the `minimal` setting, which only records the list of TaskRuns/Runs under PipelineRun's status.
+  In this case, statuses of TaskRuns/Runs only exist in their own CRs. kfp-tekton backend retrieves statuses of TaskRuns/Runs
+  from individual CR, aggregates, and stores them into the backend storage.

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-role.yaml
@@ -25,6 +25,7 @@ rules:
   - pipelineruns
   - taskruns
   - conditions
+  - runs
   verbs:
   - create
   - get

--- a/manifests/kustomize/third-party/tekton/upstream/manifests/base/tektoncd-install/tekton-config.yaml
+++ b/manifests/kustomize/third-party/tekton/upstream/manifests/base/tektoncd-install/tekton-config.yaml
@@ -8,3 +8,4 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 data:
   enable-custom-tasks: "true"
+  embedded-status: "full"


### PR DESCRIPTION
Add logic to support `embedded-status` feature when using
the `minimal` setting. For now, the TaskRun/Run status is retrieved
and inserted to PipelineRun.Status and stored into ml-pipeline
backend storage.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
