### PR TITLE
Add alpha preview feature into compiler

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -618,13 +618,20 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                         dst = '$(results.%s.path)' % sanitize_k8s_name(result['name'])
                         if artifact_name == result['name'] and src != dst:
                             add_copy_results_artifacts_step = True
+                            total_size_command = 'TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n'
+                            copy_command = '    cp ' + src + ' ' + dst + '\n'
+                            if env.get('OUTPUT_PREVIEW', 'false').lower() == 'true':
+                                preview_size = env.get('OUTPUT_PREVIEW_SIZE', '100')
+                                total_size_command = 'TOTAL_SIZE=$( expr $TOTAL_SIZE + %s)\n' % preview_size
+                                copy_command = '    dd if=' + src + ' of=' + \
+                                               dst + ' bs=' + preview_size + ' count=1\n'
                             copy_results_artifact_step['script'] += (
                                     'ARTIFACT_SIZE=`wc -c %s | awk \'{print $1}\'`\n' % src +
-                                    'TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
+                                    total_size_command +
                                     'touch ' + dst + '\n' +  # create an empty file by default.
                                     'if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
                                     '  if ! awk "/[^[:print:]]/{f=1} END{exit !f}" %s; then\n' % src +
-                                    '    cp ' + src + ' ' + dst + '\n' +
+                                    copy_command +
                                     '  fi\n'
                                     'fi\n'
                             )


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #988 

**Description of your changes:**
Add alpha preview feature into compiler so that the big data outputs can be trimmed based on a preview size. Since we will be using this feature for A/B testing, we use env variables to set this flag.

To enable this set
```
export OUTPUT_PREVIEW=true
export OUTPUT_PREVIEW_SIZE=100
```

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
