### PR TITLE
fix(sdk): Support passing directories in step-copy-results-artifacts and step-copy-artifacts. Fixes #996

### DIFF
--- a/manifests/kustomize/base/pipeline/kfp-pipeline-config.yaml
+++ b/manifests/kustomize/base/pipeline/kfp-pipeline-config.yaml
@@ -15,7 +15,7 @@ data:
   terminate_status: "Cancelled"
   artifact_script: |-
     push_artifact() {
-        if [ -f "$2" ]; then
+        if [ -f "$2" ] || [ -d "$2" ]; then
             tar -cvzf $1.tgz -C $(dirname $2) $(basename $2)
             mc cp $1.tgz storage/$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else

--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -637,21 +637,17 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                             script += (
                                     'if [ -d ' + src + ' ]; then\n' + 
                                     '  tar -czvf ' + src + '.tar.gz ' + src + '\n' +
-                                    '  ARTIFACT_SIZE=`wc -c %s.tar.gz | awk \'{print $1}\'`\n' % src +
-                                    '  TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
-                                    '  touch ' + dst + '\n' +  # create an empty file by default.
-                                    '  if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
-                                    '    tar -tzf ' + src + '.tar.gz > ' + dst + '\n' +
-                                    '  fi\n'
-                                    'else\n' +
-                                    '  ARTIFACT_SIZE=`wc -c %s | awk \'{print $1}\'`\n' % src +
-                                    '  TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
-                                    '  touch ' + dst + '\n' +  # create an empty file by default.
-                                    '  if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
-                                    '    if ! awk "/[^[:print:]]/{f=1} END{exit !f}" %s; then\n' % src +
-                                    '      cp ' + src + ' ' + dst + '\n' +
-                                    '    fi\n'
-                                    '  fi\n'
+                                    '  SUFFIX=".tar.gz"\n' +
+                                    'fi\n' +
+                                    'ARTIFACT_SIZE=`wc -c %s${SUFFIX} | awk \'{print $1}\'`\n' % src +
+                                    'TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
+                                    'touch ' + dst + '\n' +  # create an empty file by default.
+                                    'if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
+                                    '  if [ -d ' + src + ' ]; then\n' + 
+                                    '    tar -tzf ' + src + ' > ' + dst + '\n' +
+                                    '  elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" %s; then\n' % src +
+                                    '    cp ' + src + ' ' + dst + '\n' +
+                                    '  fi\n' +
                                     'fi\n'
                             )
             copy_results_artifact_step['command'].append(script)

--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -634,7 +634,7 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                         dst = '$(results.%s.path)' % sanitize_k8s_name(result['name'])
                         if artifact_name == result['name'] and src != dst:
                             add_copy_results_artifacts_step = True
-                            copy_results_artifact_step['script'] += (
+                            script += (
                                     'if [ -d ' + src + ' ]; then\n' + 
                                     '  tar -czvf ' + src + '.tar.gz ' + src + '\n' +
                                     '  ARTIFACT_SIZE=`wc -c %s.tar.gz | awk \'{print $1}\'`\n' % src +

--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -635,7 +635,7 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                         if artifact_name == result['name'] and src != dst:
                             add_copy_results_artifacts_step = True
                             script += (
-                                    'if [ -d ' + src + ' ]; then\n' + 
+                                    'if [ -d ' + src + ' ]; then\n' +
                                     '  tar -czvf ' + src + '.tar.gz ' + src + '\n' +
                                     '  SUFFIX=".tar.gz"\n' +
                                     'fi\n' +
@@ -643,7 +643,7 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                                     'TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
                                     'touch ' + dst + '\n' +  # create an empty file by default.
                                     'if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
-                                    '  if [ -d ' + src + ' ]; then\n' + 
+                                    '  if [ -d ' + src + ' ]; then\n' +
                                     '    tar -tzf ' + src + ' > ' + dst + '\n' +
                                     '  elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" %s; then\n' % src +
                                     '    cp ' + src + ' ' + dst + '\n' +

--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -644,7 +644,7 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                                     'touch ' + dst + '\n' +  # create an empty file by default.
                                     'if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
                                     '  if [ -d ' + src + ' ]; then\n' +
-                                    '    tar -tzf ' + src + ' > ' + dst + '\n' +
+                                    '    tar -tzf ' + src + '.tar.gz > ' + dst + '\n' +
                                     '  elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" %s; then\n' % src +
                                     '    cp ' + src + ' ' + dst + '\n' +
                                     '  fi\n' +

--- a/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp_tekton/compiler/_data_passing_rewriter.py
@@ -619,12 +619,22 @@ def big_data_passing_tasks(prname: str, task: dict, pipelinerun_template: dict,
                         if artifact_name == result['name'] and src != dst:
                             add_copy_results_artifacts_step = True
                             copy_results_artifact_step['script'] += (
-                                    'ARTIFACT_SIZE=`wc -c %s | awk \'{print $1}\'`\n' % src +
-                                    'TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
-                                    'touch ' + dst + '\n' +  # create an empty file by default.
-                                    'if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
-                                    '  if ! awk "/[^[:print:]]/{f=1} END{exit !f}" %s; then\n' % src +
-                                    '    cp ' + src + ' ' + dst + '\n' +
+                                    'if [ -d ' + src + ' ]; then\n' + 
+                                    '  tar -czvf ' + src + '.tar.gz ' + src + '\n' +
+                                    '  ARTIFACT_SIZE=`wc -c %s.tar.gz | awk \'{print $1}\'`\n' % src +
+                                    '  TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
+                                    '  touch ' + dst + '\n' +  # create an empty file by default.
+                                    '  if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
+                                    '    tar -tzf ' + src + '.tar.gz > ' + dst + '\n' +
+                                    '  fi\n'
+                                    'else\n' +
+                                    '  ARTIFACT_SIZE=`wc -c %s | awk \'{print $1}\'`\n' % src +
+                                    '  TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)\n' +
+                                    '  touch ' + dst + '\n' +  # create an empty file by default.
+                                    '  if [[ $TOTAL_SIZE -lt 3072 ]]; then\n' +
+                                    '    if ! awk "/[^[:print:]]/{f=1} END{exit !f}" %s; then\n' % src +
+                                    '      cp ' + src + ' ' + dst + '\n' +
+                                    '    fi\n'
                                     '  fi\n'
                                     'fi\n'
                             )

--- a/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
@@ -85,7 +85,7 @@ spec:
             touch $(results.data.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
-                tar -tzf $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data > $(results.data.path)
+                tar -tzf $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
                 cp $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
               fi

--- a/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
@@ -74,12 +74,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.data.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
-                cp $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
+            if [ -d $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
+              tar -czvf $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data
+              ARTIFACT_SIZE=`wc -c $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.data.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.data.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
+                  cp $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
+                fi
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
@@ -78,20 +78,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
               tar -czvf $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data
-              ARTIFACT_SIZE=`wc -c $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.data.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.data.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
-                  cp $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.data.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
+                tar -tzf $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data > $(results.data.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
+                cp $(workspaces.gcs-download.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -118,7 +118,7 @@ spec:
             touch $(results.output-text.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text ]; then
-                tar -tzf $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text > $(results.output-text.path)
+                tar -tzf $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text.tar.gz > $(results.output-text.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text; then
                 cp $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text $(results.output-text.path)
               fi
@@ -245,7 +245,7 @@ spec:
             touch $(results.odd-lines.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines ]; then
-                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines > $(results.odd-lines.path)
+                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines.tar.gz > $(results.odd-lines.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines; then
                 cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines $(results.odd-lines.path)
               fi
@@ -259,7 +259,7 @@ spec:
             touch $(results.even-lines.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines ]; then
-                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines > $(results.even-lines.path)
+                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines.tar.gz > $(results.even-lines.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines; then
                 cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines $(results.even-lines.path)
               fi
@@ -483,7 +483,7 @@ spec:
             touch $(results.numbers.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers ]; then
-                tar -tzf $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers > $(results.numbers.path)
+                tar -tzf $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers.tar.gz > $(results.numbers.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers; then
                 cp $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers $(results.numbers.path)
               fi
@@ -661,7 +661,7 @@ spec:
             touch $(results.output.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output ]; then
-                tar -tzf $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output > $(results.output.path)
+                tar -tzf $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz > $(results.output.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
                 cp $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
               fi

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -111,20 +111,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text ]; then
               tar -czvf $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text.tar.gz $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text
-              ARTIFACT_SIZE=`wc -c $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.output-text.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text.tar.gz > $(results.output-text.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.output-text.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text; then
-                  cp $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text $(results.output-text.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.output-text.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text ]; then
+                tar -tzf $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text > $(results.output-text.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text; then
+                cp $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text $(results.output-text.path)
               fi
             fi
           onError: continue
@@ -242,38 +238,30 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines ]; then
               tar -czvf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines.tar.gz $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines
-              ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.odd-lines.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines.tar.gz > $(results.odd-lines.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.odd-lines.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines; then
-                  cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines $(results.odd-lines.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.odd-lines.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines ]; then
+                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines > $(results.odd-lines.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines; then
+                cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines $(results.odd-lines.path)
               fi
             fi
             if [ -d $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines ]; then
               tar -czvf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines.tar.gz $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines
-              ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.even-lines.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines.tar.gz > $(results.even-lines.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.even-lines.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines; then
-                  cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines $(results.even-lines.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.even-lines.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines ]; then
+                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines > $(results.even-lines.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines; then
+                cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines $(results.even-lines.path)
               fi
             fi
           onError: continue
@@ -488,20 +476,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers ]; then
               tar -czvf $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers.tar.gz $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers
-              ARTIFACT_SIZE=`wc -c $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.numbers.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers.tar.gz > $(results.numbers.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.numbers.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers; then
-                  cp $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers $(results.numbers.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.numbers.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers ]; then
+                tar -tzf $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers > $(results.numbers.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers; then
+                cp $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers $(results.numbers.path)
               fi
             fi
           onError: continue
@@ -670,20 +654,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output ]; then
               tar -czvf $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output
-              ARTIFACT_SIZE=`wc -c $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.output.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz > $(results.output.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.output.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
-                  cp $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.output.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output ]; then
+                tar -tzf $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output > $(results.output.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
+                cp $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -107,12 +107,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.output-text.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text; then
-                cp $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text $(results.output-text.path)
+            if [ -d $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text ]; then
+              tar -czvf $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text.tar.gz $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text
+              ARTIFACT_SIZE=`wc -c $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.output-text.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text.tar.gz > $(results.output-text.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.output-text.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text; then
+                  cp $(workspaces.repeat-line.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_text $(results.output-text.path)
+                fi
               fi
             fi
           onError: continue
@@ -224,20 +234,40 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.odd-lines.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines; then
-                cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines $(results.odd-lines.path)
+            if [ -d $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines ]; then
+              tar -czvf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines.tar.gz $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines
+              ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.odd-lines.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines.tar.gz > $(results.odd-lines.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.odd-lines.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines; then
+                  cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/odd_lines $(results.odd-lines.path)
+                fi
               fi
             fi
-            ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.even-lines.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines; then
-                cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines $(results.even-lines.path)
+            if [ -d $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines ]; then
+              tar -czvf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines.tar.gz $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines
+              ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.even-lines.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines.tar.gz > $(results.even-lines.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.even-lines.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines; then
+                  cp $(workspaces.split-text-lines.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/even_lines $(results.even-lines.path)
+                fi
               fi
             fi
           onError: continue
@@ -448,12 +478,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.numbers.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers; then
-                cp $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers $(results.numbers.path)
+            if [ -d $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers ]; then
+              tar -czvf $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers.tar.gz $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers
+              ARTIFACT_SIZE=`wc -c $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.numbers.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers.tar.gz > $(results.numbers.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.numbers.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers; then
+                  cp $(workspaces.write-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/numbers $(results.numbers.path)
+                fi
               fi
             fi
           onError: continue
@@ -618,12 +658,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.output.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
-                cp $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
+            if [ -d $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output ]; then
+              tar -czvf $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output
+              ARTIFACT_SIZE=`wc -c $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.output.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz > $(results.output.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.output.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
+                  cp $(workspaces.sum-numbers.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
+                fi
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
+++ b/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
@@ -108,7 +108,7 @@ spec:
             touch $(results.output-dir.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir ]; then
-                tar -tzf $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir > $(results.output-dir.path)
+                tar -tzf $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir.tar.gz > $(results.output-dir.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir; then
                 cp $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir $(results.output-dir.path)
               fi
@@ -187,7 +187,7 @@ spec:
             touch $(results.subdir.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir ]; then
-                tar -tzf $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir > $(results.subdir.path)
+                tar -tzf $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir.tar.gz > $(results.subdir.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir; then
                 cp $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir $(results.subdir.path)
               fi

--- a/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
+++ b/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
@@ -101,20 +101,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir ]; then
               tar -czvf $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir.tar.gz $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir
-              ARTIFACT_SIZE=`wc -c $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.output-dir.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir.tar.gz > $(results.output-dir.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.output-dir.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir; then
-                  cp $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir $(results.output-dir.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.output-dir.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir ]; then
+                tar -tzf $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir > $(results.output-dir.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir; then
+                cp $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir $(results.output-dir.path)
               fi
             fi
           onError: continue
@@ -184,20 +180,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir ]; then
               tar -czvf $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir.tar.gz $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir
-              ARTIFACT_SIZE=`wc -c $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.subdir.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir.tar.gz > $(results.subdir.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.subdir.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir; then
-                  cp $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir $(results.subdir.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.subdir.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir ]; then
+                tar -tzf $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir > $(results.subdir.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir; then
+                cp $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir $(results.subdir.path)
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
+++ b/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
@@ -97,12 +97,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.output-dir.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir; then
-                cp $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir $(results.output-dir.path)
+            if [ -d $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir ]; then
+              tar -czvf $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir.tar.gz $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir
+              ARTIFACT_SIZE=`wc -c $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.output-dir.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir.tar.gz > $(results.output-dir.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.output-dir.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir; then
+                  cp $(workspaces.produce-dir-with-files-python-op.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/output_dir $(results.output-dir.path)
+                fi
               fi
             fi
           onError: continue
@@ -168,12 +178,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.subdir.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir; then
-                cp $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir $(results.subdir.path)
+            if [ -d $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir ]; then
+              tar -czvf $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir.tar.gz $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir
+              ARTIFACT_SIZE=`wc -c $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.subdir.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir.tar.gz > $(results.subdir.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.subdir.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir; then
+                  cp $(workspaces.get-subdirectory.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Subdir $(results.subdir.path)
+                fi
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
@@ -131,20 +131,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
               tar -czvf $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data
-              ARTIFACT_SIZE=`wc -c $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.data.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.data.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
-                  cp $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.data.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
+                tar -tzf $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data > $(results.data.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
+                cp $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
               fi
             fi
           onError: continue
@@ -226,20 +222,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
               tar -czvf $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data
-              ARTIFACT_SIZE=`wc -c $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.data.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.data.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
-                  cp $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.data.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
+                tar -tzf $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data > $(results.data.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
+                cp $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
               fi
             fi
           onError: continue
@@ -339,20 +331,16 @@ spec:
             TOTAL_SIZE=0
             if [ -d $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output ]; then
               tar -czvf $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output
-              ARTIFACT_SIZE=`wc -c $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.output.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz > $(results.output.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.output.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
-                  cp $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.output.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output ]; then
+                tar -tzf $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output > $(results.output.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
+                cp $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
@@ -138,7 +138,7 @@ spec:
             touch $(results.data.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
-                tar -tzf $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data > $(results.data.path)
+                tar -tzf $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
                 cp $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
               fi
@@ -229,7 +229,7 @@ spec:
             touch $(results.data.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
-                tar -tzf $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data > $(results.data.path)
+                tar -tzf $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
                 cp $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
               fi
@@ -338,7 +338,7 @@ spec:
             touch $(results.output.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output ]; then
-                tar -tzf $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output > $(results.output.path)
+                tar -tzf $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz > $(results.output.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
                 cp $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
               fi

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
@@ -127,12 +127,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.data.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
-                cp $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
+            if [ -d $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
+              tar -czvf $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data
+              ARTIFACT_SIZE=`wc -c $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.data.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.data.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
+                  cp $(workspaces.produce-anything.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
+                fi
               fi
             fi
           onError: continue
@@ -210,12 +220,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.data.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
-                cp $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
+            if [ -d $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data ]; then
+              tar -czvf $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data
+              ARTIFACT_SIZE=`wc -c $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.data.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data.tar.gz > $(results.data.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.data.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data; then
+                  cp $(workspaces.produce-something.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/data $(results.data.path)
+                fi
               fi
             fi
           onError: continue
@@ -311,12 +331,22 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.output.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
-                cp $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
+            if [ -d $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output ]; then
+              tar -czvf $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output
+              ARTIFACT_SIZE=`wc -c $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.output.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output.tar.gz > $(results.output.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.output.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output; then
+                  cp $(workspaces.produce-string.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/Output $(results.output.path)
+                fi
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/many_results.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results.yaml
@@ -119,38 +119,30 @@ spec:
             TOTAL_SIZE=0
             if [ -d /tekton/home/tep-results/param1 ]; then
               tar -czvf /tekton/home/tep-results/param1.tar.gz /tekton/home/tep-results/param1
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param1.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.param1.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf /tekton/home/tep-results/param1.tar.gz > $(results.param1.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param1 | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.param1.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param1; then
-                  cp /tekton/home/tep-results/param1 $(results.param1.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param1${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.param1.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d /tekton/home/tep-results/param1 ]; then
+                tar -tzf /tekton/home/tep-results/param1 > $(results.param1.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param1; then
+                cp /tekton/home/tep-results/param1 $(results.param1.path)
               fi
             fi
             if [ -d /tekton/home/tep-results/param3-b ]; then
               tar -czvf /tekton/home/tep-results/param3-b.tar.gz /tekton/home/tep-results/param3-b
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3-b.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.param3-b.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf /tekton/home/tep-results/param3-b.tar.gz > $(results.param3-b.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3-b | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.param3-b.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3-b; then
-                  cp /tekton/home/tep-results/param3-b $(results.param3-b.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3-b${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.param3-b.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d /tekton/home/tep-results/param3-b ]; then
+                tar -tzf /tekton/home/tep-results/param3-b > $(results.param3-b.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3-b; then
+                cp /tekton/home/tep-results/param3-b $(results.param3-b.path)
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/many_results.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results.yaml
@@ -126,7 +126,7 @@ spec:
             touch $(results.param1.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d /tekton/home/tep-results/param1 ]; then
-                tar -tzf /tekton/home/tep-results/param1 > $(results.param1.path)
+                tar -tzf /tekton/home/tep-results/param1.tar.gz > $(results.param1.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param1; then
                 cp /tekton/home/tep-results/param1 $(results.param1.path)
               fi
@@ -140,7 +140,7 @@ spec:
             touch $(results.param3-b.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d /tekton/home/tep-results/param3-b ]; then
-                tar -tzf /tekton/home/tep-results/param3-b > $(results.param3-b.path)
+                tar -tzf /tekton/home/tep-results/param3-b.tar.gz > $(results.param3-b.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3-b; then
                 cp /tekton/home/tep-results/param3-b $(results.param3-b.path)
               fi

--- a/sdk/python/tests/compiler/testdata/many_results.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results.yaml
@@ -115,20 +115,40 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param1 | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.param1.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param1; then
-                cp /tekton/home/tep-results/param1 $(results.param1.path)
+            if [ -d /tekton/home/tep-results/param1 ]; then
+              tar -czvf /tekton/home/tep-results/param1.tar.gz /tekton/home/tep-results/param1
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param1.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.param1.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf /tekton/home/tep-results/param1.tar.gz > $(results.param1.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param1 | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.param1.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param1; then
+                  cp /tekton/home/tep-results/param1 $(results.param1.path)
+                fi
               fi
             fi
-            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3-b | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.param3-b.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3-b; then
-                cp /tekton/home/tep-results/param3-b $(results.param3-b.path)
+            if [ -d /tekton/home/tep-results/param3-b ]; then
+              tar -czvf /tekton/home/tep-results/param3-b.tar.gz /tekton/home/tep-results/param3-b
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3-b.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.param3-b.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf /tekton/home/tep-results/param3-b.tar.gz > $(results.param3-b.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3-b | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.param3-b.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3-b; then
+                  cp /tekton/home/tep-results/param3-b $(results.param3-b.path)
+                fi
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
@@ -119,56 +119,44 @@ spec:
             TOTAL_SIZE=0
             if [ -d /tekton/home/tep-results/param2 ]; then
               tar -czvf /tekton/home/tep-results/param2.tar.gz /tekton/home/tep-results/param2
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param2.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.param2.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf /tekton/home/tep-results/param2.tar.gz > $(results.param2.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param2 | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.param2.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param2; then
-                  cp /tekton/home/tep-results/param2 $(results.param2.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param2${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.param2.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d /tekton/home/tep-results/param2 ]; then
+                tar -tzf /tekton/home/tep-results/param2 > $(results.param2.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param2; then
+                cp /tekton/home/tep-results/param2 $(results.param2.path)
               fi
             fi
             if [ -d /tekton/home/tep-results/param3 ]; then
               tar -czvf /tekton/home/tep-results/param3.tar.gz /tekton/home/tep-results/param3
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.param3.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf /tekton/home/tep-results/param3.tar.gz > $(results.param3.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3 | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.param3.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3; then
-                  cp /tekton/home/tep-results/param3 $(results.param3.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.param3.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d /tekton/home/tep-results/param3 ]; then
+                tar -tzf /tekton/home/tep-results/param3 > $(results.param3.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3; then
+                cp /tekton/home/tep-results/param3 $(results.param3.path)
               fi
             fi
             if [ -d /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper ]; then
               tar -czvf /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.tar.gz /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.tar.gz | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                tar -tzf /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.tar.gz > $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
-              fi
-            else
-              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper | awk '{print $1}'`
-              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-              touch $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
-              if [[ $TOTAL_SIZE -lt 3072 ]]; then
-                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper; then
-                  cp /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
-                fi
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper ]; then
+                tar -tzf /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper > $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper; then
+                cp /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
               fi
             fi
           onError: continue

--- a/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
@@ -126,7 +126,7 @@ spec:
             touch $(results.param2.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d /tekton/home/tep-results/param2 ]; then
-                tar -tzf /tekton/home/tep-results/param2 > $(results.param2.path)
+                tar -tzf /tekton/home/tep-results/param2.tar.gz > $(results.param2.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param2; then
                 cp /tekton/home/tep-results/param2 $(results.param2.path)
               fi
@@ -140,7 +140,7 @@ spec:
             touch $(results.param3.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d /tekton/home/tep-results/param3 ]; then
-                tar -tzf /tekton/home/tep-results/param3 > $(results.param3.path)
+                tar -tzf /tekton/home/tep-results/param3.tar.gz > $(results.param3.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3; then
                 cp /tekton/home/tep-results/param3 $(results.param3.path)
               fi
@@ -154,7 +154,7 @@ spec:
             touch $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
             if [[ $TOTAL_SIZE -lt 3072 ]]; then
               if [ -d /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper ]; then
-                tar -tzf /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper > $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
+                tar -tzf /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.tar.gz > $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
               elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper; then
                 cp /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
               fi

--- a/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
@@ -115,28 +115,58 @@ spec:
             #!/bin/sh
             set -exo pipefail
             TOTAL_SIZE=0
-            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param2 | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.param2.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param2; then
-                cp /tekton/home/tep-results/param2 $(results.param2.path)
+            if [ -d /tekton/home/tep-results/param2 ]; then
+              tar -czvf /tekton/home/tep-results/param2.tar.gz /tekton/home/tep-results/param2
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param2.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.param2.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf /tekton/home/tep-results/param2.tar.gz > $(results.param2.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param2 | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.param2.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param2; then
+                  cp /tekton/home/tep-results/param2 $(results.param2.path)
+                fi
               fi
             fi
-            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3 | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.param3.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3; then
-                cp /tekton/home/tep-results/param3 $(results.param3.path)
+            if [ -d /tekton/home/tep-results/param3 ]; then
+              tar -czvf /tekton/home/tep-results/param3.tar.gz /tekton/home/tep-results/param3
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.param3.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf /tekton/home/tep-results/param3.tar.gz > $(results.param3.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/param3 | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.param3.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/param3; then
+                  cp /tekton/home/tep-results/param3 $(results.param3.path)
+                fi
               fi
             fi
-            ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper | awk '{print $1}'`
-            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
-            touch $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
-            if [[ $TOTAL_SIZE -lt 3072 ]]; then
-              if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper; then
-                cp /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
+            if [ -d /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper ]; then
+              tar -czvf /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.tar.gz /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.tar.gz | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                tar -tzf /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.tar.gz > $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
+              fi
+            else
+              ARTIFACT_SIZE=`wc -c /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper | awk '{print $1}'`
+              TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+              touch $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
+              if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                if ! awk "/[^[:print:]]/{f=1} END{exit !f}" /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper; then
+                  cp /tekton/home/tep-results/superlongnamesuperlongnamesuperlongnamesuperlongnamesuper $(results.superlongnamesuperlongnamesuperlongnamesuperlongnamesuper.path)
+                fi
               fi
             fi
           onError: continue


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #996 

**Description of your changes:**

1. To add support to directories in step-copy-artifacts script, I added check [ -d "$2" ] to allow directories to be transmitted as artifacts

2. To add support to directories in step-copy-results-artifacts script, I check if the provided result (src) is a directory; if so, create a tar.gz archive and compute the ARTIFACT_SIZE on {src}.tar.gz.
Moreover, print on {dst} file the list of files in {src}.tar.gz (namely, the result of `tar -tzf {src}.tar.gz`) instead of copying directly {src} into {dst}

**Environment tested:**

* Python Version (use `python --version`): Python 3.10.5
* Tekton Version (use `tkn version`): kfp-tekton v1.2.1
* Kubernetes Version (use `kubectl version`): client v1.23.6, server v1.24.0
* OS (e.g. from `/etc/os-release`): macOS Monterey v12.4
