### PR TITLE
eliminate the use of `taskSpec.script`

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -448,6 +448,22 @@ def big_data_passing_pipeline(name: str, template: dict, inputs_tasks: set(),
                     "name": task.get('name'),
                     "workspace": pipeline_name
                 })
+        artifact_output_list = task.get('taskSpec', {}).get('metadata', {}).get('annotations', {}).get(
+            ARTIFACT_OUTPUTLIST_ANNOTATION_KEY, '')
+        if artifact_output_list:
+            tmp_list = set()
+            for output in json.loads(artifact_output_list):
+                tmp_list.add(sanitize_k8s_name(output))
+            for task_output in task.get('taskSpec', {}).get('results', []):
+                if task_output.get('name') in tmp_list:
+                    if not task.setdefault('workspaces', []):
+                        task['workspaces'].append({
+                          "name": task.get('name'),
+                            "workspace": pipeline_name
+                        })
+                        pipeline_workspaces.add(pipeline_name)
+                        break
+
     if pipeline_name in pipeline_workspaces:
         # Add workspaces to pipeline
         if not pipeline_spec.setdefault('workspaces', []):
@@ -511,7 +527,7 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
             # For child nodes to know the taskrun name, it has to pass to results via /tekton/results emptydir
             if not appended_taskrun_name:
                 copy_taskrun_name_step = _get_base_step('output-taskrun-name')
-                copy_taskrun_name_step['script'] += 'echo -n "%s" > $(results.taskrun-name.path)\n' % ("$(context.taskRun.name)")
+                copy_taskrun_name_step['command'].append('echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"')
                 task['taskSpec']['results'].append({"name": "taskrun-name", "type": "string"})
                 task['taskSpec']['steps'].append(copy_taskrun_name_step)
                 _append_original_pr_name_env(task)
@@ -608,7 +624,7 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
         if task_spec.get('results', []):
             copy_results_artifact_step = _get_base_step('copy-results-artifacts')
             copy_results_artifact_step['onError'] = 'continue'  # supported by v0.27+ of tekton.
-            copy_results_artifact_step['script'] += 'TOTAL_SIZE=0\n'
+            script = "set -exo pipefail\nTOTAL_SIZE=0\n"
             for result in task_spec['results']:
                 if task['name'] in artifact_items:
                     artifact_i = artifact_items[task['name']]
@@ -618,7 +634,7 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                         dst = '$(results.%s.path)' % sanitize_k8s_name(result['name'])
                         if artifact_name == result['name'] and src != dst:
                             add_copy_results_artifacts_step = True
-                            copy_results_artifact_step['script'] += (
+                            script += (
                                     'ARTIFACT_SIZE=`wc -c %s | awk \'{print $1}\'`\n' % src +
                                     'TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
                                     'touch ' + dst + '\n' +  # create an empty file by default.
@@ -628,6 +644,7 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                                     '  fi\n'
                                     'fi\n'
                             )
+            copy_results_artifact_step['command'].append(script)
             _append_original_pr_name_env_to_step(copy_results_artifact_step)
             if add_copy_results_artifacts_step:
                 task['taskSpec']['steps'].append(copy_results_artifact_step)
@@ -651,17 +668,19 @@ def input_artifacts_tasks_pr_params(template: dict, artifact: dict) -> dict:
     task_name = template.get('name')
     task_spec = template.get('taskSpec', {})
     task_params = task_spec.get('params', [])
+    script = "set -exo pipefail\n"
     for task_param in task_params:
         # For pipeline parameter input artifacts, it will never come from another task because pipeline
         # params are global parameters. Thus, task_name will always be the executing task name.
         workspaces_parameter = '$(workspaces.%s.path)/%s/%s/%s' % (
             task_name, BIG_DATA_MIDPATH, "$(context.taskRun.name)", task_param.get('name'))
         if 'raw' in artifact:
-            copy_inputs_step['script'] += 'mkdir -p %s\n' % pathlib.Path(workspaces_parameter).parent
-            copy_inputs_step['script'] += 'echo -n "%s" > %s\n' % (
+            script += 'mkdir -p %s\n' % pathlib.Path(workspaces_parameter).parent
+            script += 'echo -n "%s" > %s\n' % (
                 artifact['raw']['data'], workspaces_parameter)
         _append_original_pr_name_env(template)
 
+    copy_inputs_step['command'].append(script)
     template['taskSpec']['steps'] = _prepend_steps(
         [copy_inputs_step], template['taskSpec']['steps'])
 
@@ -676,8 +695,8 @@ def input_artifacts_tasks(template: dict, artifact: dict) -> dict:
     mounted_param_paths = []
     copy_inputs_step = _get_base_step('copy-inputs')
     if 'raw' in artifact:
-        copy_inputs_step['script'] += 'echo -n "%s" > %s\n' % (
-            artifact['raw']['data'], artifact['path'])
+        copy_inputs_step['command'].append('set -exo pipefail\necho -n "%s" > %s\n' % (
+            artifact['raw']['data'], artifact['path']))
     mount_path = artifact['path'].rsplit("/", 1)[0]
     if mount_path not in mounted_param_paths:
         _add_mount_path(artifact['name'], artifact['path'], mount_path,

--- a/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
@@ -64,14 +64,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
@@ -113,4 +115,19 @@ spec:
         workspaces:
         - name: gcs-download
       timeout: 525600m
+      workspaces:
+      - name: gcs-download
+        workspace: artifact-out-pipeline
+    workspaces:
+    - name: artifact-out-pipeline
   timeout: 525600m
+  workspaces:
+  - name: artifact-out-pipeline
+    volumeClaimTemplate:
+      spec:
+        storageClassName: kfp-csi-s3
+        accessModes:
+        - ReadWriteMany
+        resources:
+          requests:
+            storage: 2Gi

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -97,14 +97,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text | awk '{print $1}'`
@@ -148,8 +150,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             echo -n "one
             two
@@ -214,14 +218,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines | awk '{print $1}'`
@@ -438,14 +444,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers | awk '{print $1}'`
@@ -608,14 +616,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output | awk '{print $1}'`

--- a/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
+++ b/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
@@ -87,14 +87,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir | awk '{print $1}'`
@@ -158,14 +160,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir | awk '{print $1}'`

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
@@ -117,14 +117,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
@@ -200,14 +202,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
@@ -301,14 +305,16 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         - image: busybox
           name: output-taskrun-name
-          script: |
-            #!/bin/sh
-            set -exo pipefail
-            echo -n "$(context.taskRun.name)" > $(results.taskrun-name.path)
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output | awk '{print $1}'`
@@ -457,8 +463,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             echo -n "constant" > /tmp/inputs/data/data
         - name: main
@@ -506,8 +514,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             echo -n "constant" > /tmp/inputs/data/data
         - name: main
@@ -555,8 +565,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             echo -n "constant" > /tmp/inputs/data/data
         - name: main
@@ -884,8 +896,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-anything-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "anything_param" > $(workspaces.consume-anything-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/anything_param
@@ -937,8 +951,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-anything-as-file-3.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "something_param" > $(workspaces.consume-anything-as-file-3.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/something_param
@@ -990,8 +1006,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-anything-as-file-4.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "string_param" > $(workspaces.consume-anything-as-file-4.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/string_param
@@ -1043,8 +1061,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-something-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "anything_param" > $(workspaces.consume-something-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/anything_param
@@ -1096,8 +1116,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-something-as-file-3.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "something_param" > $(workspaces.consume-something-as-file-3.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/something_param
@@ -1149,8 +1171,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-string-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "anything_param" > $(workspaces.consume-string-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/anything_param
@@ -1202,8 +1226,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-string-as-file-3.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "string_param" > $(workspaces.consume-string-as-file-3.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/string_param

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_param_as_file.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_param_as_file.yaml
@@ -54,8 +54,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-anything-as-file.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "anything_param" > $(workspaces.consume-anything-as-file.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/anything_param
@@ -107,8 +109,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-anything-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "something_param" > $(workspaces.consume-anything-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/something_param
@@ -160,8 +164,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-anything-as-file-3.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "string_param" > $(workspaces.consume-anything-as-file-3.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/string_param
@@ -213,8 +219,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-something-as-file.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "anything_param" > $(workspaces.consume-something-as-file.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/anything_param
@@ -266,8 +274,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-something-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "something_param" > $(workspaces.consume-something-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/something_param
@@ -319,8 +329,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-string-as-file.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "anything_param" > $(workspaces.consume-string-as-file.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/anything_param
@@ -372,8 +384,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             mkdir -p $(workspaces.consume-string-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)
             echo -n "string_param" > $(workspaces.consume-string-as-file-2.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/string_param

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -37,8 +37,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             echo -n "Constant artifact value" > /tmp/inputs/text/data
         - name: main
@@ -72,8 +74,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             echo -n "Constant artifact value" > /tmp/inputs/text/data
         - name: main
@@ -107,8 +111,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             echo -n "hard-coded artifact value" > /tmp/inputs/text/data
         - name: main
@@ -142,8 +148,10 @@ spec:
         steps:
         - image: busybox
           name: copy-inputs
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             echo -n "Text from a file with hard-coded artifact value
             " > /tmp/inputs/text/data

--- a/sdk/python/tests/compiler/testdata/many_results.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results.yaml
@@ -111,8 +111,10 @@ spec:
           image: library/bash
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param1 | awk '{print $1}'`

--- a/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
@@ -111,8 +111,10 @@ spec:
           image: library/bash
         - image: busybox
           name: copy-results-artifacts
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             TOTAL_SIZE=0
             ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param2 | awk '{print $1}'`

--- a/sdk/python/tests/compiler/testdata/nested_custom_conditions.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_custom_conditions.yaml
@@ -70,8 +70,10 @@ spec:
           image: alpine:3.6
         - image: busybox
           name: copy-results
-          script: |
-            #!/bin/sh
+          command:
+          - sh
+          - -ec
+          - |
             set -exo pipefail
             cp /tmp/outputs/stdout/data $(results.stdout.path);
         params:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #989 

**Description of your changes:**

when using script, it generates an init container to process the script.
we'd like to avoid the init container in pipelinerun.
remove `script` and use `command` and `arg` instead.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
