### PR TITLE
chore(apiserver): Object Storage connection abstraction

### DIFF
--- a/backend/src/apiserver/client/minio.go
+++ b/backend/src/apiserver/client/minio.go
@@ -57,7 +57,7 @@ func CreateMinioClient(minioServiceHost string, minioServicePort string,
 	return minioClient, nil
 }
 
-func CreateMinioClientOrFatal(minioServiceHost string, minioServicePort string,
+func CreateObjectStoreClientOrFatal(minioServiceHost string, minioServicePort string,
 	accessKey string, secretKey string, secure bool, region string, initConnectionTimeout time.Duration) *minio.Client {
 	var minioClient *minio.Client
 	var err error

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -35,22 +35,22 @@ import (
 )
 
 const (
-	minioServiceHost       = "MINIO_SERVICE_SERVICE_HOST"
-	minioServicePort       = "MINIO_SERVICE_SERVICE_PORT"
-	minioServiceRegion     = "MINIO_SERVICE_REGION"
-	minioServiceSecure     = "MINIO_SERVICE_SECURE"
-	pipelineBucketName     = "MINIO_PIPELINE_BUCKET_NAME"
-	pipelinePath           = "MINIO_PIPELINE_PATH"
-	mysqlServiceHost       = "DBConfig.Host"
-	mysqlServicePort       = "DBConfig.Port"
-	mysqlUser              = "DBConfig.User"
-	mysqlPassword          = "DBConfig.Password"
-	mysqlDBName            = "DBConfig.DBName"
-	mysqlGroupConcatMaxLen = "DBConfig.GroupConcatMaxLen"
-	mysqlExtraParams       = "DBConfig.ExtraParams"
-	archiveLogFileName     = "ARCHIVE_LOG_FILE_NAME"
-	archiveLogPathPrefix   = "ARCHIVE_LOG_PATH_PREFIX"
-	dbConMaxLifeTime       = "DBConfig.ConMaxLifeTime"
+	objectStoreServiceHost   = "MINIO_SERVICE_SERVICE_HOST"
+	objectStoreServicePort   = "MINIO_SERVICE_SERVICE_PORT"
+	objectStoreServiceRegion = "MINIO_SERVICE_REGION"
+	objectStoreServiceSecure = "MINIO_SERVICE_SECURE"
+	pipelineBucketName       = "MINIO_PIPELINE_BUCKET_NAME"
+	pipelinePath             = "MINIO_PIPELINE_PATH"
+	mysqlServiceHost         = "DBConfig.Host"
+	mysqlServicePort         = "DBConfig.Port"
+	mysqlUser                = "DBConfig.User"
+	mysqlPassword            = "DBConfig.Password"
+	mysqlDBName              = "DBConfig.DBName"
+	mysqlGroupConcatMaxLen   = "DBConfig.GroupConcatMaxLen"
+	mysqlExtraParams         = "DBConfig.ExtraParams"
+	archiveLogFileName       = "ARCHIVE_LOG_FILE_NAME"
+	archiveLogPathPrefix     = "ARCHIVE_LOG_PATH_PREFIX"
+	dbConMaxLifeTime         = "DBConfig.ConMaxLifeTime"
 
 	visualizationServiceHost = "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST"
 	visualizationServicePort = "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT"
@@ -175,7 +175,7 @@ func (c *ClientManager) init() {
 	c.resourceReferenceStore = storage.NewResourceReferenceStore(db)
 	c.dBStatusStore = storage.NewDBStatusStore(db)
 	c.defaultExperimentStore = storage.NewDefaultExperimentStore(db)
-	c.objectStore = initMinioClient(common.GetDurationConfig(initConnectionTimeout))
+	c.objectStore = initObjectStoreClient(common.GetDurationConfig(initConnectionTimeout))
 
 	// Use default value of client QPS (5) & burst (10) defined in
 	// k8s.io/client-go/rest/config.go#RESTClientFor
@@ -381,32 +381,32 @@ func initMysql(driverName string, initConnectionTimeout time.Duration) string {
 	return mysqlConfig.FormatDSN()
 }
 
-func initMinioClient(initConnectionTimeout time.Duration) storage.ObjectStoreInterface {
-	// Create minio client.
-	minioServiceHost := common.GetStringConfigWithDefault(
-		"ObjectStoreConfig.Host", os.Getenv(minioServiceHost))
-	minioServicePort := common.GetStringConfigWithDefault(
-		"ObjectStoreConfig.Port", os.Getenv(minioServicePort))
-	minioServiceRegion := common.GetStringConfigWithDefault(
-		"ObjectStoreConfig.Region", os.Getenv(minioServiceRegion))
-	minioServiceSecure := common.GetBoolConfigWithDefault(
-		"ObjectStoreConfig.Secure", common.GetBoolFromStringWithDefault(os.Getenv(minioServiceSecure), false))
+func initObjectStoreClient(initConnectionTimeout time.Duration) storage.ObjectStoreInterface {
+	// Create client.
+	objectStoreServiceHost := common.GetStringConfigWithDefault(
+		"ObjectStoreConfig.Host", os.Getenv(objectStoreServiceHost))
+	objectStoreServicePort := common.GetStringConfigWithDefault(
+		"ObjectStoreConfig.Port", os.Getenv(objectStoreServicePort))
+	objectStoreServiceRegion := common.GetStringConfigWithDefault(
+		"ObjectStoreConfig.Region", os.Getenv(objectStoreServiceRegion))
+	objectStoreServiceSecure := common.GetBoolConfigWithDefault(
+		"ObjectStoreConfig.Secure", common.GetBoolFromStringWithDefault(os.Getenv(objectStoreServiceSecure), false))
 	accessKey := common.GetStringConfigWithDefault("ObjectStoreConfig.AccessKey", "")
 	secretKey := common.GetStringConfigWithDefault("ObjectStoreConfig.SecretAccessKey", "")
 	bucketName := common.GetStringConfigWithDefault("ObjectStoreConfig.BucketName", os.Getenv(pipelineBucketName))
 	pipelinePath := common.GetStringConfigWithDefault("ObjectStoreConfig.PipelinePath", os.Getenv(pipelinePath))
 	disableMultipart := common.GetBoolConfigWithDefault("ObjectStoreConfig.Multipart.Disable", true)
 
-	minioClient := client.CreateMinioClientOrFatal(minioServiceHost, minioServicePort, accessKey,
-		secretKey, minioServiceSecure, minioServiceRegion, initConnectionTimeout)
-	createMinioBucket(minioClient, bucketName, minioServiceRegion)
+	client := client.CreateObjectStoreClientOrFatal(objectStoreServiceHost, objectStoreServicePort, accessKey,
+		secretKey, objectStoreServiceSecure, objectStoreServiceRegion, initConnectionTimeout)
+	createBucket(client, bucketName, objectStoreServiceRegion)
 
-	return storage.NewMinioObjectStore(&storage.MinioClient{Client: minioClient}, bucketName, pipelinePath, disableMultipart)
+	return storage.NewMinioObjectStore(&storage.MinioClient{Client: client}, bucketName, pipelinePath, disableMultipart)
 }
 
-func createMinioBucket(minioClient *minio.Client, bucketName, region string) {
+func createBucket(client *minio.Client, bucketName, region string) {
 	// Check to see if we already own this bucket.
-	exists, err := minioClient.BucketExists(bucketName)
+	exists, err := client.BucketExists(bucketName)
 	if err != nil {
 		glog.Fatalf("Failed to check if Minio bucket exists. Error: %v", err)
 	}
@@ -415,7 +415,7 @@ func createMinioBucket(minioClient *minio.Client, bucketName, region string) {
 		return
 	}
 	// Create bucket if it does not exist
-	err = minioClient.MakeBucket(bucketName, region)
+	err = client.MakeBucket(bucketName, region)
 	if err != nil {
 		glog.Fatalf("Failed to create Minio bucket. Error: %v", err)
 	}

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -46,6 +46,8 @@ const (
 	ApplyTektonCustomResource               string = "APPLY_TEKTON_CUSTOM_RESOURCE"
 	TerminateStatus                         string = "TERMINATE_STATUS"
 	Path4InternalResults                    string = "PATH_FOR_INTERNAL_RESULTS"
+	ObjectStoreAccessKey                    string = "OBJECTSTORECONFIG_ACCESSKEY"
+	ObjectStoreSecretKey                    string = "OBJECTSTORECONFIG_SECRETKEY"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -17,6 +17,8 @@ data:
   mlmdDb: metadb
   cacheDb: cachedb
   pipelineDb: mlpipeline
+  objectStoreHost: minio-service
+  objectStorePort: "9000"
   bucketName: mlpipeline
   ## defaultPipelineRoot: Optional. Default pipeline root in v2 compatible mode.
   ## https://www.kubeflow.org/docs/components/pipelines/sdk/v2/v2-compatibility/

--- a/manifests/kustomize/base/pipeline/apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/apiserver-deployment.yaml
@@ -12,6 +12,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: OBJECTSTORECONFIG_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: objectStoreHost
+        - name: OBJECTSTORECONFIG_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: objectStorePort
         - name: OBJECTSTORECONFIG_SECURE
           value: "false"
         - name: OBJECTSTORECONFIG_BUCKETNAME

--- a/v2/objectstore/object_store_test.go
+++ b/v2/objectstore/object_store_test.go
@@ -181,8 +181,8 @@ func Test_bucketConfig_KeyFromURI(t *testing.T) {
 
 func Test_GetMinioDefaultEndpoint(t *testing.T) {
 	defer func() {
-		os.Unsetenv("MINIO_SERVICE_SERVICE_HOST")
-		os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
+		os.Unsetenv("OBJECT_STORE_SERVICE_HOST")
+		os.Unsetenv("OBJECT_STORE_SERVICE_PORT")
 	}()
 	tests := []struct {
 		name                string
@@ -206,19 +206,19 @@ func Test_GetMinioDefaultEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.minioServiceHostEnv != "" {
-				os.Setenv("MINIO_SERVICE_SERVICE_HOST", tt.minioServiceHostEnv)
+				os.Setenv("OBJECT_STORE_SERVICE_HOST", tt.minioServiceHostEnv)
 			} else {
-				os.Unsetenv("MINIO_SERVICE_SERVICE_HOST")
+				os.Unsetenv("OBJECT_STORE_SERVICE_HOST")
 			}
 			if tt.minioServicePortEnv != "" {
-				os.Setenv("MINIO_SERVICE_SERVICE_PORT", tt.minioServicePortEnv)
+				os.Setenv("OBJECT_STORE_SERVICE_PORT", tt.minioServicePortEnv)
 			} else {
-				os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
+				os.Unsetenv("OBJECT_STORE_SERVICE_PORT")
 			}
 			got := objectstore.MinioDefaultEndpoint()
 			if got != tt.want {
 				t.Errorf(
-					"MinioDefaultEndpoint() = %q, want %q\nwhen MINIO_SERVICE_SERVICE_HOST=%q MINIO_SERVICE_SERVICE_PORT=%q",
+					"MinioDefaultEndpoint() = %q, want %q\nwhen OBJECT_STORE_SERVICE_HOST=%q OBJECT_STORE_SERVICE_PORT=%q",
 					got, tt.want, tt.minioServiceHostEnv, tt.minioServicePortEnv,
 				)
 			}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
N/A

**Description of your changes:**
Removes any reference to minio to make object storage access abstract

**Environment tested:**

* Python Version (use `python --version`): 3.10.4
* Tekton Version (use `tkn version`): 0.33.2
* Kubernetes Version (use `kubectl version`): 1.22.3
* OS (e.g. from `/etc/os-release`): Fedora 35

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

