### PR TITLE
fix(backend): nil ptr exception for empty run status in pipeline-loops, fixes #981

### DIFF
--- a/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
+++ b/tekton-catalog/pipeline-loops/pkg/reconciler/pipelinelooprun/pipelinelooprun.go
@@ -808,7 +808,7 @@ func (c *Reconciler) updatePipelineRunStatus(ctx context.Context, iterationEleme
 		}
 		for _, runStatus := range pr.Status.Runs {
 			if strings.HasPrefix(runStatus.PipelineTaskName, "pipelineloop-break-operation") {
-				if !runStatus.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
+				if runStatus.Status != nil && !runStatus.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
 					err = c.cancelAllPipelineRuns(ctx, run)
 					if err != nil {
 						return 0, nil, nil, fmt.Errorf("could not cancel PipelineRuns belonging to Run %s."+


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #981

**Description of your changes:**
Add a `nil` check for run status.

Without that, the status will eventually be wrapped into `ConditionsAccessor` interface, which means the `nil` will be transformed into `(*RunStatus)(nil)` (i.e. the method table is non-nil, but the data table of the interface fat-pointer is nil). A casual `nil` check done in `GetCondition` cannot detect typed nils.

That kind of cases should be avoided and are generally quite [bothersome to detect](https://go.dev/play/p/WBawQ4ujB1s):
```go
var i interface{} = nil
assert.Equal(t, i, nil)

var s *string = nil
i = s
assert.NoEqual(t, i, nil)
assert.True(t, reflect.ValueOf(i).Kind() == reflect.Ptr && reflect.ValueOf(i).IsNil())
```

Instead, it would be best not to call `GetCondition` with a nil argument at all. This PR, therefore, adds a `nil` check before that call.

**Environment tested:**

* Python Version (use `python --version`): 3.9.0
* Tekton Version (use `tkn version`): 0.36
* Kubernetes Version (use `kubectl version`): v1.22.10+IKS
* OS (e.g. from `/etc/os-release`): irrelevant

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
