### PR TITLE
optimize(sdk): Move common task labels to pipeline labels to reduce yaml size

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -579,7 +579,7 @@ def _op_to_template(op: BaseOp,
         try:
             result_size_map = json.loads(result_size_map)
         except ValueError:
-            raise("tekton-result-sizes annotation is not a valid JSON")
+            raise ("tekton-result-sizes annotation is not a valid JSON")
         # Normalize estimated result size keys.
         result_size_map = {sanitize_k8s_name(key, allow_capital_underscore=True): value
                            for key, value in result_size_map.items()}
@@ -596,7 +596,7 @@ def _op_to_template(op: BaseOp,
             try:
                 value = int(value)
             except ValueError:
-                raise("Estimated value for result %s is %s, but it needs to be an integer." % (key, value))
+                raise ("Estimated value for result %s is %s, but it needs to be an integer." % (key, value))
             if key in op_result_names:
                 packed_index = -1
                 # Look for bin that can fit the result value

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -1014,7 +1014,7 @@ class TektonCompiler(Compiler):
 
             # Only one of --taskRef and --taskSpec allowed.
             if custom_task_args.get('taskRef', '') and custom_task_args.get('taskSpec', ''):
-              raise("Custom task invalid configuration %s, Only one of --taskRef and --taskSpec allowed." % custom_task_args)
+              raise ("Custom task invalid configuration %s, Only one of --taskRef and --taskSpec allowed." % custom_task_args)
             if custom_task_args.get('taskRef', ''):
               try:
                 custom_task_cr = {
@@ -1033,7 +1033,7 @@ class TektonCompiler(Compiler):
                 if custom_task_cr:
                   self.custom_task_crs.append(custom_task_cr)
               except ValueError:
-                raise("Custom task ref %s is not a valid Python Dictionary" % custom_task_args['taskRef'])
+                raise ("Custom task ref %s is not a valid Python Dictionary" % custom_task_args['taskRef'])
             # Setting --taskRef flag indicates, that spec be inlined.
             if custom_task_args.get('taskSpec', ''):
               try:
@@ -1048,7 +1048,7 @@ class TektonCompiler(Compiler):
                   }
                 }
               except ValueError:
-                raise("Custom task spec %s is not a valid Python Dictionary" % custom_task_args['taskSpec'])
+                raise ("Custom task spec %s is not a valid Python Dictionary" % custom_task_args['taskSpec'])
             # Pop custom task artifacts since we have no control of how
             # custom task controller is handling the container/task execution.
             self.artifact_items.pop(template['metadata']['name'], None)

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -150,6 +150,8 @@ class TektonCompiler(Compiler):
 
   def _set_pipeline_conf(self, tekton_pipeline_conf: TektonPipelineConf):
     self.pipeline_labels = tekton_pipeline_conf.pipeline_labels
+    self.pipeline_labels['pipelines.kubeflow.org/pipelinename'] = ''
+    self.pipeline_labels['pipelines.kubeflow.org/generation'] = ''
     self.pipeline_annotations = tekton_pipeline_conf.pipeline_annotations
     self.tekton_inline_spec = tekton_pipeline_conf.tekton_inline_spec
     self.resource_in_separate_yaml = tekton_pipeline_conf.resource_in_separate_yaml
@@ -1055,8 +1057,6 @@ class TektonCompiler(Compiler):
         if task_ref.get('taskSpec', ''):
           task_ref['taskSpec']['metadata'] = task_ref['taskSpec'].get('metadata', {})
           task_labels = template['metadata'].get('labels', {})
-          task_labels['pipelines.kubeflow.org/pipelinename'] = task_labels.get('pipelines.kubeflow.org/pipelinename', '')
-          task_labels['pipelines.kubeflow.org/generation'] = task_labels.get('pipelines.kubeflow.org/generation', '')
           cache_default = self.pipeline_labels.get('pipelines.kubeflow.org/cache_enabled', 'true')
           task_labels['pipelines.kubeflow.org/cache_enabled'] = task_labels.get('pipelines.kubeflow.org/cache_enabled', cache_default)
 

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -1855,8 +1855,6 @@ class TektonCompiler(Compiler):
       if 'taskSpec' in workflow_tasks[j]:
         workflow_tasks[j]['taskSpec']['metadata'] = workflow_tasks[j]['taskSpec'].get('metadata', {})
         task_labels = workflow_tasks[j]['taskSpec']['metadata'].get('labels', {})
-        task_labels['pipelines.kubeflow.org/pipelinename'] = task_labels.get('pipelines.kubeflow.org/pipelinename', '')
-        task_labels['pipelines.kubeflow.org/generation'] = task_labels.get('pipelines.kubeflow.org/generation', '')
         cache_default = self.pipeline_labels.get('pipelines.kubeflow.org/cache_enabled', 'true')
         task_labels['pipelines.kubeflow.org/cache_enabled'] = task_labels.get('pipelines.kubeflow.org/cache_enabled', cache_default)
         workflow_tasks[j]['taskSpec']['metadata']['labels'] = task_labels

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with affinity",
       "name": "affinity"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -44,8 +47,6 @@ spec:
             runAsUser: 0
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/any_sequencer.yaml
+++ b/sdk/python/tests/compiler/testdata/any_sequencer.yaml
@@ -32,6 +32,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Any Sequencer Component
       Demo", "name": "any-sequencer"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -46,8 +49,6 @@ spec:
           image: alpine:latest
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "sleepComponent",
@@ -65,8 +66,6 @@ spec:
           image: alpine:latest
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "sleepComponent",
@@ -84,8 +83,6 @@ spec:
           image: alpine:latest
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "sleepComponent",
@@ -150,8 +147,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Flip coin", "outputs":
@@ -171,8 +166,6 @@ spec:
           image: alpine:latest
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "sleepComponent",
@@ -205,8 +198,6 @@ spec:
           description: /tmp/outputs/status/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "any_test", "outputs":

--- a/sdk/python/tests/compiler/testdata/any_sequencer_looped.yaml
+++ b/sdk/python/tests/compiler/testdata/any_sequencer_looped.yaml
@@ -40,6 +40,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[\"a\", \"b\",
       \"c\"]", "name": "param", "optional": true, "type": "JsonArray"}], "name": "any-sequencer-looped"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param
@@ -68,9 +71,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-00", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -96,9 +99,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-01", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -127,9 +130,9 @@ spec:
           description: /tmp/outputs/status/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "any-seq-0", "outputs":
               [{"description": "The output file to create the status", "name": "status"}],
@@ -176,9 +179,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-10",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -204,9 +207,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-11",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -235,9 +238,9 @@ spec:
                   description: /tmp/outputs/status/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "any-seq-1",
                       "outputs": [{"description": "The output file to create the status",

--- a/sdk/python/tests/compiler/testdata/any_sequencer_looped.yaml
+++ b/sdk/python/tests/compiler/testdata/any_sequencer_looped.yaml
@@ -72,8 +72,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-00", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -100,8 +98,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-01", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -131,8 +127,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "any-seq-0", "outputs":
               [{"description": "The output file to create the status", "name": "status"}],
@@ -180,8 +174,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-10",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -208,8 +200,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-11",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -239,8 +229,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "any-seq-1",
                       "outputs": [{"description": "The output file to create the status",
@@ -260,7 +248,5 @@ spec:
           iterateParam: param-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/any_sequencer_looped_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/any_sequencer_looped_noninlined.yaml
@@ -49,8 +49,7 @@ metadata:
       paramter.\", \"name\": \"output_value\", \"type\": \"String\"}], \"version\":
       \"print-10@sha256=ea7fa8edfd92cf64a15f8464292143a4e0d5f34898368bfd63618884decf3be1\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
+      "true"}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
       "output-value", "type": "string"}], "steps": [{"command": ["sh", "-c", "set
       -e\necho $0 > $1\n", "print-10", "$(results.output-value.path)"], "image": "alpine:3.6",
       "name": "main"}]}, "timeout": "525600m"}, {"name": "print-11", "taskSpec": {"metadata":
@@ -58,8 +57,7 @@ metadata:
       \"print-11\", \"outputs\": [{\"description\": \"Represents an output paramter.\",
       \"name\": \"output_value\", \"type\": \"String\"}], \"version\": \"print-11@sha256=3b423bb0ced0bc21fb9157ce814a38c94d3e72718a33cfa8b4ef4f75abe725bd\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
+      "true"}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
       "output-value", "type": "string"}], "steps": [{"command": ["sh", "-c", "set
       -e\necho $0 > $1\n", "print-11", "$(results.output-value.path)"], "image": "alpine:3.6",
       "name": "main"}]}, "timeout": "525600m"}, {"name": "any-seq-1", "params": [{"name":
@@ -69,13 +67,15 @@ metadata:
       \"outputs\": [{\"description\": \"The output file to create the status\", \"name\":
       \"status\"}], \"version\": \"any-seq-1@sha256=75c65b3423dd61b79c35122746a1f16d67a98ab7b570daa36de2d310e1e57c22\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "pipelineRun-name", "type": "string"}, {"name": "pipelineRun-namespace",
-      "type": "string"}], "results": [{"description": "/tmp/outputs/status/data",
+      "true"}}, "params": [{"name": "pipelineRun-name", "type": "string"}, {"name":
+      "pipelineRun-namespace", "type": "string"}], "results": [{"description": "/tmp/outputs/status/data",
       "name": "status", "type": "string"}], "steps": [{"args": ["--namespace", "$(params.pipelineRun-namespace)",
       "--prName", "$(params.pipelineRun-name)", "--taskList", "print-10,print-11",
       "--statusPath", "$(results.status.path)"], "command": ["any-task"], "image":
       "dspipelines/any-sequencer:latest", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param
@@ -104,8 +104,6 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-00", "outputs":
@@ -132,8 +130,6 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-01", "outputs":
@@ -163,8 +159,6 @@ spec:
           description: /tmp/outputs/status/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "any-seq-0", "outputs":

--- a/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
@@ -31,6 +31,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Add labels to identify
       outputs as artifacts.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url1", "optional": true, "type": "String"}], "name": "artifact-out-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: url1
@@ -109,8 +112,6 @@ spec:
           type: string
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             artifact_outputs: '["data"]'

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
@@ -41,6 +41,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "Artifact passing pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -110,8 +113,6 @@ spec:
           type: string
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Producer", "outputs":
@@ -199,8 +200,6 @@ spec:
           type: string
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Processor", "outputs":
@@ -243,8 +242,6 @@ spec:
         - name: processor-trname
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consumer", "outputs":
@@ -337,8 +334,6 @@ spec:
           emptyDir: {}
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Metadata and

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -72,8 +72,6 @@ spec:
           description: /tmp/outputs/word/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "frequent-word",
@@ -107,8 +105,6 @@ spec:
           value: default_output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "save-message",
@@ -127,8 +123,6 @@ spec:
           image: python:3.6-jessie
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "exit-handler",

--- a/sdk/python/tests/compiler/testdata/big_data_multi_volumes_1.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_multi_volumes_1.yaml
@@ -30,6 +30,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "big-data"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -59,8 +62,6 @@ spec:
             secretName: secret-sm
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-sm", "outputs":
@@ -104,8 +105,6 @@ spec:
           emptyDir: {}
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-big", "outputs":

--- a/sdk/python/tests/compiler/testdata/big_data_multi_volumes_2.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_multi_volumes_2.yaml
@@ -30,6 +30,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "big-data"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -61,8 +64,6 @@ spec:
             secretName: secret-sm
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-sm", "outputs":
@@ -111,8 +112,6 @@ spec:
           emptyDir: {}
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-big", "outputs":

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -141,8 +141,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Repeat line",
               "outputs": [{"name": "output_text", "type": "String"}], "version": "Repeat
@@ -285,8 +283,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Split text lines",
               "outputs": [{"name": "odd_lines", "type": "String"}, {"name": "even_lines",
@@ -348,8 +344,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print text",
               "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -405,8 +399,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print text",
               "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -506,8 +498,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Write numbers",
               "outputs": [{"name": "numbers", "type": "String"}], "version": "Write
@@ -562,8 +552,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print text",
               "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -686,8 +674,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Sum numbers",
               "outputs": [{"name": "Output", "type": "Integer"}], "version": "Sum
@@ -744,8 +730,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print text",
               "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -817,8 +801,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Gen params",
               "outputs": [{"name": "Output", "type": "Integer"}], "version": "Gen
@@ -858,8 +840,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print params",
               "outputs": [], "version": "Print params@sha256=3fb942e817debe20ad7b6a10ff15f184d01b788e9908d665b20ecc89e7bb48da"}'
@@ -953,8 +933,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "Print text", "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -981,8 +959,6 @@ spec:
                             storage: 2Gi
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
             workspaces:
             - name: big-data-passing
@@ -999,8 +975,6 @@ spec:
                     storage: 2Gi
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
     workspaces:
     - name: big-data-passing

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -48,6 +48,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "Big data passing"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -137,9 +140,9 @@ spec:
           type: string
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Repeat line",
               "outputs": [{"name": "output_text", "type": "String"}], "version": "Repeat
@@ -281,9 +284,9 @@ spec:
           type: string
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Split text lines",
               "outputs": [{"name": "odd_lines", "type": "String"}, {"name": "even_lines",
@@ -344,9 +347,9 @@ spec:
         - name: split-text-lines-trname
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print text",
               "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -401,9 +404,9 @@ spec:
         - name: split-text-lines-trname
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print text",
               "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -502,9 +505,9 @@ spec:
           type: string
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Write numbers",
               "outputs": [{"name": "numbers", "type": "String"}], "version": "Write
@@ -558,9 +561,9 @@ spec:
         - name: write-numbers-trname
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print text",
               "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -682,9 +685,9 @@ spec:
           type: string
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Sum numbers",
               "outputs": [{"name": "Output", "type": "Integer"}], "version": "Sum
@@ -740,9 +743,9 @@ spec:
         - name: sum-numbers-trname
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print text",
               "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'
@@ -813,9 +816,9 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Gen params",
               "outputs": [{"name": "Output", "type": "Integer"}], "version": "Gen
@@ -854,9 +857,9 @@ spec:
         - name: gen-params-Output
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print params",
               "outputs": [], "version": "Print params@sha256=3fb942e817debe20ad7b6a10ff15f184d01b788e9908d665b20ecc89e7bb48da"}'
@@ -949,9 +952,9 @@ spec:
                           type: string
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "Print text", "outputs": [], "version": "Print text@sha256=7840827b663006501280bd895395a3ff9cf8fe2d9b1c9ca8c15f57c17a187318"}'

--- a/sdk/python/tests/compiler/testdata/break_task_pipeline.yaml
+++ b/sdk/python/tests/compiler/testdata/break_task_pipeline.yaml
@@ -83,8 +83,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=8ccab3a28a39a406554d964865f2ccb0aed854a43b6de827f613eff2bccd6f8f"}'
@@ -114,7 +112,5 @@ spec:
           iterateParam: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/break_task_pipeline.yaml
+++ b/sdk/python/tests/compiler/testdata/break_task_pipeline.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "param",
       "optional": true, "type": "Integer"}], "name": "pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param
@@ -79,9 +82,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=8ccab3a28a39a406554d964865f2ccb0aed854a43b6de827f613eff2bccd6f8f"}'

--- a/sdk/python/tests/compiler/testdata/break_task_pipeline_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/break_task_pipeline_noninlined.yaml
@@ -36,9 +36,8 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=8ccab3a28a39a406554d964865f2ccb0aed854a43b6de827f613eff2bccd6f8f\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name": "param",
-      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name":
+      "param", "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
       "$(inputs.params.loop-item-param-1)", "$(inputs.params.param)"], "command":
       ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
       "525600m"}, {"name": "condition-cel", "params": [{"name": "outcome", "value":
@@ -47,6 +46,9 @@ metadata:
       "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "BreakTask",
       "name": "pipelineloop-break-operation"}, "timeout": "525600m", "when": [{"input":
       "$(tasks.condition-cel.results.outcome)", "operator": "in", "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param

--- a/sdk/python/tests/compiler/testdata/cache.yaml
+++ b/sdk/python/tests/compiler/testdata/cache.yaml
@@ -31,6 +31,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Example of caching", "name":
       "cache"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -50,8 +53,6 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "cache-enabled",
@@ -75,8 +76,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "false"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "cache-disabled",
               "outputs": [{"name": "out", "type": "String"}], "version": "cache-disabled@sha256=c6b73e13a48ba7dfacb66ebd9987eda874087ace7615130da8180b2b46dd53c9"}'

--- a/sdk/python/tests/compiler/testdata/calc_pipeline.py
+++ b/sdk/python/tests/compiler/testdata/calc_pipeline.py
@@ -62,10 +62,10 @@ def my_divmod(dividend: float, divisor: float) -> NamedTuple('MyDivmodOutput', [
     metrics = {
       'metrics': [{
           'name': 'quotient',
-          'numberValue':  float(quotient),
+          'numberValue': float(quotient),
         }, {
           'name': 'remainder',
-          'numberValue':  float(remainder),
+          'numberValue': float(remainder),
         }]}
 
     from collections import namedtuple

--- a/sdk/python/tests/compiler/testdata/compose.yaml
+++ b/sdk/python/tests/compiler/testdata/compose.yaml
@@ -72,8 +72,6 @@ spec:
           description: /tmp/outputs/downloaded/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "download", "outputs":
@@ -104,8 +102,6 @@ spec:
           description: /tmp/outputs/word/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "get-frequent",
@@ -135,8 +131,6 @@ spec:
         - name: outputpath
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "save", "outputs":

--- a/sdk/python/tests/compiler/testdata/cond_recur.yaml
+++ b/sdk/python/tests/compiler/testdata/cond_recur.yaml
@@ -51,6 +51,9 @@ metadata:
       "$(params.condition-cel-outcome)"}, {"name": "iter_num", "value": "$(tasks.condition-cel-2.results.outcome)"},
       {"name": "just_one_iteration", "value": ["1"]}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "name": "condition-and-recur-graph-recur-2"}}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: iter_num

--- a/sdk/python/tests/compiler/testdata/cond_recur.yaml
+++ b/sdk/python/tests/compiler/testdata/cond_recur.yaml
@@ -42,10 +42,9 @@ metadata:
       \"print-iter\", \"outputs\": [{\"name\": \"stdout\", \"type\": \"String\"}],
       \"version\": \"print-iter@sha256=3cf57010e9ac86e617167ddc4190e3656853a26ee3aace62fea023f62c0e60be\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-2-outcome", "type": "string"}], "results":
-      [{"description": "/tmp/outputs/stdout/data", "name": "stdout", "type": "string"}],
-      "steps": [{"command": ["echo", "Iter: $(inputs.params.condition-cel-2-outcome)",
+      "true"}}, "params": [{"name": "condition-cel-2-outcome", "type": "string"}],
+      "results": [{"description": "/tmp/outputs/stdout/data", "name": "stdout", "type":
+      "string"}], "steps": [{"command": ["echo", "Iter: $(inputs.params.condition-cel-2-outcome)",
       ">", "$(results.stdout.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
       "525600m"}, {"name": "recur", "params": [{"name": "condition-cel-outcome", "value":
       "$(params.condition-cel-outcome)"}, {"name": "iter_num", "value": "$(tasks.condition-cel-2.results.outcome)"},

--- a/sdk/python/tests/compiler/testdata/cond_recur_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/cond_recur_noninlined.yaml
@@ -42,16 +42,18 @@ metadata:
       \"print-iter\", \"outputs\": [{\"name\": \"stdout\", \"type\": \"String\"}],
       \"version\": \"print-iter@sha256=3cf57010e9ac86e617167ddc4190e3656853a26ee3aace62fea023f62c0e60be\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-2-outcome", "type": "string"}], "results":
-      [{"description": "/tmp/outputs/stdout/data", "name": "stdout", "type": "string"}],
-      "steps": [{"command": ["echo", "Iter: $(inputs.params.condition-cel-2-outcome)",
+      "true"}}, "params": [{"name": "condition-cel-2-outcome", "type": "string"}],
+      "results": [{"description": "/tmp/outputs/stdout/data", "name": "stdout", "type":
+      "string"}], "steps": [{"command": ["echo", "Iter: $(inputs.params.condition-cel-2-outcome)",
       ">", "$(results.stdout.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
       "525600m"}, {"name": "recur", "params": [{"name": "just_one_iteration", "value":
       ["1"]}, {"name": "iter_num", "value": "$(tasks.condition-cel-2.results.outcome)"},
       {"name": "condition-cel-outcome", "value": "$(params.condition-cel-outcome)"}],
       "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop",
       "name": "condition-and-recur-graph-recur-2"}}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: iter_num

--- a/sdk/python/tests/compiler/testdata/condition.yaml
+++ b/sdk/python/tests/compiler/testdata/condition.yaml
@@ -37,6 +37,9 @@ metadata:
       "type": "String"}, {"default": "tails", "name": "forced_result2", "optional":
       true, "type": "String"}, {"default": "heads", "name": "forced_result3", "optional":
       true, "type": "String"}], "name": "flip-coin-example-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: forced_result1
@@ -77,8 +80,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip", "outputs":
@@ -108,8 +109,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip", "outputs":
@@ -139,8 +138,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip", "outputs":
@@ -167,8 +164,6 @@ spec:
         - name: flip-3-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
@@ -195,8 +190,6 @@ spec:
         - name: flip-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/condition_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/condition_custom_task.yaml
@@ -39,6 +39,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use dsl.Condition().",
       "name": "conditional-execution-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -59,8 +62,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
@@ -95,8 +96,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "generate-random-number",
@@ -137,8 +136,6 @@ spec:
         - name: generate-random-number-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
@@ -165,8 +162,6 @@ spec:
         - name: generate-random-number-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
@@ -197,8 +192,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "generate-random-number",
@@ -239,8 +232,6 @@ spec:
         - name: generate-random-number-2-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
@@ -267,8 +258,6 @@ spec:
         - name: generate-random-number-2-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/condition_depend.yaml
+++ b/sdk/python/tests/compiler/testdata/condition_depend.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "param",
       "optional": true, "type": "Integer"}], "name": "pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param
@@ -92,8 +95,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "False", "outputs":
@@ -121,8 +122,6 @@ spec:
         - name: param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
@@ -155,8 +154,6 @@ spec:
         - name: param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
@@ -191,8 +188,6 @@ spec:
         - name: param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",

--- a/sdk/python/tests/compiler/testdata/condition_dependency.yaml
+++ b/sdk/python/tests/compiler/testdata/condition_dependency.yaml
@@ -35,6 +35,9 @@ metadata:
       "inputs": [{"default": "heads", "name": "forced_result1", "optional": true,
       "type": "String"}, {"default": "tails", "name": "forced_result2", "optional":
       true, "type": "String"}], "name": "flip-coin-with-dependency"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: forced_result1
@@ -71,8 +74,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip", "outputs":
@@ -102,8 +103,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip", "outputs":
@@ -130,8 +129,6 @@ spec:
         - name: flip-2-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
@@ -158,8 +155,6 @@ spec:
         - name: flip-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
@@ -181,8 +176,6 @@ spec:
           image: alpine:3.6
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/conditions_and_loops.yaml
+++ b/sdk/python/tests/compiler/testdata/conditions_and_loops.yaml
@@ -126,8 +126,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce numbers",
               "outputs": [{"name": "Output", "type": "JsonArray"}], "version": "Produce
@@ -223,8 +221,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Add numbers",
                       "outputs": [{"name": "Output", "type": "Integer"}], "version":
@@ -298,8 +294,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Print
                       number", "outputs": [{"name": "Output", "type": "Integer"}],
@@ -330,8 +324,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Notify
                       success", "outputs": [], "version": "Notify success@sha256=b32dbdd3dc06d69ac8358045345f65fc0610ccdf6e9927c447deb4634016028a"}'
@@ -366,8 +358,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Notify
                       failure", "outputs": [], "version": "Notify failure@sha256=fa2f0190a19f2fa88c34a3805a4517a3f5d697e30491bec02fb3cf9504d909d7"}'
@@ -424,8 +414,6 @@ spec:
                   image: python:alpine3.6
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
             - name: condition-3
               params:
@@ -473,13 +461,9 @@ spec:
                   image: python:alpine3.6
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterateParam: produce-numbers-Output-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/conditions_and_loops.yaml
+++ b/sdk/python/tests/compiler/testdata/conditions_and_loops.yaml
@@ -35,6 +35,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "3", "name": "n",
       "optional": true, "type": "Integer"}, {"default": "20", "name": "threshold",
       "optional": true, "type": "Integer"}], "name": "conditions-and-loops"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: "n"
@@ -122,9 +125,9 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce numbers",
               "outputs": [{"name": "Output", "type": "JsonArray"}], "version": "Produce
@@ -219,9 +222,9 @@ spec:
                   description: /tmp/outputs/Output/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Add numbers",
                       "outputs": [{"name": "Output", "type": "Integer"}], "version":
@@ -294,9 +297,9 @@ spec:
                   description: /tmp/outputs/Output/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Print
                       number", "outputs": [{"name": "Output", "type": "Integer"}],
@@ -326,9 +329,9 @@ spec:
                   image: python:3.7
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Notify
                       success", "outputs": [], "version": "Notify success@sha256=b32dbdd3dc06d69ac8358045345f65fc0610ccdf6e9927c447deb4634016028a"}'
@@ -362,9 +365,9 @@ spec:
                   image: python:3.7
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Notify
                       failure", "outputs": [], "version": "Notify failure@sha256=fa2f0190a19f2fa88c34a3805a4517a3f5d697e30491bec02fb3cf9504d909d7"}'

--- a/sdk/python/tests/compiler/testdata/conditions_and_loops_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/conditions_and_loops_noninlined.yaml
@@ -45,8 +45,7 @@ metadata:
       "{\"name\": \"Add numbers\", \"outputs\": [{\"name\": \"Output\", \"type\":
       \"Integer\"}], \"version\": \"Add numbers@sha256=4a4bea3d4b7966f0ce3cdef5ad4d997a283ef6a895959791e037cf391732bb04\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-numbers-Output-loop-item", "type": "string"}],
+      "true"}}, "params": [{"name": "produce-numbers-Output-loop-item", "type": "string"}],
       "results": [{"description": "/tmp/outputs/Output/data", "name": "Output", "type":
       "string"}], "steps": [{"args": ["--a", "$(inputs.params.produce-numbers-Output-loop-item)",
       "--b", "10", "----output-paths", "$(results.Output.path)"], "command": ["sh",
@@ -70,8 +69,7 @@ metadata:
       "{\"name\": \"Print number\", \"outputs\": [{\"name\": \"Output\", \"type\":
       \"Integer\"}], \"version\": \"Print number@sha256=7ad81f52d1b478fd168c0234b16a496672bdfc43da71a71fcdc5d688791f04cf\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "add-numbers-Output", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "add-numbers-Output", "type": "string"}], "results":
       [{"description": "/tmp/outputs/Output/data", "name": "Output", "type": "string"}],
       "steps": [{"args": ["--a", "$(inputs.params.add-numbers-Output)", "----output-paths",
       "$(results.Output.path)"], "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf
@@ -92,29 +90,29 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"Notify success\", \"outputs\": [], \"version\": \"Notify success@sha256=b32dbdd3dc06d69ac8358045345f65fc0610ccdf6e9927c447deb4634016028a\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "steps": [{"command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\"
-      \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n", "def notify_success():\n    print(''SUCCESS!'')\n\nimport
-      argparse\n_parser = argparse.ArgumentParser(prog=''Notify success'', description='''')\n_parsed_args
-      = vars(_parser.parse_args())\n\n_outputs = notify_success(**_parsed_args)\n"],
-      "image": "python:3.7", "name": "main"}]}, "timeout": "525600m", "when": [{"input":
-      "$(tasks.condition-2.results.outcome)", "operator": "in", "values": ["true"]}]},
-      {"name": "notify-failure", "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
+      "true"}}, "steps": [{"command": ["sh", "-ec", "program_path=$(mktemp)\nprintf
+      \"%s\" \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n", "def
+      notify_success():\n    print(''SUCCESS!'')\n\nimport argparse\n_parser = argparse.ArgumentParser(prog=''Notify
+      success'', description='''')\n_parsed_args = vars(_parser.parse_args())\n\n_outputs
+      = notify_success(**_parsed_args)\n"], "image": "python:3.7", "name": "main"}]},
+      "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
+      "operator": "in", "values": ["true"]}]}, {"name": "notify-failure", "taskSpec":
+      {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"Notify failure\", \"outputs\": [], \"version\": \"Notify failure@sha256=fa2f0190a19f2fa88c34a3805a4517a3f5d697e30491bec02fb3cf9504d909d7\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "steps": [{"command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\"
-      \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n", "def notify_failure():\n    print(''FAILED!'')\n\nimport
-      argparse\n_parser = argparse.ArgumentParser(prog=''Notify failure'', description='''')\n_parsed_args
-      = vars(_parser.parse_args())\n\n_outputs = notify_failure(**_parsed_args)\n"],
-      "image": "python:3.7", "name": "main"}]}, "timeout": "525600m", "when": [{"input":
-      "$(tasks.condition-3.results.outcome)", "operator": "in", "values": ["true"]}]},
-      {"name": "condition-2", "params": [{"name": "operand1", "value": "$(tasks.print-number.results.Output)"},
-      {"name": "operand2", "value": "$(params.threshold)"}, {"name": "operator", "value":
-      ">"}], "taskSpec": {"params": [{"name": "operand1", "type": "string"}, {"name":
-      "operand2", "type": "string"}, {"name": "operator", "type": "string"}], "results":
-      [{"description": "Conditional task outcome", "name": "outcome", "type": "string"}],
-      "steps": [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
+      "true"}}, "steps": [{"command": ["sh", "-ec", "program_path=$(mktemp)\nprintf
+      \"%s\" \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n", "def
+      notify_failure():\n    print(''FAILED!'')\n\nimport argparse\n_parser = argparse.ArgumentParser(prog=''Notify
+      failure'', description='''')\n_parsed_args = vars(_parser.parse_args())\n\n_outputs
+      = notify_failure(**_parsed_args)\n"], "image": "python:3.7", "name": "main"}]},
+      "timeout": "525600m", "when": [{"input": "$(tasks.condition-3.results.outcome)",
+      "operator": "in", "values": ["true"]}]}, {"name": "condition-2", "params": [{"name":
+      "operand1", "value": "$(tasks.print-number.results.Output)"}, {"name": "operand2",
+      "value": "$(params.threshold)"}, {"name": "operator", "value": ">"}], "taskSpec":
+      {"params": [{"name": "operand1", "type": "string"}, {"name": "operand2", "type":
+      "string"}, {"name": "operator", "type": "string"}], "results": [{"description":
+      "Conditional task outcome", "name": "outcome", "type": "string"}], "steps":
+      [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
       if (input1 $(inputs.params.operator) input2) else \"false\"\nf = open(\"/tekton/results/outcome\",
       \"w\")\nf.write(outcome)\nf.close()\n", "$(inputs.params.operand1)", "$(inputs.params.operand2)"],
       "command": ["sh", "-ec", "program_path=$(mktemp); printf \"%s\" \"$0\" > \"$program_path\";  python3
@@ -129,6 +127,9 @@ metadata:
       \"w\")\nf.write(outcome)\nf.close()\n", "$(inputs.params.operand1)", "$(inputs.params.operand2)"],
       "command": ["sh", "-ec", "program_path=$(mktemp); printf \"%s\" \"$0\" > \"$program_path\";  python3
       -u \"$program_path\" \"$1\" \"$2\""], "image": "python:alpine3.6", "name": "main"}]}}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: "n"
@@ -216,8 +217,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce numbers",

--- a/sdk/python/tests/compiler/testdata/conditions_with_global_params.yaml
+++ b/sdk/python/tests/compiler/testdata/conditions_with_global_params.yaml
@@ -34,6 +34,9 @@ metadata:
       "optional": true, "type": "Integer"}, {"default": "10", "name": "threshold",
       "optional": true, "type": "Integer"}, {"default": "15", "name": "lower_bound",
       "optional": true, "type": "Integer"}], "name": "conditions-with-global-params"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: lower_bound
@@ -122,8 +125,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Add numbers",
@@ -196,8 +197,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print number",
@@ -228,8 +227,6 @@ spec:
           image: python:3.7
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Notify success",
@@ -264,8 +261,6 @@ spec:
           image: python:3.7
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Notify failure",

--- a/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
+++ b/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
@@ -39,6 +39,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "create-component-from-function"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -127,8 +130,6 @@ spec:
           type: string
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce dir with
@@ -208,8 +209,6 @@ spec:
           type: string
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Get subdirectory",
@@ -255,8 +254,6 @@ spec:
           description: /tmp/outputs/Items/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "List items",
@@ -305,8 +302,6 @@ spec:
           description: /tmp/outputs/Items/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "List items 2",

--- a/sdk/python/tests/compiler/testdata/custom_task_exit.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_exit.yaml
@@ -53,8 +53,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -88,8 +86,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     valid_container: "false"
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "cel",
@@ -102,8 +98,6 @@ spec:
             automountServiceAccountToken: "false"
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "false"
           annotations:
             ws-pipelines.ibm.com/pipeline-cache-enabled: "false"

--- a/sdk/python/tests/compiler/testdata/custom_task_exit.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_exit.yaml
@@ -27,6 +27,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "test pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -49,9 +52,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -84,9 +87,9 @@ spec:
                 spec: {}
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     valid_container: "false"
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "cel",

--- a/sdk/python/tests/compiler/testdata/custom_task_long_name.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_long_name.yaml
@@ -36,6 +36,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url1", "optional": true, "type": "String"}], "name": "some-very-long-name-with-lots-of-words-in-it-it-should-be-over-63-chars-long-in-order-to-observe-the-problem"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: url1
@@ -69,8 +72,6 @@ spec:
           description: /tmp/outputs/Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "GCS - DownloadGCS
@@ -94,8 +95,6 @@ spec:
         - name: gcs-downloadgcs-downloadgcs-downloadgcs-download-Data-_123Data-_123Data-_123Data-_123Data-_123Data-_123Dat
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "printprintprintprintprintprintprintprintprintprint",

--- a/sdk/python/tests/compiler/testdata/custom_task_output.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_output.yaml
@@ -32,6 +32,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "uppercase vs lowercase"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -74,8 +77,6 @@ spec:
           description: /tmp/outputs/stdout/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "artifact-printer-0",
@@ -103,8 +104,6 @@ spec:
           description: /tmp/outputs/stdout/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "artifact-printer-1",

--- a/sdk/python/tests/compiler/testdata/custom_task_params_ref.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_params_ref.yaml
@@ -29,6 +29,9 @@ metadata:
       "foo", "optional": true, "type": "String"}, {"default": "buzz", "name": "bar",
       "optional": true}, {"name": "pi", "optional": true, "type": "Integer"}], "name":
       "Main task ref"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: bar

--- a/sdk/python/tests/compiler/testdata/custom_task_params_spec.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_params_spec.yaml
@@ -29,6 +29,9 @@ metadata:
       "foo", "optional": true, "type": "String"}, {"default": "buzz", "name": "bar",
       "optional": true}, {"name": "pi", "optional": true, "type": "Integer"}], "name":
       "Main task spec"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: bar
@@ -67,8 +70,6 @@ spec:
             default: 3
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             valid_container: "false"

--- a/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond.yaml
@@ -40,8 +40,7 @@ metadata:
       "{\"name\": \"print\", \"outputs\": [{\"name\": \"stdout\", \"type\": \"String\"}],
       \"version\": \"print@sha256=823faa68fcc8685fb1248a51eedd18a6880137a4415c369714ed3f0060a7196d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-outcome", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "condition-cel-outcome", "type": "string"}], "results":
       [{"description": "/tmp/stdout", "name": "stdout", "type": "string"}], "steps":
       [{"args": ["echo Iter: $(inputs.params.condition-cel-outcome) > $(results.stdout.path)"],
       "command": ["sh", "-c"], "image": "alpine:3.6", "name": "main"}]}, "timeout":

--- a/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond.yaml
@@ -57,6 +57,9 @@ metadata:
       "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop",
       "name": "recursion-test-graph-recur-2"}, "when": [{"input": "$(tasks.condition-cel-4.results.outcome)",
       "operator": "in", "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: until

--- a/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond_noninlined.yaml
@@ -40,8 +40,7 @@ metadata:
       "{\"name\": \"print\", \"outputs\": [{\"name\": \"stdout\", \"type\": \"String\"}],
       \"version\": \"print@sha256=823faa68fcc8685fb1248a51eedd18a6880137a4415c369714ed3f0060a7196d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-outcome", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "condition-cel-outcome", "type": "string"}], "results":
       [{"description": "/tmp/stdout", "name": "stdout", "type": "string"}], "steps":
       [{"args": ["echo Iter: $(inputs.params.condition-cel-outcome) > $(results.stdout.path)"],
       "command": ["sh", "-c"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
@@ -57,6 +56,9 @@ metadata:
       "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop",
       "name": "recursion-test-graph-recur-2"}, "when": [{"input": "$(tasks.condition-cel-4.results.outcome)",
       "operator": "in", "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: until

--- a/sdk/python/tests/compiler/testdata/custom_task_ref.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_ref.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use Tekton
       custom task with custom spec on KFP", "name": "tekton-custom-task-on-kubeflow-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:

--- a/sdk/python/tests/compiler/testdata/custom_task_ref_timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_ref_timeout.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use Tekton
       custom task with custom spec on KFP", "name": "tekton-custom-task-on-kubeflow-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:

--- a/sdk/python/tests/compiler/testdata/custom_task_spec.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_spec.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use Tekton
       custom task with custom spec on KFP", "name": "tekton-custom-task-on-kubeflow-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -41,8 +44,6 @@ spec:
           raw: raw
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             valid_container: "false"
@@ -61,8 +62,6 @@ spec:
           raw: raw
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             valid_container: "false"

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
@@ -62,6 +62,9 @@ metadata:
       "name": "something_param", "optional": true, "type": "Something"}, {"default":
       "string_param", "name": "string_param", "optional": true, "type": "String"}],
       "name": "data_passing_pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: anything_param
@@ -157,8 +160,6 @@ spec:
           type: string
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce anything",
@@ -248,8 +249,6 @@ spec:
           type: string
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce something",
@@ -357,8 +356,6 @@ spec:
           type: string
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce string",
@@ -398,8 +395,6 @@ spec:
           image: python:3.7
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -433,8 +428,6 @@ spec:
           image: python:3.7
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -468,8 +461,6 @@ spec:
           image: python:3.7
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -512,8 +503,6 @@ spec:
           image: python:3.7
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -563,8 +552,6 @@ spec:
           image: python:3.7
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -614,8 +601,6 @@ spec:
           image: python:3.7
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -661,8 +646,6 @@ spec:
         - name: anything_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -701,8 +684,6 @@ spec:
         - name: something_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -741,8 +722,6 @@ spec:
         - name: string_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -781,8 +760,6 @@ spec:
         - name: anything_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -821,8 +798,6 @@ spec:
         - name: something_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -861,8 +836,6 @@ spec:
         - name: anything_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -901,8 +874,6 @@ spec:
         - name: string_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -951,8 +922,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1006,8 +975,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1061,8 +1028,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1116,8 +1081,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -1171,8 +1134,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -1226,8 +1187,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -1281,8 +1240,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -1326,8 +1283,6 @@ spec:
         - name: produce-anything-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1366,8 +1321,6 @@ spec:
         - name: produce-something-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1406,8 +1359,6 @@ spec:
         - name: produce-string-Output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1446,8 +1397,6 @@ spec:
         - name: produce-anything-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -1486,8 +1435,6 @@ spec:
         - name: produce-something-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -1526,8 +1473,6 @@ spec:
         - name: produce-anything-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -1566,8 +1511,6 @@ spec:
         - name: produce-string-Output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -1612,8 +1555,6 @@ spec:
         - name: produce-anything-trname
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1665,8 +1606,6 @@ spec:
         - name: produce-something-trname
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1718,8 +1657,6 @@ spec:
         - name: produce-string-trname
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -1771,8 +1708,6 @@ spec:
         - name: produce-anything-trname
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -1824,8 +1759,6 @@ spec:
         - name: produce-something-trname
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -1877,8 +1810,6 @@ spec:
         - name: produce-anything-trname
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -1930,8 +1861,6 @@ spec:
         - name: produce-string-trname
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_param_as_file.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_param_as_file.yaml
@@ -32,6 +32,9 @@ metadata:
       "name": "something_param", "optional": true, "type": "Something"}, {"default":
       "string_param", "name": "string_param", "optional": true, "type": "String"}],
       "name": "data_passing_pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: anything_param
@@ -91,8 +94,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -146,8 +147,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -201,8 +200,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume anything
@@ -256,8 +253,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -311,8 +306,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume something
@@ -366,8 +359,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string
@@ -421,8 +412,6 @@ spec:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume string

--- a/sdk/python/tests/compiler/testdata/exception.yaml
+++ b/sdk/python/tests/compiler/testdata/exception.yaml
@@ -56,8 +56,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":
               [], "version": "echo@sha256=4307d04e3d8d097b882bcd9cba02f5ae7d2433c3a6e5968af9f6bf1e17582984"}'
@@ -101,8 +99,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "gcs-download",
                       "outputs": [{"name": "data", "type": "String"}], "version":
@@ -128,8 +124,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "echo",
                       "outputs": [], "version": "echo@sha256=4307d04e3d8d097b882bcd9cba02f5ae7d2433c3a6e5968af9f6bf1e17582984"}'
@@ -137,7 +131,5 @@ spec:
               timeout: 525600m
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/exception.yaml
+++ b/sdk/python/tests/compiler/testdata/exception.yaml
@@ -31,6 +31,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Addon sample for exception
       handing", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url", "optional": true, "type": "String"}], "name": "addon-sample"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: url
@@ -52,9 +55,9 @@ spec:
           image: library/bash:4.4.23
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":
               [], "version": "echo@sha256=4307d04e3d8d097b882bcd9cba02f5ae7d2433c3a6e5968af9f6bf1e17582984"}'
@@ -97,9 +100,9 @@ spec:
                   description: /tmp/outputs/data/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "gcs-download",
                       "outputs": [{"name": "data", "type": "String"}], "version":
@@ -124,9 +127,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "echo",
                       "outputs": [], "version": "echo@sha256=4307d04e3d8d097b882bcd9cba02f5ae7d2433c3a6e5968af9f6bf1e17582984"}'

--- a/sdk/python/tests/compiler/testdata/exit_handler.yaml
+++ b/sdk/python/tests/compiler/testdata/exit_handler.yaml
@@ -32,6 +32,9 @@ metadata:
       prints it. The exit handler will run after the pipeline finishes (successfully
       or not).", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url", "optional": true, "type": "String"}], "name": "exit-handler"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: url
@@ -63,8 +66,6 @@ spec:
           description: /tmp/outputs/data/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "gcs-download",
@@ -88,8 +89,6 @@ spec:
         - name: gcs-download-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":
@@ -109,8 +108,6 @@ spec:
           image: library/bash:4.4.23
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
+++ b/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
@@ -34,6 +34,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Run a script that passes
       file to a non configurable path", "name": "hidden-output-file-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -61,8 +64,6 @@ spec:
           description: /tmp/outputs/underscore_test/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "download-file",
@@ -91,8 +92,6 @@ spec:
         - name: download-file-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -30,6 +30,9 @@ metadata:
       and Save to GCS", "inputs": [{"default": "When flies fly behind flies, then
       flies are following flies.", "name": "message", "optional": true, "type": "String"}],
       "name": "save-most-frequent"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: message
@@ -63,8 +66,6 @@ spec:
           description: /tmp/outputs/word/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "get-frequent",

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets_with_node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets_with_node_selector.yaml
@@ -30,6 +30,9 @@ metadata:
       and Save to GCS", "inputs": [{"default": "When flies fly behind flies, then
       flies are following flies.", "name": "message", "optional": true, "type": "String"}],
       "name": "save-most-frequent"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: message
@@ -63,8 +66,6 @@ spec:
           description: /tmp/outputs/word/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "get-frequent",

--- a/sdk/python/tests/compiler/testdata/init_container.yaml
+++ b/sdk/python/tests/compiler/testdata/init_container.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with init container.",
       "name": "initcontainer"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -45,8 +48,6 @@ spec:
           image: alpine:latest
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "hello", "outputs":

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline shows how to
       define artifact inputs and pass raw artifacts to them.", "name": "pipeline-with-artifact-input-raw-argument-value"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -54,8 +57,6 @@ spec:
           image: alpine
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "component_with_inline_input_artifact",
@@ -91,8 +92,6 @@ spec:
           image: alpine
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "component_with_input_artifact",
@@ -128,8 +127,6 @@ spec:
           image: alpine
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "component_with_input_artifact",
@@ -166,8 +163,6 @@ spec:
           image: alpine
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "component_with_input_artifact",

--- a/sdk/python/tests/compiler/testdata/katib.yaml
+++ b/sdk/python/tests/compiler/testdata/katib.yaml
@@ -37,6 +37,9 @@ metadata:
       true, "type": "Integer"}, {"default": "60", "name": "experimentTimeoutMinutes",
       "optional": true, "type": "Integer"}, {"default": "True", "name": "deleteAfterDone",
       "optional": true, "type": "Boolean"}], "name": "launch-katib-experiment"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: deleteAfterDone
@@ -142,8 +145,6 @@ spec:
           description: /tmp/outputs/bestHyperParameter/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "mnist-hpo", "outputs":
@@ -168,8 +169,6 @@ spec:
         - name: mnist-hpo-bestHyperParameter
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop",

--- a/sdk/python/tests/compiler/testdata/literal_params_test.yaml
+++ b/sdk/python/tests/compiler/testdata/literal_params_test.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"name": "foo", "type": "String"}],
       "name": "literal-params-test"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: foo

--- a/sdk/python/tests/compiler/testdata/load_from_yaml.yaml
+++ b/sdk/python/tests/compiler/testdata/load_from_yaml.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with components
       loaded from yaml", "name": "component-yaml-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -49,8 +52,6 @@ spec:
           description: /tmp/outputs/dummy_output_path/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "busybox", "outputs":

--- a/sdk/python/tests/compiler/testdata/long_param_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_param_name.yaml
@@ -34,6 +34,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url1", "optional": true, "type": "String"}], "name": "some-very-long-name-with-lots-of-words-in-it-it-should-be-over-63-chars-long-in-order-to-observe-the-problem"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: url1
@@ -67,8 +70,6 @@ spec:
           description: /tmp/outputs/datadatadatadatadatadatadatadatadatadata/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "GCS - DownloadGCS
@@ -92,8 +93,6 @@ spec:
         - name: gcs-downloadgcs-downloadgcs-downloadgcs-download-datadatadatadatadatadatadatadatadatadata
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "printprintprintprintprintprintprintprintprintprint",

--- a/sdk/python/tests/compiler/testdata/long_pipeline_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_pipeline_name.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[\"a\", \"b\",
       \"c\"]", "name": "arr", "optional": true, "type": "typing.List[str]"}], "name":
       "some-very-long-name-with-lots-of-words-in-it-it-should-be-over-63-chars-long-in-order-to-observe-the-problem"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: arr
@@ -66,9 +69,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print",
                       "outputs": [], "version": "print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d"}'

--- a/sdk/python/tests/compiler/testdata/long_pipeline_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_pipeline_name.yaml
@@ -70,8 +70,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print",
                       "outputs": [], "version": "print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d"}'
@@ -80,7 +78,5 @@ spec:
           iterateParam: arr-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/long_pipeline_name_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/long_pipeline_name_noninlined.yaml
@@ -36,10 +36,12 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"print\", \"outputs\": [], \"version\": \"print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "arr-loop-item", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.arr-loop-item)"], "image": "alpine:3.6", "name": "main"}]},
-      "timeout": "525600m"}]}}}]'
+      "true"}}, "params": [{"name": "arr-loop-item", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.arr-loop-item)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: arr

--- a/sdk/python/tests/compiler/testdata/long_recursive_group_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_recursive_group_name.yaml
@@ -42,8 +42,7 @@ metadata:
       output paramter.\", \"name\": \"output_value\", \"type\": \"String\"}], \"version\":
       \"print-iter@sha256=1390d83fb5d8aa6c6a41af858140c4c362850b13718dedacfc3fb0a633596313\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-outcome", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "condition-cel-outcome", "type": "string"}], "results":
       [{"description": "/tmp/outputs/output_value/data", "name": "output-value", "type":
       "string"}], "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "Iter:
       $(inputs.params.condition-cel-outcome)", "$(results.output-value.path)"], "image":

--- a/sdk/python/tests/compiler/testdata/long_recursive_group_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_recursive_group_name.yaml
@@ -53,6 +53,9 @@ metadata:
       "kind": "PipelineLoop", "name": "pipeline-the-name-of-which-is-exactly-51-51-chars-long-1"},
       "when": [{"input": "$(tasks.condition-cel.results.outcome)", "operator": "notin",
       "values": ["0"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: iter_num

--- a/sdk/python/tests/compiler/testdata/long_recursive_group_name_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/long_recursive_group_name_noninlined.yaml
@@ -42,8 +42,7 @@ metadata:
       output paramter.\", \"name\": \"output_value\", \"type\": \"String\"}], \"version\":
       \"print-iter@sha256=1390d83fb5d8aa6c6a41af858140c4c362850b13718dedacfc3fb0a633596313\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-outcome", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "condition-cel-outcome", "type": "string"}], "results":
       [{"description": "/tmp/outputs/output_value/data", "name": "output-value", "type":
       "string"}], "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "Iter:
       $(inputs.params.condition-cel-outcome)", "$(results.output-value.path)"], "image":
@@ -53,6 +52,9 @@ metadata:
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name": "pipeline-the-name-of-which-is-exactly-51-51-chars-long-1"},
       "when": [{"input": "$(tasks.condition-cel.results.outcome)", "operator": "notin",
       "values": ["0"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: iter_num

--- a/sdk/python/tests/compiler/testdata/loop_empty.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_empty.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "0", "name": "start",
       "optional": true, "type": "Integer"}, {"default": "5", "name": "end", "optional":
       true, "type": "Integer"}], "name": "empty-loop"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: end

--- a/sdk/python/tests/compiler/testdata/loop_empty.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_empty.yaml
@@ -62,7 +62,5 @@ spec:
           iterateNumeric: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_in_recursion.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_in_recursion.yaml
@@ -132,6 +132,9 @@ metadata:
       ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
       "525600m"}]}}}}]}}}, "when": [{"input": "$(tasks.condition-2.results.outcome)",
       "operator": "in", "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -163,9 +166,9 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=8959c33ad80737db72737e65edcb11545dd9e408bc2ce5b50ca58248c2251ae5"}'
@@ -186,9 +189,9 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c"}'

--- a/sdk/python/tests/compiler/testdata/loop_in_recursion.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_in_recursion.yaml
@@ -45,17 +45,15 @@ metadata:
       {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"print\", \"outputs\":
       [], \"version\": \"print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-2", "runAfter":
       ["print"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=8959c33ad80737db72737e65edcb11545dd9e408bc2ce5b50ca58248c2251ae5\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0             else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -63,8 +61,7 @@ metadata:
       "operator": "in", "values": ["true"]}]}, {"name": "condition-2", "params": [{"name":
       "operand1", "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value":
       "heads"}, {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
-      "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "operand1",
+      {"pipelines.kubeflow.org/cache_enabled": "true"}}, "params": [{"name": "operand1",
       "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
       "type": "string"}], "results": [{"description": "Conditional task outcome",
       "name": "outcome", "type": "string"}], "steps": [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
@@ -83,28 +80,26 @@ metadata:
       "loop-item-param-3", "value": "[{\"a\": 1, \"b\": 2}, {\"a\": 10, \"b\": 20}]"},
       {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"}], "taskSpec":
       {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "metadata":
-      {"labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
-      "", "pipelines.kubeflow.org/pipelinename": ""}}, "spec": {"iterateParam": "loop-item-param-3",
-      "pipelineSpec": {"params": [{"name": "flip-coin-output", "type": "string"},
-      {"name": "loop-item-param-3-subvar-a", "type": "string"}, {"name": "loop-item-param-3-subvar-b",
-      "type": "string"}, {"name": "my_pipe_param", "type": "string"}], "tasks": [{"name":
-      "my-in-coop1", "params": [{"name": "loop-item-param-3-subvar-a", "value": "$(params.loop-item-param-3-subvar-a)"},
-      {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"}], "taskSpec":
-      {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
-      "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=7cea0db49353eacc7cc6a63f30e125ca464ba08a6320ccf928eb803a1ff06ee0\"}",
+      {"labels": {"pipelines.kubeflow.org/cache_enabled": "true"}}, "spec": {"iterateParam":
+      "loop-item-param-3", "pipelineSpec": {"params": [{"name": "flip-coin-output",
+      "type": "string"}, {"name": "loop-item-param-3-subvar-a", "type": "string"},
+      {"name": "loop-item-param-3-subvar-b", "type": "string"}, {"name": "my_pipe_param",
+      "type": "string"}], "tasks": [{"name": "my-in-coop1", "params": [{"name": "loop-item-param-3-subvar-a",
+      "value": "$(params.loop-item-param-3-subvar-a)"}, {"name": "my_pipe_param",
+      "value": "$(params.my_pipe_param)"}], "taskSpec": {"metadata": {"annotations":
+      {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"my-in-coop1\",
+      \"outputs\": [], \"version\": \"my-in-coop1@sha256=7cea0db49353eacc7cc6a63f30e125ca464ba08a6320ccf928eb803a1ff06ee0\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"}, {"name":
-      "my_pipe_param", "type": "string"}], "steps": [{"args": ["echo op1 $0 $1\n",
-      "$(inputs.params.loop-item-param-3-subvar-a)", "$(inputs.params.my_pipe_param)"],
+      "true"}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"},
+      {"name": "my_pipe_param", "type": "string"}], "steps": [{"args": ["echo op1
+      $0 $1\n", "$(inputs.params.loop-item-param-3-subvar-a)", "$(inputs.params.my_pipe_param)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "my-in-coop2", "params": [{"name": "loop-item-param-3-subvar-b",
       "value": "$(params.loop-item-param-3-subvar-b)"}], "taskSpec": {"metadata":
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-in-coop2\", \"outputs\": [], \"version\": \"my-in-coop2@sha256=59d25de2883dffe404f503d64ced9d8707a35aac0ec9cab6dde8e0b8ed8afcda\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-3-subvar-b", "type": "string"}],
+      "true"}}, "params": [{"name": "loop-item-param-3-subvar-b", "type": "string"}],
       "steps": [{"args": ["echo op2 $0\n", "$(inputs.params.loop-item-param-3-subvar-b)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "loop-in-recursion-pipeline-for-loop-6", "params":
@@ -113,8 +108,7 @@ metadata:
       {"name": "loop-item-param-5", "value": "[100, 200, 300]"}, {"name": "my_pipe_param",
       "value": "$(params.my_pipe_param)"}], "taskSpec": {"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "spec": {"iterateParam": "loop-item-param-5", "pipelineSpec": {"params":
+      "true"}}, "spec": {"iterateParam": "loop-item-param-5", "pipelineSpec": {"params":
       [{"name": "flip-coin-output", "type": "string"}, {"name": "loop-item-param-3-subvar-a",
       "type": "string"}, {"name": "loop-item-param-5", "type": "string"}, {"name":
       "my_pipe_param", "type": "string"}], "tasks": [{"name": "my-inner-inner-coop",
@@ -124,10 +118,9 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-inner-inner-coop\", \"outputs\": [], \"version\": \"my-inner-inner-coop@sha256=263800ac64830eaccf32a5995dd9a36f8c679882f0a116359a858b89e17a5749\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"}, {"name":
-      "loop-item-param-5", "type": "string"}, {"name": "my_pipe_param", "type": "string"}],
-      "steps": [{"args": ["echo op1 $0 $1 $2\n", "$(inputs.params.loop-item-param-3-subvar-a)",
+      "true"}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"},
+      {"name": "loop-item-param-5", "type": "string"}, {"name": "my_pipe_param", "type":
+      "string"}], "steps": [{"args": ["echo op1 $0 $1 $2\n", "$(inputs.params.loop-item-param-3-subvar-a)",
       "$(inputs.params.loop-item-param-5)", "$(inputs.params.my_pipe_param)"], "command":
       ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
       "525600m"}]}}}}]}}}, "when": [{"input": "$(tasks.condition-2.results.outcome)",
@@ -167,8 +160,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=8959c33ad80737db72737e65edcb11545dd9e408bc2ce5b50ca58248c2251ae5"}'
@@ -190,8 +181,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c"}'

--- a/sdk/python/tests/compiler/testdata/loop_in_recursion_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_in_recursion_noninlined.yaml
@@ -45,17 +45,15 @@ metadata:
       {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"print\", \"outputs\":
       [], \"version\": \"print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-2", "runAfter":
       ["print"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=8959c33ad80737db72737e65edcb11545dd9e408bc2ce5b50ca58248c2251ae5\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0             else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -94,18 +92,16 @@ metadata:
       {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=7cea0db49353eacc7cc6a63f30e125ca464ba08a6320ccf928eb803a1ff06ee0\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"}, {"name":
-      "my_pipe_param", "type": "string"}], "steps": [{"args": ["echo op1 $0 $1\n",
-      "$(inputs.params.loop-item-param-3-subvar-a)", "$(inputs.params.my_pipe_param)"],
+      "true"}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"},
+      {"name": "my_pipe_param", "type": "string"}], "steps": [{"args": ["echo op1
+      $0 $1\n", "$(inputs.params.loop-item-param-3-subvar-a)", "$(inputs.params.my_pipe_param)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "my-in-coop2", "params": [{"name": "loop-item-param-3-subvar-b",
       "value": "$(params.loop-item-param-3-subvar-b)"}], "taskSpec": {"metadata":
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-in-coop2\", \"outputs\": [], \"version\": \"my-in-coop2@sha256=59d25de2883dffe404f503d64ced9d8707a35aac0ec9cab6dde8e0b8ed8afcda\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-3-subvar-b", "type": "string"}],
+      "true"}}, "params": [{"name": "loop-item-param-3-subvar-b", "type": "string"}],
       "steps": [{"args": ["echo op2 $0\n", "$(inputs.params.loop-item-param-3-subvar-b)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "loop-in-recursion-pipeline-for-loop-6", "params":
@@ -125,13 +121,15 @@ metadata:
       "$(params.my_pipe_param)"}], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-inner-inner-coop\", \"outputs\": [], \"version\": \"my-inner-inner-coop@sha256=263800ac64830eaccf32a5995dd9a36f8c679882f0a116359a858b89e17a5749\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"}, {"name":
-      "loop-item-param-5", "type": "string"}, {"name": "my_pipe_param", "type": "string"}],
-      "steps": [{"args": ["echo op1 $0 $1 $2\n", "$(inputs.params.loop-item-param-3-subvar-a)",
+      "true"}}, "params": [{"name": "loop-item-param-3-subvar-a", "type": "string"},
+      {"name": "loop-item-param-5", "type": "string"}, {"name": "my_pipe_param", "type":
+      "string"}], "steps": [{"args": ["echo op1 $0 $1 $2\n", "$(inputs.params.loop-item-param-3-subvar-a)",
       "$(inputs.params.loop-item-param-5)", "$(inputs.params.my_pipe_param)"], "command":
       ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
       "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -163,8 +161,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
@@ -186,8 +182,6 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "my_pipe_param",
       "optional": true, "type": "Integer"}], "name": "my-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -81,9 +84,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
@@ -85,8 +85,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -96,7 +94,5 @@ spec:
           iterateParamStringSeparator: loop-item-param-3
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator_noninlined.yaml
@@ -37,12 +37,14 @@ metadata:
       {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-2", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
-      "$(inputs.params.loop-item-param-2)", "$(inputs.params.my_pipe_param)"], "command":
-      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
-      "525600m"}]}}}]'
+      "true"}}, "params": [{"name": "loop-item-param-2", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\"
+      \"$1\"\n", "$(inputs.params.loop-item-param-2)", "$(inputs.params.my_pipe_param)"],
+      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
+      "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param

--- a/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
@@ -53,8 +53,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list",
               "outputs": [{"name": "data_list", "type": "List"}], "version": "Produce
@@ -93,8 +91,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume
                       data", "outputs": [], "version": "Consume data@sha256=53c639462e2cf5f30518ba8b2d41564c1071e3473c7cffc13dc8b589dfc219bc"}'
@@ -103,7 +99,5 @@ spec:
           iterateParam: produce-list-data_list-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Test pipeline to verify
       functions of par loop.", "name": "loop-over-lightweight-output"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -49,9 +52,9 @@ spec:
           description: /tmp/outputs/data_list/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list",
               "outputs": [{"name": "data_list", "type": "List"}], "version": "Produce
@@ -89,9 +92,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume
                       data", "outputs": [], "version": "Consume data@sha256=53c639462e2cf5f30518ba8b2d41564c1071e3473c7cffc13dc8b589dfc219bc"}'

--- a/sdk/python/tests/compiler/testdata/loop_over_lightweight_output_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_over_lightweight_output_noninlined.yaml
@@ -38,10 +38,12 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"Consume data\", \"outputs\": [], \"version\": \"Consume data@sha256=53c639462e2cf5f30518ba8b2d41564c1071e3473c7cffc13dc8b589dfc219bc\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-list-data_list-loop-item", "type": "string"}],
+      "true"}}, "params": [{"name": "produce-list-data_list-loop-item", "type": "string"}],
       "steps": [{"command": ["echo", "$(inputs.params.produce-list-data_list-loop-item)"],
       "image": "busybox", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -62,8 +64,6 @@ spec:
           description: /tmp/outputs/data_list/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list",

--- a/sdk/python/tests/compiler/testdata/loop_static.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "my_pipe_param",
       "optional": true, "type": "String"}], "name": "static-loop-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -56,9 +59,9 @@ spec:
         - name: my_pipe_param
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "static-loop-out-op",
               "outputs": [], "version": "static-loop-out-op@sha256=84e07ab9a7585349f4f6c1c53200dfae7cacee9fa6aa5bdeb26d7487dd58c203"}'
@@ -106,9 +109,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "static-loop-inner-op1",
                       "outputs": [], "version": "static-loop-inner-op1@sha256=37bfbf9bbcc6525f9915ee1c07e8a8b482c487696eb3c10fd82c27049b1b55e9"}'
@@ -134,9 +137,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "static-loop-inner-op2",
                       "outputs": [], "version": "static-loop-inner-op2@sha256=56d5b639d49c40d3d5eb06be4a8d277614742470a048197eb6f141c9c257324c"}'

--- a/sdk/python/tests/compiler/testdata/loop_static.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static.yaml
@@ -60,8 +60,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "static-loop-out-op",
               "outputs": [], "version": "static-loop-out-op@sha256=84e07ab9a7585349f4f6c1c53200dfae7cacee9fa6aa5bdeb26d7487dd58c203"}'
@@ -110,8 +108,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "static-loop-inner-op1",
                       "outputs": [], "version": "static-loop-inner-op1@sha256=37bfbf9bbcc6525f9915ee1c07e8a8b482c487696eb3c10fd82c27049b1b55e9"}'
@@ -138,8 +134,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "static-loop-inner-op2",
                       "outputs": [], "version": "static-loop-inner-op2@sha256=56d5b639d49c40d3d5eb06be4a8d277614742470a048197eb6f141c9c257324c"}'
@@ -148,7 +142,5 @@ spec:
           iterateParam: with-item-name
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_static_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static_noninlined.yaml
@@ -37,19 +37,21 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"static-loop-inner-op1\", \"outputs\": [], \"version\": \"static-loop-inner-op1@sha256=37bfbf9bbcc6525f9915ee1c07e8a8b482c487696eb3c10fd82c27049b1b55e9\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "with-item-name", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["echo op1 $0 $1\n", "$(inputs.params.with-item-name)",
-      "$(inputs.params.my_pipe_param)"], "command": ["sh", "-c"], "image": "library/bash:4.4.23",
-      "name": "main"}]}, "timeout": "525600m"}, {"name": "static-loop-inner-op2",
-      "params": [{"name": "with-item-name", "value": "$(params.with-item-name)"}],
-      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
-      "{\"name\": \"static-loop-inner-op2\", \"outputs\": [], \"version\": \"static-loop-inner-op2@sha256=56d5b639d49c40d3d5eb06be4a8d277614742470a048197eb6f141c9c257324c\"}",
+      "true"}}, "params": [{"name": "with-item-name", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["echo op1 $0 $1\n",
+      "$(inputs.params.with-item-name)", "$(inputs.params.my_pipe_param)"], "command":
+      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
+      "525600m"}, {"name": "static-loop-inner-op2", "params": [{"name": "with-item-name",
+      "value": "$(params.with-item-name)"}], "taskSpec": {"metadata": {"annotations":
+      {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"static-loop-inner-op2\",
+      \"outputs\": [], \"version\": \"static-loop-inner-op2@sha256=56d5b639d49c40d3d5eb06be4a8d277614742470a048197eb6f141c9c257324c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "with-item-name", "type": "string"}], "steps": [{"args":
-      ["echo op2 $0\n", "$(inputs.params.with-item-name)"], "command": ["sh", "-c"],
-      "image": "library/bash:4.4.23", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+      "true"}}, "params": [{"name": "with-item-name", "type": "string"}], "steps":
+      [{"args": ["echo op2 $0\n", "$(inputs.params.with-item-name)"], "command": ["sh",
+      "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -78,8 +80,6 @@ spec:
         - name: my_pipe_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "static-loop-out-op",

--- a/sdk/python/tests/compiler/testdata/loop_static_with_parallelism.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static_with_parallelism.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "my_pipe_param",
       "optional": true, "type": "String"}], "name": "para-loop-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -56,9 +59,9 @@ spec:
         - name: my_pipe_param
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "para-loop-out-op",
               "outputs": [], "version": "para-loop-out-op@sha256=2ffc845c5b44a975d837ef6a728f691bf97fb1ae8168ed429af14d94aaafaf4d"}'
@@ -106,9 +109,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "para-loop-inner-op1",
                       "outputs": [], "version": "para-loop-inner-op1@sha256=3f0d81fcc84addea722cbc93871ed081edde0ee5273c7543470ece4dd530cd78"}'
@@ -134,9 +137,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "para-loop-inner-op2",
                       "outputs": [], "version": "para-loop-inner-op2@sha256=fbc1104d87b80e5c2e81dedd9df4f8def400447d5ddb8f5972860eda7962c349"}'

--- a/sdk/python/tests/compiler/testdata/loop_static_with_parallelism.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static_with_parallelism.yaml
@@ -60,8 +60,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "para-loop-out-op",
               "outputs": [], "version": "para-loop-out-op@sha256=2ffc845c5b44a975d837ef6a728f691bf97fb1ae8168ed429af14d94aaafaf4d"}'
@@ -110,8 +108,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "para-loop-inner-op1",
                       "outputs": [], "version": "para-loop-inner-op1@sha256=3f0d81fcc84addea722cbc93871ed081edde0ee5273c7543470ece4dd530cd78"}'
@@ -138,8 +134,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "para-loop-inner-op2",
                       "outputs": [], "version": "para-loop-inner-op2@sha256=fbc1104d87b80e5c2e81dedd9df4f8def400447d5ddb8f5972860eda7962c349"}'
@@ -149,7 +143,5 @@ spec:
           iterateParam: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_static_with_parallelism_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static_with_parallelism_noninlined.yaml
@@ -38,20 +38,22 @@ metadata:
       {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"para-loop-inner-op1\",
       \"outputs\": [], \"version\": \"para-loop-inner-op1@sha256=3f0d81fcc84addea722cbc93871ed081edde0ee5273c7543470ece4dd530cd78\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["echo op1 $0 $1\n", "$(inputs.params.loop-item-param-1)",
-      "$(inputs.params.my_pipe_param)"], "command": ["sh", "-c"], "image": "library/bash:4.4.23",
-      "name": "main"}]}, "timeout": "525600m"}, {"name": "para-loop-inner-op2", "params":
-      [{"name": "loop-item-param-1", "value": "$(params.loop-item-param-1)"}], "taskSpec":
-      {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
-      "{\"name\": \"para-loop-inner-op2\", \"outputs\": [], \"version\": \"para-loop-inner-op2@sha256=fbc1104d87b80e5c2e81dedd9df4f8def400447d5ddb8f5972860eda7962c349\"}",
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["echo op1 $0 $1\n",
+      "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"], "command":
+      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
+      "525600m"}, {"name": "para-loop-inner-op2", "params": [{"name": "loop-item-param-1",
+      "value": "$(params.loop-item-param-1)"}], "taskSpec": {"metadata": {"annotations":
+      {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"para-loop-inner-op2\",
+      \"outputs\": [], \"version\": \"para-loop-inner-op2@sha256=fbc1104d87b80e5c2e81dedd9df4f8def400447d5ddb8f5972860eda7962c349\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}], "steps":
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}], "steps":
       [{"args": ["echo op2 $0\n", "$(inputs.params.loop-item-param-1)"], "command":
       ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
       "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -80,8 +82,6 @@ spec:
         - name: my_pipe_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "para-loop-out-op",

--- a/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency.yaml
@@ -38,6 +38,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[\"a\", \"b\",
       \"c\"]", "name": "param", "optional": true, "type": "JsonArray"}], "name": "empty-loop"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param
@@ -66,9 +69,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-0", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -103,9 +106,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-1", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -136,9 +139,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-2", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -186,9 +189,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-3",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -235,9 +238,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-4",
                       "outputs": [{"description": "Represents an output paramter.",

--- a/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency.yaml
@@ -70,8 +70,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-0", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -107,8 +105,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-1", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -140,8 +136,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-2", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -190,8 +184,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-3",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -201,8 +193,6 @@ spec:
           iterateParam: param-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
     - runAfter:
       - print-1
@@ -239,8 +229,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-4",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -251,7 +239,5 @@ spec:
           iterateParam: param-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency_noninlined.yaml
@@ -46,8 +46,7 @@ metadata:
       [{\"description\": \"Represents an output paramter.\", \"name\": \"output_value\",
       \"type\": \"String\"}], \"version\": \"print-3@sha256=5eed691c7d42c19cf0e5ca60612456bac19f7d8902ae2cf92ff0f37663cf4763\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
+      "true"}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
       "output-value", "type": "string"}], "steps": [{"command": ["sh", "-c", "set
       -e\necho $0 > $1\n", "print-3", "$(results.output-value.path)"], "image": "alpine:3.6",
       "name": "main"}]}, "timeout": "525600m"}]}}}, {"apiVersion": "custom.tekton.dev/v1alpha1",
@@ -59,11 +58,13 @@ metadata:
       paramter.\", \"name\": \"output_value\", \"type\": \"String\"}], \"version\":
       \"print-4@sha256=612578686b564fc00e7052b345cd44d6a9cad721cdd6ceb3ecfc68c392a932f7\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
+      "true"}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
       "output-value", "type": "string"}], "steps": [{"command": ["sh", "-c", "set
       -e\necho $0 > $1\n", "print-4", "$(results.output-value.path)"], "image": "alpine:3.6",
       "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param
@@ -92,8 +93,6 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-0", "outputs":
@@ -129,8 +128,6 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-1", "outputs":
@@ -162,8 +159,6 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-2", "outputs":

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic.yaml
@@ -53,8 +53,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list",
               "outputs": [{"name": "data_list", "type": "List"}], "version": "Produce
@@ -100,8 +98,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume
                       data", "outputs": [], "version": "Consume data@sha256=748cfc9398fb5667535b2ae5940d7947826385c62858c6b1b637b527d9b57e6e"}'
@@ -111,7 +107,5 @@ spec:
           iterateParam: produce-list-data_list-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Test pipeline to verify
       functions of par loop.", "name": "loop-with-enumerate-basic"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -49,9 +52,9 @@ spec:
           description: /tmp/outputs/data_list/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list",
               "outputs": [{"name": "data_list", "type": "List"}], "version": "Produce
@@ -96,9 +99,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume
                       data", "outputs": [], "version": "Consume data@sha256=748cfc9398fb5667535b2ae5940d7947826385c62858c6b1b637b527d9b57e6e"}'

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic_noninlined.yaml
@@ -40,11 +40,13 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"Consume data\", \"outputs\": [], \"version\": \"Consume data@sha256=748cfc9398fb5667535b2ae5940d7947826385c62858c6b1b637b527d9b57e6e\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "iteration-number-2", "type": "string"}, {"name":
+      "true"}}, "params": [{"name": "iteration-number-2", "type": "string"}, {"name":
       "produce-list-data_list-loop-item", "type": "string"}], "steps": [{"command":
       ["echo", "$(inputs.params.iteration-number-2)", "$(inputs.params.produce-list-data_list-loop-item)"],
       "image": "busybox", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -65,8 +67,6 @@ spec:
           description: /tmp/outputs/data_list/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list",

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested.yaml
@@ -105,8 +105,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=a3500c74823f34974bad0f19c6ebb9c48b9457d687021e9d6c874f840a7cd9b0"}'
@@ -134,8 +132,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop2",
                       "outputs": [], "version": "my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe"}'
@@ -201,8 +197,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-1st-inner-coop", "outputs": [], "version": "my-1st-inner-coop@sha256=feaa8a218c3caaa76fa1154bcca9fc485286e72814986c35d08edcd28d2a50b9"}'
@@ -276,8 +270,6 @@ spec:
                                 metadata:
                                   labels:
                                     pipelines.kubeflow.org/cache_enabled: "true"
-                                    pipelines.kubeflow.org/pipelinename: ''
-                                    pipelines.kubeflow.org/generation: ''
                                   annotations:
                                     pipelines.kubeflow.org/component_spec_digest: '{"name":
                                       "my-2nd-inner-coop", "outputs": [], "version":
@@ -328,8 +320,6 @@ spec:
                                         metadata:
                                           labels:
                                             pipelines.kubeflow.org/cache_enabled: "true"
-                                            pipelines.kubeflow.org/pipelinename: ''
-                                            pipelines.kubeflow.org/generation: ''
                                           annotations:
                                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                                               "my-3rd-inner-coop", "outputs": [],
@@ -339,27 +329,19 @@ spec:
                                   iterateParam: my_pipe_param3-loop-item
                                 metadata:
                                   labels:
-                                    pipelines.kubeflow.org/pipelinename: ''
-                                    pipelines.kubeflow.org/generation: ''
                                     pipelines.kubeflow.org/cache_enabled: "true"
                           iterationNumberParam: iteration-number-7
                           iterateParam: loop-item-param-5
                         metadata:
                           labels:
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                             pipelines.kubeflow.org/cache_enabled: "true"
                   iterateParam: my_pipe_param-loop-item
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterationNumberParam: iteration-number-3
           iterateParam: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[100, 200]", "name":
       "my_pipe_param", "optional": true, "type": "JsonArray"}, {"default": "[1, 2]",
       "name": "my_pipe_param3", "optional": true, "type": "JsonArray"}], "name": "withitem-multiple-nesting-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -101,9 +104,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=a3500c74823f34974bad0f19c6ebb9c48b9457d687021e9d6c874f840a7cd9b0"}'
@@ -130,9 +133,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop2",
                       "outputs": [], "version": "my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe"}'
@@ -197,9 +200,9 @@ spec:
                           type: string
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-1st-inner-coop", "outputs": [], "version": "my-1st-inner-coop@sha256=feaa8a218c3caaa76fa1154bcca9fc485286e72814986c35d08edcd28d2a50b9"}'
@@ -272,9 +275,9 @@ spec:
                                   type: string
                                 metadata:
                                   labels:
+                                    pipelines.kubeflow.org/cache_enabled: "true"
                                     pipelines.kubeflow.org/pipelinename: ''
                                     pipelines.kubeflow.org/generation: ''
-                                    pipelines.kubeflow.org/cache_enabled: "true"
                                   annotations:
                                     pipelines.kubeflow.org/component_spec_digest: '{"name":
                                       "my-2nd-inner-coop", "outputs": [], "version":
@@ -324,9 +327,9 @@ spec:
                                           type: string
                                         metadata:
                                           labels:
+                                            pipelines.kubeflow.org/cache_enabled: "true"
                                             pipelines.kubeflow.org/pipelinename: ''
                                             pipelines.kubeflow.org/generation: ''
-                                            pipelines.kubeflow.org/cache_enabled: "true"
                                           annotations:
                                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                                               "my-3rd-inner-coop", "outputs": [],

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested_noninlined.yaml
@@ -42,8 +42,7 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=a3500c74823f34974bad0f19c6ebb9c48b9457d687021e9d6c874f840a7cd9b0\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "iteration-number-3", "type": "string"}, {"name":
+      "true"}}, "params": [{"name": "iteration-number-3", "type": "string"}, {"name":
       "loop-item-param-1-subvar-a", "type": "string"}], "steps": [{"args": ["set -e\necho
       op1 \"$0) $1\"\n", "$(inputs.params.iteration-number-3)", "$(inputs.params.loop-item-param-1-subvar-a)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
@@ -52,8 +51,7 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-in-coop2\", \"outputs\": [], \"version\": \"my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"}],
+      "true"}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"}],
       "steps": [{"args": ["set -e\necho op2 \"$0\"\n", "$(inputs.params.loop-item-param-1-subvar-b)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "withitem-multiple-nesting-pipeline-for-loop-4",
@@ -76,12 +74,11 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-1st-inner-coop\", \"outputs\": [], \"version\": \"my-1st-inner-coop@sha256=feaa8a218c3caaa76fa1154bcca9fc485286e72814986c35d08edcd28d2a50b9\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1-subvar-a", "type": "string"}, {"name":
-      "my_pipe_param-loop-item", "type": "string"}], "steps": [{"args": ["set -e\necho
-      \"op1-1\" \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-a)", "$(inputs.params.my_pipe_param-loop-item)"],
-      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
-      "timeout": "525600m"}, {"name": "withitem-multiple-nesting-pipeline-for-loop-6",
+      "true"}}, "params": [{"name": "loop-item-param-1-subvar-a", "type": "string"},
+      {"name": "my_pipe_param-loop-item", "type": "string"}], "steps": [{"args": ["set
+      -e\necho \"op1-1\" \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-a)",
+      "$(inputs.params.my_pipe_param-loop-item)"], "command": ["sh", "-c"], "image":
+      "library/bash:4.4.23", "name": "main"}]}, "timeout": "525600m"}, {"name": "withitem-multiple-nesting-pipeline-for-loop-6",
       "params": [{"name": "iteration-number-3", "value": "$(params.iteration-number-3)"},
       {"name": "loop-item-param-1-subvar-b", "value": "$(params.loop-item-param-1-subvar-b)"},
       {"name": "loop-item-param-5", "value": "[4, 5]"}, {"name": "my_pipe_param3-loop-item",
@@ -102,8 +99,7 @@ metadata:
       "$(params.loop-item-param-5)"}], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-2nd-inner-coop\", \"outputs\": [], \"version\": \"my-2nd-inner-coop@sha256=446981377175c0bb9fd796c392d60faeb066a8ed375deb664fe6caae385220a4\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "iteration-number-3", "type": "string"}, {"name":
+      "true"}}, "params": [{"name": "iteration-number-3", "type": "string"}, {"name":
       "iteration-number-7", "type": "string"}, {"name": "loop-item-param-1-subvar-b",
       "type": "string"}, {"name": "loop-item-param-5", "type": "string"}], "steps":
       [{"args": ["set -e\necho \"op1-2\" \"$0)\" $1 \"$2) $3\"\n", "$(inputs.params.iteration-number-3)",
@@ -123,12 +119,14 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-3rd-inner-coop\", \"outputs\": [], \"version\": \"my-3rd-inner-coop@sha256=998ba59ac4c7f67532187f1efa987503199250edc7d4147ac0d90f3c6b595d17\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"}, {"name":
-      "my_pipe_param3-loop-item", "type": "string"}], "steps": [{"args": ["set -e\necho
-      \"op1-3\" \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-b)", "$(inputs.params.my_pipe_param3-loop-item)"],
-      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
-      "timeout": "525600m"}]}}}]'
+      "true"}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"},
+      {"name": "my_pipe_param3-loop-item", "type": "string"}], "steps": [{"args":
+      ["set -e\necho \"op1-3\" \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-b)",
+      "$(inputs.params.my_pipe_param3-loop-item)"], "command": ["sh", "-c"], "image":
+      "library/bash:4.4.23", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric.yaml
@@ -95,8 +95,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -148,8 +146,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-in-coop1", "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -158,13 +154,9 @@ spec:
                   iterateNumeric: loop-item-param-3
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterateNumeric: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric.yaml
@@ -29,6 +29,9 @@ metadata:
       "optional": true, "type": "Integer"}, {"default": "1", "name": "start", "optional":
       true, "type": "Integer"}, {"default": "2", "name": "end", "optional": true,
       "type": "Integer"}], "name": "my-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: end
@@ -91,9 +94,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -144,9 +147,9 @@ spec:
                           type: string
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-in-coop1", "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate.yaml
@@ -102,8 +102,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=3e0e81a9e227f372f7677b8cf32c5653b7947d243bedf2762beaf556af346719"}'
@@ -162,8 +160,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-in-coop1", "outputs": [], "version": "my-in-coop1@sha256=3e0e81a9e227f372f7677b8cf32c5653b7947d243bedf2762beaf556af346719"}'
@@ -173,14 +169,10 @@ spec:
                   iterateNumeric: loop-item-param-4
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterationNumberParam: iteration-number-3
           iterateNumeric: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate.yaml
@@ -29,6 +29,9 @@ metadata:
       "optional": true, "type": "Integer"}, {"default": "1", "name": "start", "optional":
       true, "type": "Integer"}, {"default": "2", "name": "end", "optional": true,
       "type": "Integer"}], "name": "my-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: end
@@ -98,9 +101,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=3e0e81a9e227f372f7677b8cf32c5653b7947d243bedf2762beaf556af346719"}'
@@ -158,9 +161,9 @@ spec:
                           type: string
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-in-coop1", "outputs": [], "version": "my-in-coop1@sha256=3e0e81a9e227f372f7677b8cf32c5653b7947d243bedf2762beaf556af346719"}'

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate_noninlined.yaml
@@ -40,8 +40,7 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=3e0e81a9e227f372f7677b8cf32c5653b7947d243bedf2762beaf556af346719\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "iteration-number-3", "type": "string"}, {"name":
+      "true"}}, "params": [{"name": "iteration-number-3", "type": "string"}, {"name":
       "loop-item-param-1", "type": "string"}, {"name": "my_pipe_param", "type": "string"}],
       "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\" \"$2\"\n", "$(inputs.params.iteration-number-3)",
       "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"], "command":
@@ -60,13 +59,15 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=3e0e81a9e227f372f7677b8cf32c5653b7947d243bedf2762beaf556af346719\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "iteration-number-6", "type": "string"}, {"name":
+      "true"}}, "params": [{"name": "iteration-number-6", "type": "string"}, {"name":
       "loop-item-param-4", "type": "string"}, {"name": "my_pipe_param", "type": "string"}],
       "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\" \"$2\"\n", "$(inputs.params.iteration-number-6)",
       "$(inputs.params.loop-item-param-4)", "$(inputs.params.my_pipe_param)"], "command":
       ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
       "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: end

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric_noninlined.yaml
@@ -38,14 +38,13 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
-      "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"], "command":
-      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
-      "525600m"}, {"name": "my-pipeline-for-loop-4", "params": [{"name": "from", "value":
-      "1"}, {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"}, {"name":
-      "to", "value": "2"}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1",
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\"
+      \"$1\"\n", "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"],
+      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
+      "timeout": "525600m"}, {"name": "my-pipeline-for-loop-4", "params": [{"name":
+      "from", "value": "1"}, {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"},
+      {"name": "to", "value": "2"}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "name": "my-pipeline-for-loop-4"}}]}}}, {"apiVersion":
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "metadata": {"name": "my-pipeline-for-loop-4"},
       "spec": {"iterateNumeric": "loop-item-param-3", "pipelineSpec": {"params": [{"name":
@@ -55,12 +54,14 @@ metadata:
       "$(params.my_pipe_param)"}], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-3", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
-      "$(inputs.params.loop-item-param-3)", "$(inputs.params.my_pipe_param)"], "command":
-      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
-      "525600m"}]}}}]'
+      "true"}}, "params": [{"name": "loop-item-param-3", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\"
+      \"$1\"\n", "$(inputs.params.loop-item-param-3)", "$(inputs.params.my_pipe_param)"],
+      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
+      "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: end

--- a/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
@@ -110,8 +110,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce message",
               "outputs": [{"name": "Output", "type": "String"}], "version": "Produce
@@ -181,8 +179,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce message",
               "outputs": [{"name": "Output", "type": "String"}], "version": "Produce
@@ -236,8 +232,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -246,8 +240,6 @@ spec:
           iterateParam: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
     - name: parallelfor-pipeline-param-in-items-reso-for-loop-4
       params:
@@ -299,8 +291,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -340,8 +330,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -350,8 +338,6 @@ spec:
           iterateParam: loop-item-param-3
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
     - name: parallelfor-pipeline-param-in-items-reso-for-loop-6
       params:
@@ -403,8 +389,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -444,8 +428,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -454,7 +436,5 @@ spec:
           iterateParam: loop-item-param-5
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
@@ -33,6 +33,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"name": "fname1", "type":
       "String"}, {"name": "fname2", "type": "String"}], "name": "Parallelfor pipeline
       param in items resolving"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: fname1
@@ -106,9 +109,9 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce message",
               "outputs": [{"name": "Output", "type": "String"}], "version": "Produce
@@ -177,9 +180,9 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce message",
               "outputs": [{"name": "Output", "type": "String"}], "version": "Produce
@@ -232,9 +235,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -295,9 +298,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -336,9 +339,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -399,9 +402,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'
@@ -440,9 +443,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=224a4b259c5bbe75af83adc0dc10c1c39c56c4eb7be09a895e2ef19f70f10e1a"}'

--- a/sdk/python/tests/compiler/testdata/loop_with_step.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_step.yaml
@@ -30,6 +30,9 @@ metadata:
       true, "type": "Integer"}, {"default": "5", "name": "end", "optional": true,
       "type": "Integer"}, {"default": "3", "name": "step", "optional": true, "type":
       "Integer"}], "name": "my-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: end
@@ -98,9 +101,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -151,9 +154,9 @@ spec:
                           type: string
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-in-coop1", "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'

--- a/sdk/python/tests/compiler/testdata/loop_with_step.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_step.yaml
@@ -102,8 +102,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -155,8 +153,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-in-coop1", "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -165,13 +161,9 @@ spec:
                   iterateNumeric: loop-item-param-3
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterateNumeric: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_step_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_step_noninlined.yaml
@@ -39,14 +39,13 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
-      "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"], "command":
-      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
-      "525600m"}, {"name": "my-pipeline-for-loop-4", "params": [{"name": "from", "value":
-      "1"}, {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"}, {"name":
-      "to", "value": "2"}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1",
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\"
+      \"$1\"\n", "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"],
+      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
+      "timeout": "525600m"}, {"name": "my-pipeline-for-loop-4", "params": [{"name":
+      "from", "value": "1"}, {"name": "my_pipe_param", "value": "$(params.my_pipe_param)"},
+      {"name": "to", "value": "2"}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1",
       "kind": "PipelineLoop", "name": "my-pipeline-for-loop-4"}}]}}}, {"apiVersion":
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "metadata": {"name": "my-pipeline-for-loop-4"},
       "spec": {"iterateNumeric": "loop-item-param-3", "pipelineSpec": {"params": [{"name":
@@ -56,12 +55,14 @@ metadata:
       "$(params.my_pipe_param)"}], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-3", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
-      "$(inputs.params.loop-item-param-3)", "$(inputs.params.my_pipe_param)"], "command":
-      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
-      "525600m"}]}}}]'
+      "true"}}, "params": [{"name": "loop-item-param-3", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\"
+      \"$1\"\n", "$(inputs.params.loop-item-param-3)", "$(inputs.params.my_pipe_param)"],
+      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
+      "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: end

--- a/sdk/python/tests/compiler/testdata/many_results.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results.yaml
@@ -36,6 +36,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline that produce
       many results.", "name": "many-results-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -166,8 +169,6 @@ spec:
           description: /tmp/outputs/param4c/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             tekton-result-sizes: '{"param1": 1500, "param2A": 700, "param3_b": 500,
@@ -196,8 +197,6 @@ spec:
         - name: print4results-param3_b
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
@@ -36,6 +36,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline that produce
       many results.", "name": "many-results-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -180,8 +183,6 @@ spec:
           description: /tmp/outputs/superlongnamesuperlongnamesuperlongnamesuperlongnamesuperlongnamesuperlongnamesuperlongname/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             tekton-result-sizes: '{"param1": 2500, "param23": 700, "param3": 500,

--- a/sdk/python/tests/compiler/testdata/multi_nested_loop_condi.yaml
+++ b/sdk/python/tests/compiler/testdata/multi_nested_loop_condi.yaml
@@ -35,6 +35,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[\"a\", \"b\",
       \"c\"]", "name": "param", "optional": true, "type": "JsonArray"}, {"default":
       "True", "name": "flag", "optional": true, "type": "Boolean"}], "name": "loop-cond2"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: flag
@@ -67,9 +70,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-0", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -155,9 +158,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-1",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -188,9 +191,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-2",
                       "outputs": [{"description": "Represents an output paramter.",

--- a/sdk/python/tests/compiler/testdata/multi_nested_loop_condi.yaml
+++ b/sdk/python/tests/compiler/testdata/multi_nested_loop_condi.yaml
@@ -71,8 +71,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print-0", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -159,8 +157,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-1",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -192,8 +188,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-2",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -210,7 +204,5 @@ spec:
           iterateParam: param-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_custom_conditions.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_custom_conditions.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"name": "a", "type": "Integer"},
       {"name": "b", "type": "Integer"}, {"name": "c", "type": "Integer"}], "name":
       "nested-condition-test"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: a
@@ -93,8 +96,6 @@ spec:
           emptyDir: {}
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/nested_loop_global_param.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_loop_global_param.yaml
@@ -31,6 +31,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[\"a\", \"b\",
       \"c\"]", "name": "param", "optional": true, "type": "JsonArray"}], "name": "empty-loop"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param
@@ -99,9 +102,9 @@ spec:
                           description: /tmp/outputs/output_value/data
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "print-0", "outputs": [{"description": "Represents an
@@ -170,9 +173,9 @@ spec:
                           description: /tmp/outputs/output_value/data
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "print-1", "outputs": [{"description": "Represents an

--- a/sdk/python/tests/compiler/testdata/nested_loop_global_param.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_loop_global_param.yaml
@@ -103,8 +103,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "print-0", "outputs": [{"description": "Represents an
@@ -115,14 +113,10 @@ spec:
                   iterateParam: param-loop-item
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterateParam: param-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
     - name: empty-loop-for-loop-3
       params:
@@ -174,8 +168,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "print-1", "outputs": [{"description": "Represents an
@@ -186,13 +178,9 @@ spec:
                   iterateParam: param-loop-item
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterateParam: param-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_loop_global_param_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_loop_global_param_noninlined.yaml
@@ -47,8 +47,7 @@ metadata:
       paramter.\", \"name\": \"output_value\", \"type\": \"String\"}], \"version\":
       \"print-0@sha256=5dd3c506ec54281b82008ca8ec5d8142834eae18d74ce8a110a31dd6e371b40d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "param", "type": "string"}], "results": [{"description":
+      "true"}}, "params": [{"name": "param", "type": "string"}], "results": [{"description":
       "/tmp/outputs/output_value/data", "name": "output-value", "type": "string"}],
       "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "print $(inputs.params.param)",
       "$(results.output-value.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
@@ -66,11 +65,13 @@ metadata:
       paramter.\", \"name\": \"output_value\", \"type\": \"String\"}], \"version\":
       \"print-1@sha256=3b81342bc143f625b58ebdb01e7c83b145880dee807be35c1e16fdb835d46580\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
+      "true"}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
       "output-value", "type": "string"}], "steps": [{"command": ["sh", "-c", "set
       -e\necho $0 > $1\n", "print", "$(results.output-value.path)"], "image": "alpine:3.6",
       "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: param

--- a/sdk/python/tests/compiler/testdata/nested_recur_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_custom_task.yaml
@@ -99,6 +99,9 @@ metadata:
       "kind": "PipelineLoop", "name": "double-recursion-test-graph-recur-b-4"}, "when":
       [{"input": "$(tasks.condition-cel-7.results.outcome)", "operator": "in", "values":
       ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: array

--- a/sdk/python/tests/compiler/testdata/nested_recur_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_custom_task.yaml
@@ -77,21 +77,20 @@ metadata:
       "{\"name\": \"print\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"print@sha256=8bcd5db23262c19ef5c49e890dfd60507d8da6c514d628749e64239c78a27a92\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-3-outcome", "type": "string"}, {"name":
-      "condition-cel-outcome", "type": "string"}], "results": [{"description": "/tmp/outputs/output/data",
-      "name": "output", "type": "string"}], "steps": [{"command": ["sh", "-c", "echo
-      $0 | tee $1\n", "Iter A: $(inputs.params.condition-cel-outcome), B: $(inputs.params.condition-cel-3-outcome)",
-      "$(results.output.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
-      "525600m"}, {"name": "condition-cel-6", "params": [{"name": "outcome", "value":
-      "$(params.condition-cel-3-outcome) + 1"}], "runAfter": ["print"], "taskRef":
-      {"apiVersion": "cel.tekton.dev/v1alpha1", "kind": "CEL", "name": "cel_condition"},
-      "timeout": "525600m"}, {"name": "condition-cel-7", "params": [{"name": "outcome",
-      "value": "$(tasks.condition-cel-6.results.outcome) < $(params.condition-cel-4-outcome)"}],
-      "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1", "kind": "CEL", "name":
-      "cel_condition"}, "timeout": "525600m"}, {"name": "recur-b", "params": [{"name":
-      "condition-cel-2-outcome", "value": "$(params.condition-cel-2-outcome)"}, {"name":
-      "condition-cel-3-outcome", "value": "$(tasks.condition-cel-6.results.outcome)"},
+      "true"}}, "params": [{"name": "condition-cel-3-outcome", "type": "string"},
+      {"name": "condition-cel-outcome", "type": "string"}], "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output", "type": "string"}], "steps": [{"command":
+      ["sh", "-c", "echo $0 | tee $1\n", "Iter A: $(inputs.params.condition-cel-outcome),
+      B: $(inputs.params.condition-cel-3-outcome)", "$(results.output.path)"], "image":
+      "alpine:3.6", "name": "main"}]}, "timeout": "525600m"}, {"name": "condition-cel-6",
+      "params": [{"name": "outcome", "value": "$(params.condition-cel-3-outcome) +
+      1"}], "runAfter": ["print"], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "condition-cel-7",
+      "params": [{"name": "outcome", "value": "$(tasks.condition-cel-6.results.outcome)
+      < $(params.condition-cel-4-outcome)"}], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "recur-b",
+      "params": [{"name": "condition-cel-2-outcome", "value": "$(params.condition-cel-2-outcome)"},
+      {"name": "condition-cel-3-outcome", "value": "$(tasks.condition-cel-6.results.outcome)"},
       {"name": "condition-cel-4-outcome", "value": "$(params.condition-cel-4-outcome)"},
       {"name": "condition-cel-5-outcome", "value": "$(params.condition-cel-5-outcome)"},
       {"name": "condition-cel-outcome", "value": "$(params.condition-cel-outcome)"},

--- a/sdk/python/tests/compiler/testdata/nested_recur_custom_task_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_custom_task_noninlined.yaml
@@ -76,21 +76,20 @@ metadata:
       "{\"name\": \"print\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"print@sha256=8bcd5db23262c19ef5c49e890dfd60507d8da6c514d628749e64239c78a27a92\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-3-outcome", "type": "string"}, {"name":
-      "condition-cel-outcome", "type": "string"}], "results": [{"description": "/tmp/outputs/output/data",
-      "name": "output", "type": "string"}], "steps": [{"command": ["sh", "-c", "echo
-      $0 | tee $1\n", "Iter A: $(inputs.params.condition-cel-outcome), B: $(inputs.params.condition-cel-3-outcome)",
-      "$(results.output.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
-      "525600m"}, {"name": "condition-cel-6", "params": [{"name": "outcome", "value":
-      "$(params.condition-cel-3-outcome) + 1"}], "runAfter": ["print"], "taskRef":
-      {"apiVersion": "cel.tekton.dev/v1alpha1", "kind": "CEL", "name": "cel_condition"},
-      "timeout": "525600m"}, {"name": "condition-cel-7", "params": [{"name": "outcome",
-      "value": "$(tasks.condition-cel-6.results.outcome) < $(params.condition-cel-4-outcome)"}],
-      "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1", "kind": "CEL", "name":
-      "cel_condition"}, "timeout": "525600m"}, {"name": "recur-b", "params": [{"name":
-      "just_one_iteration", "value": ["1"]}, {"name": "condition-cel-3-outcome", "value":
-      "$(tasks.condition-cel-6.results.outcome)"}, {"name": "condition-cel-4-outcome",
+      "true"}}, "params": [{"name": "condition-cel-3-outcome", "type": "string"},
+      {"name": "condition-cel-outcome", "type": "string"}], "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output", "type": "string"}], "steps": [{"command":
+      ["sh", "-c", "echo $0 | tee $1\n", "Iter A: $(inputs.params.condition-cel-outcome),
+      B: $(inputs.params.condition-cel-3-outcome)", "$(results.output.path)"], "image":
+      "alpine:3.6", "name": "main"}]}, "timeout": "525600m"}, {"name": "condition-cel-6",
+      "params": [{"name": "outcome", "value": "$(params.condition-cel-3-outcome) +
+      1"}], "runAfter": ["print"], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "condition-cel-7",
+      "params": [{"name": "outcome", "value": "$(tasks.condition-cel-6.results.outcome)
+      < $(params.condition-cel-4-outcome)"}], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "recur-b",
+      "params": [{"name": "just_one_iteration", "value": ["1"]}, {"name": "condition-cel-3-outcome",
+      "value": "$(tasks.condition-cel-6.results.outcome)"}, {"name": "condition-cel-4-outcome",
       "value": "$(params.condition-cel-4-outcome)"}, {"name": "condition-cel-2-outcome",
       "value": "$(params.condition-cel-2-outcome)"}, {"name": "condition-cel-5-outcome",
       "value": "$(params.condition-cel-5-outcome)"}, {"name": "condition-cel-outcome",
@@ -98,6 +97,9 @@ metadata:
       "kind": "PipelineLoop", "name": "double-recursion-test-graph-recur-b-4"}, "when":
       [{"input": "$(tasks.condition-cel-7.results.outcome)", "operator": "in", "values":
       ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: array

--- a/sdk/python/tests/compiler/testdata/nested_recur_params.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_params.yaml
@@ -76,27 +76,27 @@ metadata:
       "{\"name\": \"print\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"print@sha256=8bcd5db23262c19ef5c49e890dfd60507d8da6c514d628749e64239c78a27a92\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-3-outcome", "type": "string"}, {"name":
-      "condition-cel-outcome", "type": "string"}], "results": [{"description": "/tmp/outputs/output/data",
-      "name": "output", "type": "string"}], "steps": [{"command": ["sh", "-c", "echo
-      $0 | tee $1\n", "Iter A: $(inputs.params.condition-cel-outcome), B: $(inputs.params.condition-cel-3-outcome)",
-      "$(results.output.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
-      "525600m"}, {"name": "condition-cel-5", "params": [{"name": "outcome", "value":
-      "$(params.condition-cel-3-outcome) + 1"}], "runAfter": ["print"], "taskRef":
-      {"apiVersion": "cel.tekton.dev/v1alpha1", "kind": "CEL", "name": "cel_condition"},
-      "timeout": "525600m"}, {"name": "condition-cel-6", "params": [{"name": "outcome",
-      "value": "$(tasks.condition-cel-5.results.outcome) < $(params.until_b)"}], "taskRef":
-      {"apiVersion": "cel.tekton.dev/v1alpha1", "kind": "CEL", "name": "cel_condition"},
-      "timeout": "525600m"}, {"name": "recur-b", "params": [{"name": "condition-cel-2-outcome",
-      "value": "$(params.condition-cel-2-outcome)"}, {"name": "condition-cel-3-outcome",
-      "value": "$(tasks.condition-cel-5.results.outcome)"}, {"name": "condition-cel-4-outcome",
-      "value": "$(params.condition-cel-4-outcome)"}, {"name": "condition-cel-outcome",
-      "value": "$(params.condition-cel-outcome)"}, {"name": "just_one_iteration",
-      "value": ["1"]}, {"name": "until_b", "value": "$(params.until_b)"}], "taskRef":
-      {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name":
-      "double-recursion-test-graph-recur-b-4"}, "when": [{"input": "$(tasks.condition-cel-6.results.outcome)",
-      "operator": "in", "values": ["true"]}]}]}}}]'
+      "true"}}, "params": [{"name": "condition-cel-3-outcome", "type": "string"},
+      {"name": "condition-cel-outcome", "type": "string"}], "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output", "type": "string"}], "steps": [{"command":
+      ["sh", "-c", "echo $0 | tee $1\n", "Iter A: $(inputs.params.condition-cel-outcome),
+      B: $(inputs.params.condition-cel-3-outcome)", "$(results.output.path)"], "image":
+      "alpine:3.6", "name": "main"}]}, "timeout": "525600m"}, {"name": "condition-cel-5",
+      "params": [{"name": "outcome", "value": "$(params.condition-cel-3-outcome) +
+      1"}], "runAfter": ["print"], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "condition-cel-6",
+      "params": [{"name": "outcome", "value": "$(tasks.condition-cel-5.results.outcome)
+      < $(params.until_b)"}], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "recur-b",
+      "params": [{"name": "condition-cel-2-outcome", "value": "$(params.condition-cel-2-outcome)"},
+      {"name": "condition-cel-3-outcome", "value": "$(tasks.condition-cel-5.results.outcome)"},
+      {"name": "condition-cel-4-outcome", "value": "$(params.condition-cel-4-outcome)"},
+      {"name": "condition-cel-outcome", "value": "$(params.condition-cel-outcome)"},
+      {"name": "just_one_iteration", "value": ["1"]}, {"name": "until_b", "value":
+      "$(params.until_b)"}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1",
+      "kind": "PipelineLoop", "name": "double-recursion-test-graph-recur-b-4"}, "when":
+      [{"input": "$(tasks.condition-cel-6.results.outcome)", "operator": "in", "values":
+      ["true"]}]}]}}}]'
   labels:
     pipelines.kubeflow.org/pipelinename: ''
     pipelines.kubeflow.org/generation: ''

--- a/sdk/python/tests/compiler/testdata/nested_recur_params.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_params.yaml
@@ -97,6 +97,9 @@ metadata:
       {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name":
       "double-recursion-test-graph-recur-b-4"}, "when": [{"input": "$(tasks.condition-cel-6.results.outcome)",
       "operator": "in", "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: until_a

--- a/sdk/python/tests/compiler/testdata/nested_recur_params_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_params_noninlined.yaml
@@ -76,27 +76,29 @@ metadata:
       "{\"name\": \"print\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"print@sha256=8bcd5db23262c19ef5c49e890dfd60507d8da6c514d628749e64239c78a27a92\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "condition-cel-3-outcome", "type": "string"}, {"name":
-      "condition-cel-outcome", "type": "string"}], "results": [{"description": "/tmp/outputs/output/data",
-      "name": "output", "type": "string"}], "steps": [{"command": ["sh", "-c", "echo
-      $0 | tee $1\n", "Iter A: $(inputs.params.condition-cel-outcome), B: $(inputs.params.condition-cel-3-outcome)",
-      "$(results.output.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
-      "525600m"}, {"name": "condition-cel-5", "params": [{"name": "outcome", "value":
-      "$(params.condition-cel-3-outcome) + 1"}], "runAfter": ["print"], "taskRef":
-      {"apiVersion": "cel.tekton.dev/v1alpha1", "kind": "CEL", "name": "cel_condition"},
-      "timeout": "525600m"}, {"name": "condition-cel-6", "params": [{"name": "outcome",
-      "value": "$(tasks.condition-cel-5.results.outcome) < $(params.until_b)"}], "taskRef":
-      {"apiVersion": "cel.tekton.dev/v1alpha1", "kind": "CEL", "name": "cel_condition"},
-      "timeout": "525600m"}, {"name": "recur-b", "params": [{"name": "just_one_iteration",
-      "value": ["1"]}, {"name": "condition-cel-3-outcome", "value": "$(tasks.condition-cel-5.results.outcome)"},
-      {"name": "until_b", "value": "$(params.until_b)"}, {"name": "condition-cel-2-outcome",
-      "value": "$(params.condition-cel-2-outcome)"}, {"name": "condition-cel-4-outcome",
-      "value": "$(params.condition-cel-4-outcome)"}, {"name": "condition-cel-outcome",
-      "value": "$(params.condition-cel-outcome)"}], "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1",
-      "kind": "PipelineLoop", "name": "double-recursion-test-graph-recur-b-4"}, "when":
-      [{"input": "$(tasks.condition-cel-6.results.outcome)", "operator": "in", "values":
-      ["true"]}]}]}}}]'
+      "true"}}, "params": [{"name": "condition-cel-3-outcome", "type": "string"},
+      {"name": "condition-cel-outcome", "type": "string"}], "results": [{"description":
+      "/tmp/outputs/output/data", "name": "output", "type": "string"}], "steps": [{"command":
+      ["sh", "-c", "echo $0 | tee $1\n", "Iter A: $(inputs.params.condition-cel-outcome),
+      B: $(inputs.params.condition-cel-3-outcome)", "$(results.output.path)"], "image":
+      "alpine:3.6", "name": "main"}]}, "timeout": "525600m"}, {"name": "condition-cel-5",
+      "params": [{"name": "outcome", "value": "$(params.condition-cel-3-outcome) +
+      1"}], "runAfter": ["print"], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "condition-cel-6",
+      "params": [{"name": "outcome", "value": "$(tasks.condition-cel-5.results.outcome)
+      < $(params.until_b)"}], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "recur-b",
+      "params": [{"name": "just_one_iteration", "value": ["1"]}, {"name": "condition-cel-3-outcome",
+      "value": "$(tasks.condition-cel-5.results.outcome)"}, {"name": "until_b", "value":
+      "$(params.until_b)"}, {"name": "condition-cel-2-outcome", "value": "$(params.condition-cel-2-outcome)"},
+      {"name": "condition-cel-4-outcome", "value": "$(params.condition-cel-4-outcome)"},
+      {"name": "condition-cel-outcome", "value": "$(params.condition-cel-outcome)"}],
+      "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop",
+      "name": "double-recursion-test-graph-recur-b-4"}, "when": [{"input": "$(tasks.condition-cel-6.results.outcome)",
+      "operator": "in", "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: until_a

--- a/sdk/python/tests/compiler/testdata/nested_recur_runafter.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_runafter.yaml
@@ -45,16 +45,14 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print\", \"outputs\": [], \"version\": \"print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m"}, {"name": "flip-coin-3", "runAfter": ["print-2"],
-      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m"}, {"name": "flip-coin-3", "runAfter":
+      ["print-2"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -62,11 +60,11 @@ metadata:
       "operator": "in", "values": ["true"]}]}, {"name": "condition-4", "params": [{"name":
       "operand1", "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value":
       "tails"}, {"name": "operator", "value": "=="}], "runAfter": [], "taskSpec":
-      {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
-      "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "operand1",
-      "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
-      "type": "string"}], "results": [{"description": "Conditional task outcome",
-      "name": "outcome", "type": "string"}], "steps": [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
+      {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled": "true"}}, "params":
+      [{"name": "operand1", "type": "string"}, {"name": "operand2", "type": "string"},
+      {"name": "operator", "type": "string"}], "results": [{"description": "Conditional
+      task outcome", "name": "outcome", "type": "string"}], "steps": [{"args": ["import
+      sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
       if (input1 $(inputs.params.operator) input2) else \"false\"\nf = open(\"/tekton/results/outcome\",
       \"w\")\nf.write(outcome)\nf.close()\n", "$(inputs.params.operand1)", "$(inputs.params.operand2)"],
       "command": ["sh", "-ec", "program_path=$(mktemp); printf \"%s\" \"$0\" > \"$program_path\";  python3
@@ -90,17 +88,15 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"print\", \"outputs\": [], \"version\": \"print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-3.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-3.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-2", "runAfter":
       ["print"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -108,8 +104,7 @@ metadata:
       "operator": "in", "values": ["true"]}]}, {"name": "condition-3", "params": [{"name":
       "operand1", "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value":
       "heads"}, {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
-      "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "operand1",
+      {"pipelines.kubeflow.org/cache_enabled": "true"}}, "params": [{"name": "operand1",
       "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
       "type": "string"}], "results": [{"description": "Conditional task outcome",
       "name": "outcome", "type": "string"}], "steps": [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
@@ -154,8 +149,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d"}'
@@ -177,8 +170,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d"}'

--- a/sdk/python/tests/compiler/testdata/nested_recur_runafter.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_runafter.yaml
@@ -123,6 +123,9 @@ metadata:
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name": "nested-recursion-pipeline-ip-component-b-2"},
       "when": [{"input": "$(tasks.condition-3.results.outcome)", "operator": "in",
       "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -150,9 +153,9 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d"}'
@@ -173,9 +176,9 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d"}'

--- a/sdk/python/tests/compiler/testdata/nested_recur_runafter_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_runafter_noninlined.yaml
@@ -45,16 +45,14 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print\", \"outputs\": [], \"version\": \"print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m"}, {"name": "flip-coin-3", "runAfter": ["print-2"],
-      "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m"}, {"name": "flip-coin-3", "runAfter":
+      ["print-2"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -89,17 +87,15 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"print\", \"outputs\": [], \"version\": \"print@sha256=6094ad4b5bb22e7370e9532a47f8e1f4e78cf8916f98b5f06817fc6140285c4d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-3.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-3.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-2", "runAfter":
       ["print"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -121,6 +117,9 @@ metadata:
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name": "nested-recursion-pipeline-ip-component-b-2"},
       "when": [{"input": "$(tasks.condition-3.results.outcome)", "operator": "in",
       "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -148,8 +147,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
@@ -171,8 +168,6 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with Node Selector",
       "name": "node-selector"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -43,8 +46,6 @@ spec:
           image: busybox
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/node_selector_from_pipeline.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector_from_pipeline.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with Node Selector",
       "name": "node-selector"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -43,8 +46,6 @@ spec:
           image: busybox
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/node_selector_from_pipeline_override.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector_from_pipeline_override.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with Node Selector",
       "name": "node-selector"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -43,8 +46,6 @@ spec:
           image: busybox
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/parallel_join.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join.yaml
@@ -34,6 +34,9 @@ metadata:
       in parallel and prints the concatenated result.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url1", "optional": true, "type": "String"}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
       "name": "url2", "optional": true, "type": "String"}], "name": "parallel-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: url1
@@ -71,8 +74,6 @@ spec:
           description: /tmp/outputs/data/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "gcs-download",
@@ -103,8 +104,6 @@ spec:
           description: /tmp/outputs/data/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "gcs-download",
@@ -134,8 +133,6 @@ spec:
         - name: gcs-download-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
@@ -35,6 +35,9 @@ metadata:
       [{"default": "gs://ml-pipeline-playground/shakespeare1.txt", "name": "url1",
       "optional": true, "type": "String"}, {"default": "gs://ml-pipeline-playground/shakespeare2.txt",
       "name": "url2", "optional": true, "type": "String"}], "name": "parallel-pipeline-with-argo-vars"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: url1
@@ -72,8 +75,6 @@ spec:
           description: /tmp/outputs/data/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "gcs-download",
@@ -104,8 +105,6 @@ spec:
           description: /tmp/outputs/data/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "gcs-download",
@@ -144,8 +143,6 @@ spec:
         - name: pipelineRun-uid
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -41,6 +41,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "parallelfor-item-argument-resolving"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -98,9 +101,9 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce str",
               "outputs": [{"name": "Output", "type": "String"}], "version": "Produce
@@ -170,9 +173,9 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list
               of strings", "outputs": [{"name": "Output", "type": "JsonArray"}], "version":
@@ -242,9 +245,9 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list
               of ints", "outputs": [{"name": "Output", "type": "JsonArray"}], "version":
@@ -314,9 +317,9 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list
               of dicts", "outputs": [{"name": "Output", "type": "JsonArray"}], "version":
@@ -380,9 +383,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -421,9 +424,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -462,9 +465,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -528,9 +531,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -569,9 +572,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -635,9 +638,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -676,9 +679,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -102,8 +102,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce str",
               "outputs": [{"name": "Output", "type": "String"}], "version": "Produce
@@ -174,8 +172,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list
               of strings", "outputs": [{"name": "Output", "type": "JsonArray"}], "version":
@@ -246,8 +242,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list
               of ints", "outputs": [{"name": "Output", "type": "JsonArray"}], "version":
@@ -318,8 +312,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list
               of dicts", "outputs": [{"name": "Output", "type": "JsonArray"}], "version":
@@ -384,8 +376,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -425,8 +415,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -466,8 +454,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -476,8 +462,6 @@ spec:
           iterateParam: produce-list-of-strings-Output-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
     - runAfter:
       - produce-list-of-ints
@@ -532,8 +516,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -573,8 +555,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -583,8 +563,6 @@ spec:
           iterateParam: produce-list-of-ints-Output-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
     - runAfter:
       - produce-list-of-dicts
@@ -639,8 +617,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -680,8 +656,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "Consume",
                       "outputs": [], "version": "Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da"}'
@@ -690,7 +664,5 @@ spec:
           iterateParam: produce-list-of-dicts-Output-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving_noninlined.yaml
@@ -51,8 +51,7 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"Consume\", \"outputs\": [], \"version\": \"Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-list-of-strings-Output", "type": "string"}],
+      "true"}}, "params": [{"name": "produce-list-of-strings-Output", "type": "string"}],
       "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-strings-Output)"],
       "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
       -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
@@ -64,8 +63,7 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"Consume\", \"outputs\": [], \"version\": \"Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-list-of-strings-Output-loop-item", "type":
+      "true"}}, "params": [{"name": "produce-list-of-strings-Output-loop-item", "type":
       "string"}], "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-strings-Output-loop-item)"],
       "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
       -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
@@ -77,8 +75,7 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"Consume\", \"outputs\": [], \"version\": \"Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-str-Output", "type": "string"}], "steps":
+      "true"}}, "params": [{"name": "produce-str-Output", "type": "string"}], "steps":
       [{"args": ["--param1", "$(inputs.params.produce-str-Output)"], "command": ["sh",
       "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
       -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
@@ -94,8 +91,7 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"Consume\", \"outputs\": [], \"version\": \"Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-list-of-ints-Output", "type": "string"}],
+      "true"}}, "params": [{"name": "produce-list-of-ints-Output", "type": "string"}],
       "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-ints-Output)"],
       "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
       -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
@@ -107,9 +103,8 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"Consume\", \"outputs\": [], \"version\": \"Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-list-of-ints-Output-loop-item", "type": "string"}],
-      "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-ints-Output-loop-item)"],
+      "true"}}, "params": [{"name": "produce-list-of-ints-Output-loop-item", "type":
+      "string"}], "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-ints-Output-loop-item)"],
       "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
       -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
       argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
@@ -125,8 +120,7 @@ metadata:
       {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"Consume\", \"outputs\":
       [], \"version\": \"Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-list-of-dicts-Output", "type": "string"}],
+      "true"}}, "params": [{"name": "produce-list-of-dicts-Output", "type": "string"}],
       "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-dicts-Output)"],
       "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
       -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
@@ -139,8 +133,7 @@ metadata:
       {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"Consume\", \"outputs\": [], \"version\": \"Consume@sha256=81237bf045292d631ce2f9d982637189181ba23abe552f8bf048b87322d6b5da\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "produce-list-of-dicts-Output-loop-item-subvar-aaa",
+      "true"}}, "params": [{"name": "produce-list-of-dicts-Output-loop-item-subvar-aaa",
       "type": "string"}], "steps": [{"args": ["--param1", "$(inputs.params.produce-list-of-dicts-Output-loop-item-subvar-aaa)"],
       "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
       -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
@@ -148,6 +141,9 @@ metadata:
       dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
       = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"], "image":
       "python:3.7", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -205,8 +201,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce str",
@@ -277,8 +271,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list
@@ -349,8 +341,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list
@@ -421,8 +411,6 @@ spec:
           description: /tmp/outputs/Output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Produce list

--- a/sdk/python/tests/compiler/testdata/param_same_prefix.yaml
+++ b/sdk/python/tests/compiler/testdata/param_same_prefix.yaml
@@ -118,8 +118,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-10", "outputs":
               [{"name": "bar-10-val", "type": "String"}], "version": "foo-10@sha256=d6d62cb6c6b77d1f0d609f5f5f2e0827d16f80de51fdfa5bde09e631fb759995"}'
@@ -148,8 +146,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-11", "outputs":
               [{"name": "foo-11-val", "type": "String"}], "version": "foo-11@sha256=377008435f70950b0bc568837051eb5d49375b55d1105eb7bc9c4f7863c336a3"}'
@@ -178,8 +174,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-12", "outputs":
               [{"name": "foo-12", "type": "String"}], "version": "foo-12@sha256=ce03e07a304a0a53f19878261cbde059912689fd90a0a68b61aa0821e6201480"}'
@@ -255,8 +249,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "fetch-00",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -289,8 +281,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "fetch-01",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -323,8 +313,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "fetch-02",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -357,8 +345,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-10",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -391,8 +377,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-11",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -425,8 +409,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-12",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -436,7 +418,5 @@ spec:
           iterateParam: li-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/param_same_prefix.yaml
+++ b/sdk/python/tests/compiler/testdata/param_same_prefix.yaml
@@ -53,6 +53,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"name": "foo", "type": "String"},
       {"default": "[1, 2, 3]", "name": "li", "optional": true, "type": "JsonArray"}],
       "name": "prefixes"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: foo
@@ -114,9 +117,9 @@ spec:
           description: /tmp/outputs/bar-10-val/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-10", "outputs":
               [{"name": "bar-10-val", "type": "String"}], "version": "foo-10@sha256=d6d62cb6c6b77d1f0d609f5f5f2e0827d16f80de51fdfa5bde09e631fb759995"}'
@@ -144,9 +147,9 @@ spec:
           description: /tmp/outputs/foo-11-val/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-11", "outputs":
               [{"name": "foo-11-val", "type": "String"}], "version": "foo-11@sha256=377008435f70950b0bc568837051eb5d49375b55d1105eb7bc9c4f7863c336a3"}'
@@ -174,9 +177,9 @@ spec:
           description: /tmp/outputs/foo-12/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-12", "outputs":
               [{"name": "foo-12", "type": "String"}], "version": "foo-12@sha256=ce03e07a304a0a53f19878261cbde059912689fd90a0a68b61aa0821e6201480"}'
@@ -251,9 +254,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "fetch-00",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -285,9 +288,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "fetch-01",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -319,9 +322,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "fetch-02",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -353,9 +356,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-10",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -387,9 +390,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-11",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":
@@ -421,9 +424,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print-12",
                       "outputs": [{"name": "output_value", "type": "String"}], "version":

--- a/sdk/python/tests/compiler/testdata/param_same_prefix_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/param_same_prefix_noninlined.yaml
@@ -65,8 +65,7 @@ metadata:
       "{\"name\": \"fetch-00\", \"outputs\": [{\"name\": \"output_value\", \"type\":
       \"String\"}], \"version\": \"fetch-00@sha256=7e9b72ed3ff0fe01739d5c1882d0398713f844d5b40d856da78cd272aa29224e\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "foo-00-bar-00-val", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "foo-00-bar-00-val", "type": "string"}], "results":
       [{"description": "/tmp/outputs/output_value/data", "name": "output-value", "type":
       "string"}], "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "$(inputs.params.foo-00-bar-00-val)",
       "$(results.output-value.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
@@ -75,8 +74,7 @@ metadata:
       "{\"name\": \"fetch-01\", \"outputs\": [{\"name\": \"output_value\", \"type\":
       \"String\"}], \"version\": \"fetch-01@sha256=aabda0027c4968f5bd77ca09283a4d6893a7cc0f24aba3c8ed3e736a189664c2\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "foo-01-foo-01-val", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "foo-01-foo-01-val", "type": "string"}], "results":
       [{"description": "/tmp/outputs/output_value/data", "name": "output-value", "type":
       "string"}], "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "$(inputs.params.foo-01-foo-01-val)",
       "$(results.output-value.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
@@ -85,18 +83,16 @@ metadata:
       "{\"name\": \"fetch-02\", \"outputs\": [{\"name\": \"output_value\", \"type\":
       \"String\"}], \"version\": \"fetch-02@sha256=50fd399aa3779cb4c5b268102fb26755c28079d262e8b96e13e1fc204d69b921\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "foo-02-foo-02", "type": "string"}], "results": [{"description":
-      "/tmp/outputs/output_value/data", "name": "output-value", "type": "string"}],
-      "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "$(inputs.params.foo-02-foo-02)",
+      "true"}}, "params": [{"name": "foo-02-foo-02", "type": "string"}], "results":
+      [{"description": "/tmp/outputs/output_value/data", "name": "output-value", "type":
+      "string"}], "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "$(inputs.params.foo-02-foo-02)",
       "$(results.output-value.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
       "525600m"}, {"name": "print-10", "params": [{"name": "foo-10-bar-10-val", "value":
       "$(params.foo-10-bar-10-val)"}], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print-10\", \"outputs\": [{\"name\": \"output_value\", \"type\":
       \"String\"}], \"version\": \"print-10@sha256=d9ea1c895144dfa19d7e457987bdf79548809f7b45af8ae4560998c99e193751\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "foo-10-bar-10-val", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "foo-10-bar-10-val", "type": "string"}], "results":
       [{"description": "/tmp/outputs/output_value/data", "name": "output-value", "type":
       "string"}], "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "$(inputs.params.foo-10-bar-10-val)",
       "$(results.output-value.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
@@ -105,8 +101,7 @@ metadata:
       "{\"name\": \"print-11\", \"outputs\": [{\"name\": \"output_value\", \"type\":
       \"String\"}], \"version\": \"print-11@sha256=5a1013995ecd3285d03ae6b24d872d3d1ca1eaf7c78d099eca050a3ce9e3fd83\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "foo-11-foo-11-val", "type": "string"}], "results":
+      "true"}}, "params": [{"name": "foo-11-foo-11-val", "type": "string"}], "results":
       [{"description": "/tmp/outputs/output_value/data", "name": "output-value", "type":
       "string"}], "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "$(inputs.params.foo-11-foo-11-val)",
       "$(results.output-value.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
@@ -115,12 +110,14 @@ metadata:
       "{\"name\": \"print-12\", \"outputs\": [{\"name\": \"output_value\", \"type\":
       \"String\"}], \"version\": \"print-12@sha256=8c34161acc91f4c5e394f75aeffd0a793db16e196aa8a246c0c26bd2336c54e6\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "foo-12-foo-12", "type": "string"}], "results": [{"description":
-      "/tmp/outputs/output_value/data", "name": "output-value", "type": "string"}],
-      "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "$(inputs.params.foo-12-foo-12)",
+      "true"}}, "params": [{"name": "foo-12-foo-12", "type": "string"}], "results":
+      [{"description": "/tmp/outputs/output_value/data", "name": "output-value", "type":
+      "string"}], "steps": [{"command": ["sh", "-c", "set -e\necho $0 > $1\n", "$(inputs.params.foo-12-foo-12)",
       "$(results.output-value.path)"], "image": "alpine:3.6", "name": "main"}]}, "timeout":
       "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: foo
@@ -182,8 +179,6 @@ spec:
           description: /tmp/outputs/bar-10-val/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-10", "outputs":
@@ -212,8 +207,6 @@ spec:
           description: /tmp/outputs/foo-11-val/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-11", "outputs":
@@ -242,8 +235,6 @@ spec:
           description: /tmp/outputs/foo-12/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "foo-12", "outputs":

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline shows how
       to apply functions to all ops in the pipeline by pipeline transformers", "name":
       "pipeline-transformer"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -42,8 +45,6 @@ spec:
         metadata:
           labels:
             hobby: football
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             hobby: football
@@ -62,8 +63,6 @@ spec:
         metadata:
           labels:
             hobby: football
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             hobby: football

--- a/sdk/python/tests/compiler/testdata/pipelineparam_env.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparam_env.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "echo pipeline", "inputs":
       [{"default": "80", "name": "port_number", "optional": true}], "name": "echo"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: port_number
@@ -56,8 +59,6 @@ spec:
         - name: port_number
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             tekton.dev/template: ''

--- a/sdk/python/tests/compiler/testdata/pipelineparams.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.yaml
@@ -32,6 +32,9 @@ metadata:
       pipeline params.", "inputs": [{"default": "latest", "name": "tag", "optional":
       true, "type": "String"}, {"default": "10", "name": "sleep_ms", "optional": true,
       "type": "Integer"}], "name": "pipeline-params"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: sleep_ms
@@ -72,8 +75,6 @@ spec:
           description: /tmp/outputs/data/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "download", "outputs":
@@ -102,8 +103,6 @@ spec:
         - name: download-data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/recur_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested.yaml
@@ -45,17 +45,15 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print\", \"outputs\": [], \"version\": \"print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-5.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-5.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-3", "runAfter":
       ["print-2"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -63,8 +61,7 @@ metadata:
       "operator": "in", "values": ["true"]}]}, {"name": "condition-2", "params": [{"name":
       "operand1", "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value":
       "heads"}, {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
-      "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "operand1",
+      {"pipelines.kubeflow.org/cache_enabled": "true"}}, "params": [{"name": "operand1",
       "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
       "type": "string"}], "results": [{"description": "Conditional task outcome",
       "name": "outcome", "type": "string"}], "steps": [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
@@ -75,8 +72,7 @@ metadata:
       {"name": "condition-5", "params": [{"name": "operand1", "value": "$(params.flip-coin-output)"},
       {"name": "operand2", "value": "tails"}, {"name": "operator", "value": "=="}],
       "taskSpec": {"metadata": {"labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
+      "true"}}, "params": [{"name": "operand1", "type": "string"}, {"name": "operand2",
       "type": "string"}, {"name": "operator", "type": "string"}], "results": [{"description":
       "Conditional task outcome", "name": "outcome", "type": "string"}], "steps":
       [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
@@ -104,17 +100,15 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print\", \"outputs\": [], \"version\": \"print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-4.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-4.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-2", "runAfter":
       ["print"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -122,8 +116,7 @@ metadata:
       "operator": "in", "values": ["true"]}]}, {"name": "condition-4", "params": [{"name":
       "operand1", "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value":
       "heads"}, {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
-      "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "operand1",
+      {"pipelines.kubeflow.org/cache_enabled": "true"}}, "params": [{"name": "operand1",
       "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
       "type": "string"}], "results": [{"description": "Conditional task outcome",
       "name": "outcome", "type": "string"}], "steps": [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
@@ -168,8 +161,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d"}'
@@ -191,8 +182,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c"}'

--- a/sdk/python/tests/compiler/testdata/recur_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested.yaml
@@ -137,6 +137,9 @@ metadata:
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name": "nested-recursion-pipeline-ip-component-b-3"},
       "when": [{"input": "$(tasks.condition-4.results.outcome)", "operator": "in",
       "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -164,9 +167,9 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d"}'
@@ -187,9 +190,9 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c"}'

--- a/sdk/python/tests/compiler/testdata/recur_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested_noninlined.yaml
@@ -45,17 +45,15 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print\", \"outputs\": [], \"version\": \"print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-5.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-5.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-3", "runAfter":
       ["print-2"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -101,17 +99,15 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print\", \"outputs\": [], \"version\": \"print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-4.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-4.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-2", "runAfter":
       ["print"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -133,6 +129,9 @@ metadata:
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name": "nested-recursion-pipeline-ip-component-b-3"},
       "when": [{"input": "$(tasks.condition-4.results.outcome)", "operator": "in",
       "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -160,8 +159,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
@@ -183,8 +180,6 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/recur_nested_separate.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested_separate.yaml
@@ -36,6 +36,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use graph_component
       and nested recursion.", "inputs": [{"default": "12", "name": "maxVal", "optional":
       true, "type": "Integer"}], "name": "nested-recursion-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -63,9 +66,9 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d"}'
@@ -86,9 +89,9 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c"}'

--- a/sdk/python/tests/compiler/testdata/recur_nested_separate.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested_separate.yaml
@@ -67,8 +67,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d"}'
@@ -90,8 +88,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c"}'

--- a/sdk/python/tests/compiler/testdata/recursion_while.yaml
+++ b/sdk/python/tests/compiler/testdata/recursion_while.yaml
@@ -43,17 +43,15 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print\", \"outputs\": [], \"version\": \"print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-2", "runAfter":
       ["print"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -61,8 +59,7 @@ metadata:
       "operator": "in", "values": ["true"]}]}, {"name": "condition-2", "params": [{"name":
       "operand1", "value": "$(params.flip-coin-output)"}, {"name": "operand2", "value":
       "heads"}, {"name": "operator", "value": "=="}], "taskSpec": {"metadata": {"labels":
-      {"pipelines.kubeflow.org/cache_enabled": "true", "pipelines.kubeflow.org/generation":
-      "", "pipelines.kubeflow.org/pipelinename": ""}}, "params": [{"name": "operand1",
+      {"pipelines.kubeflow.org/cache_enabled": "true"}}, "params": [{"name": "operand1",
       "type": "string"}, {"name": "operand2", "type": "string"}, {"name": "operator",
       "type": "string"}], "results": [{"description": "Conditional task outcome",
       "name": "outcome", "type": "string"}], "steps": [{"args": ["import sys\ninput1=str.rstrip(sys.argv[1])\ninput2=str.rstrip(sys.argv[2])\ntry:\n  input1=int(input1)\n  input2=int(input2)\nexcept:\n  input1=str(input1)\noutcome=\"true\"
@@ -107,8 +104,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d"}'
@@ -130,8 +125,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c"}'

--- a/sdk/python/tests/compiler/testdata/recursion_while.yaml
+++ b/sdk/python/tests/compiler/testdata/recursion_while.yaml
@@ -76,6 +76,9 @@ metadata:
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name": "recursion-pipeline-flip-component-1"},
       "when": [{"input": "$(tasks.condition-2.results.outcome)", "operator": "in",
       "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -103,9 +106,9 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
               [{"name": "output", "type": "String"}], "version": "flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d"}'
@@ -126,9 +129,9 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":
               [], "version": "print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c"}'

--- a/sdk/python/tests/compiler/testdata/recursion_while_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/recursion_while_noninlined.yaml
@@ -43,17 +43,15 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"print\", \"outputs\": [], \"version\": \"print@sha256=8232f0c48ead41f53f1c61e3c35a4d3440cdd0591ab17933736e5ed7c8390d5c\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps": [{"command":
-      ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6", "name":
-      "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
+      "true"}}, "params": [{"name": "flip-coin-output", "type": "string"}], "steps":
+      [{"command": ["echo", "$(inputs.params.flip-coin-output)"], "image": "alpine:3.6",
+      "name": "main"}]}, "timeout": "525600m", "when": [{"input": "$(tasks.condition-2.results.outcome)",
       "operator": "in", "values": ["true"]}]}, {"name": "flip-coin-2", "runAfter":
       ["print"], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"flip-coin\", \"outputs\": [{\"name\": \"output\", \"type\": \"String\"}],
       \"version\": \"flip-coin@sha256=1989ae83915edcd7253e495603317c1f99196f5ef2b0bacb31a0273d941e830d\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
+      "true"}}, "results": [{"description": "/tmp/outputs/output/data", "name": "output",
       "type": "string"}], "steps": [{"args": ["python -c \"import random; result =
       ''heads'' if random.randint(0,1) == 0           else ''tails''; print(result)\"
       | tee $0\n", "$(results.output.path)"], "command": ["sh", "-c"], "image": "python:alpine3.6",
@@ -75,6 +73,9 @@ metadata:
       "custom.tekton.dev/v1alpha1", "kind": "PipelineLoop", "name": "recursion-pipeline-flip-component-1"},
       "when": [{"input": "$(tasks.condition-2.results.outcome)", "operator": "in",
       "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: maxVal
@@ -102,8 +103,6 @@ spec:
           description: /tmp/outputs/output/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
@@ -125,8 +124,6 @@ spec:
         - name: flip-coin-output
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A Basic Example on ResourceOp
       Usage.", "name": "resourceop-basic"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -123,8 +126,6 @@ spec:
           description: '{.metadata.name}'
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             tekton.dev/template: ''

--- a/sdk/python/tests/compiler/testdata/retry.yaml
+++ b/sdk/python/tests/compiler/testdata/retry.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "The pipeline includes
       two steps which fail randomly. It shows how to use ContainerOp(...).set_retry(...).",
       "name": "retry-random-failures"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -45,8 +48,6 @@ spec:
           image: python:alpine3.6
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "random-failure",
@@ -68,8 +69,6 @@ spec:
           image: python:alpine3.6
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "random-failure",

--- a/sdk/python/tests/compiler/testdata/separator_from_param.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_param.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "a,b,c", "name":
       "text", "optional": true, "type": "String"}, {"default": ",", "name": "separator",
       "optional": true, "type": "String"}], "name": "separator-from-param"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: separator
@@ -76,9 +79,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print",
                       "outputs": [{"description": "Represents an output paramter.",

--- a/sdk/python/tests/compiler/testdata/separator_from_param.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_param.yaml
@@ -80,8 +80,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -92,7 +90,5 @@ spec:
           iterateParamStringSeparator: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/separator_from_param_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_param_noninlined.yaml
@@ -38,11 +38,13 @@ metadata:
       paramter.\", \"name\": \"output_value\", \"type\": \"String\"}], \"version\":
       \"print@sha256=c6e88bb19253b3bedeb9912855f4e324700cd80285e6b625b9ebcffb58677766\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
+      "true"}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
       "output-value", "type": "string"}], "steps": [{"command": ["sh", "-c", "set
       -e\necho $0 > $1\n", "print", "$(results.output-value.path)"], "image": "alpine:3.6",
       "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: separator

--- a/sdk/python/tests/compiler/testdata/separator_from_task.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_task.yaml
@@ -58,8 +58,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "text", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -86,8 +84,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "separator", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -129,8 +125,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print",
                       "outputs": [{"description": "Represents an output paramter.",
@@ -141,7 +135,5 @@ spec:
           iterateParamStringSeparator: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/separator_from_task.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_task.yaml
@@ -32,6 +32,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "separator-from-task"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -54,9 +57,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "text", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -82,9 +85,9 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "separator", "outputs":
               [{"description": "Represents an output paramter.", "name": "output_value",
@@ -125,9 +128,9 @@ spec:
                   description: /tmp/outputs/output_value/data
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "print",
                       "outputs": [{"description": "Represents an output paramter.",

--- a/sdk/python/tests/compiler/testdata/separator_from_task_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_task_noninlined.yaml
@@ -41,11 +41,13 @@ metadata:
       [{\"description\": \"Represents an output paramter.\", \"name\": \"output_value\",
       \"type\": \"String\"}], \"version\": \"print@sha256=c6e88bb19253b3bedeb9912855f4e324700cd80285e6b625b9ebcffb58677766\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
+      "true"}}, "results": [{"description": "/tmp/outputs/output_value/data", "name":
       "output-value", "type": "string"}], "steps": [{"command": ["sh", "-c", "set
       -e\necho $0 > $1\n", "print", "$(results.output-value.path)"], "image": "alpine:3.6",
       "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -68,8 +70,6 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "text", "outputs":
@@ -96,8 +96,6 @@ spec:
           description: /tmp/outputs/output_value/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "separator", "outputs":

--- a/sdk/python/tests/compiler/testdata/sequential.yaml
+++ b/sdk/python/tests/compiler/testdata/sequential.yaml
@@ -30,6 +30,9 @@ metadata:
       steps.", "inputs": [{"default": "gs://ml-pipeline-playground/shakespeare1.txt",
       "name": "url", "optional": true, "type": "String"}, {"default": "/tmp/results.txt",
       "name": "path", "optional": true, "type": "String"}], "name": "sequential-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: path
@@ -67,8 +70,6 @@ spec:
           description: /tmp/outputs/data/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "gcs-download",
@@ -93,8 +94,6 @@ spec:
         - name: path
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/set_display_name.yaml
+++ b/sdk/python/tests/compiler/testdata/set_display_name.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "echo pipeline", "name":
       "set-display-name"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -43,8 +46,6 @@ spec:
           image: busybox
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/task_display_name: Hello World

--- a/sdk/python/tests/compiler/testdata/sidecar.yaml
+++ b/sdk/python/tests/compiler/testdata/sidecar.yaml
@@ -30,6 +30,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with sidecars.",
       "name": "sidecar"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -51,8 +54,6 @@ spec:
           description: /tmp/outputs/download/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "download", "outputs":
@@ -77,8 +78,6 @@ spec:
         - name: download-download
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/tekton_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_custom_task.yaml
@@ -33,6 +33,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use Tekton
       custom task with KFP", "name": "tekton-custom-task-on-kubeflow-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -54,8 +57,6 @@ spec:
           description: /tmp/outputs/output_result/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
@@ -80,8 +81,6 @@ spec:
           description: /tmp/outputs/output_result/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "flip-coin", "outputs":
@@ -112,8 +111,6 @@ spec:
         - name: condition-cel-outcome
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "print", "outputs":

--- a/sdk/python/tests/compiler/testdata/tekton_loop_dsl.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_loop_dsl.yaml
@@ -83,8 +83,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -114,7 +112,5 @@ spec:
           iterateParam: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/tekton_loop_dsl.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_loop_dsl.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "my_pipe_param",
       "optional": true, "type": "Integer"}], "name": "my-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -79,9 +82,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'

--- a/sdk/python/tests/compiler/testdata/tekton_loop_dsl_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_loop_dsl_noninlined.yaml
@@ -36,17 +36,19 @@ metadata:
       "$(params.my_pipe_param)"}], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
-      "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"], "command":
-      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
-      "525600m"}, {"name": "condition-cel", "params": [{"name": "outcome", "value":
-      "$(params.loop-item-param-1) == 1"}], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\"
+      \"$1\"\n", "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"],
+      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
+      "timeout": "525600m"}, {"name": "condition-cel", "params": [{"name": "outcome",
+      "value": "$(params.loop-item-param-1) == 1"}], "taskRef": {"apiVersion": "cel.tekton.dev/v1alpha1",
       "kind": "CEL", "name": "cel_condition"}, "timeout": "525600m"}, {"name": "pipelineloop-break-operation",
       "taskRef": {"apiVersion": "custom.tekton.dev/v1alpha1", "kind": "BreakTask",
       "name": "pipelineloop-break-operation"}, "timeout": "525600m", "when": [{"input":
       "$(tasks.condition-cel.results.outcome)", "operator": "in", "values": ["true"]}]}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.yaml
@@ -31,6 +31,8 @@ metadata:
   labels:
     test: label
     test2: label2
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -47,8 +49,6 @@ spec:
           image: busybox
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout.yaml
@@ -27,6 +27,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "shows how to use ContainerOp
       set_timeout().", "name": "pipeline-includes-two-steps-which-fail-randomly"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -44,8 +47,6 @@ spec:
           image: python:alpine3.6
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "random-failure",
@@ -66,8 +67,6 @@ spec:
           image: python:alpine3.6
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "random-failure",

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with tolerations",
       "name": "tolerations"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -49,8 +52,6 @@ spec:
           description: /tmp/outputs/downloaded/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "download", "outputs":

--- a/sdk/python/tests/compiler/testdata/volume.yaml
+++ b/sdk/python/tests/compiler/testdata/volume.yaml
@@ -30,6 +30,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A pipeline with volume.",
       "name": "volume"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -64,8 +67,6 @@ spec:
             secretName: user-gcp-sa
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "download", "outputs":
@@ -92,8 +93,6 @@ spec:
         - name: download-downloaded
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":

--- a/sdk/python/tests/compiler/testdata/volume_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_op.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"description": "A Basic Example on VolumeOp
       Usage.", "inputs": [{"default": "10M", "name": "size", "optional": true, "type":
       "String"}], "name": "volumeop-basic"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: size
@@ -123,8 +126,6 @@ spec:
           description: '{.status.capacity.storage}'
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             tekton.dev/template: ''
@@ -153,8 +154,6 @@ spec:
             claimName: $(inputs.params.create-pvc-name)
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "cop", "outputs":

--- a/sdk/python/tests/compiler/testdata/withitem_multi_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_multi_nested.yaml
@@ -98,8 +98,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=7da1ee1a43a4ddb0a66d5603e5a1f097b9d88d4602cdbd92637408a6278ce663"}'
@@ -127,8 +125,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop2",
                       "outputs": [], "version": "my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe"}'
@@ -190,8 +186,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-inner-inner-coop", "outputs": [], "version": "my-inner-inner-coop@sha256=e09082c663a9e1fc40f3b14bfbdd8d0174e6bc6391e6ab334383e3edca20d8dd"}'
@@ -249,8 +243,6 @@ spec:
                                 metadata:
                                   labels:
                                     pipelines.kubeflow.org/cache_enabled: "true"
-                                    pipelines.kubeflow.org/pipelinename: ''
-                                    pipelines.kubeflow.org/generation: ''
                                   annotations:
                                     pipelines.kubeflow.org/component_spec_digest: '{"name":
                                       "my-inner-inner-coop", "outputs": [], "version":
@@ -301,8 +293,6 @@ spec:
                                         metadata:
                                           labels:
                                             pipelines.kubeflow.org/cache_enabled: "true"
-                                            pipelines.kubeflow.org/pipelinename: ''
-                                            pipelines.kubeflow.org/generation: ''
                                           annotations:
                                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                                               "my-inner-inner-coop", "outputs": [],
@@ -312,25 +302,17 @@ spec:
                                   iterateParam: my_pipe_param3-loop-item
                                 metadata:
                                   labels:
-                                    pipelines.kubeflow.org/pipelinename: ''
-                                    pipelines.kubeflow.org/generation: ''
                                     pipelines.kubeflow.org/cache_enabled: "true"
                           iterateParam: loop-item-param-4
                         metadata:
                           labels:
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                             pipelines.kubeflow.org/cache_enabled: "true"
                   iterateParam: my_pipe_param-loop-item
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterateParam: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withitem_multi_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_multi_nested.yaml
@@ -29,6 +29,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[100, 200]", "name":
       "my_pipe_param", "optional": true, "type": "JsonArray"}, {"default": "[1, 2]",
       "name": "my_pipe_param3", "optional": true, "type": "JsonArray"}], "name": "withitem-multiple-nesting-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -94,9 +97,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=7da1ee1a43a4ddb0a66d5603e5a1f097b9d88d4602cdbd92637408a6278ce663"}'
@@ -123,9 +126,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop2",
                       "outputs": [], "version": "my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe"}'
@@ -186,9 +189,9 @@ spec:
                           type: string
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-inner-inner-coop", "outputs": [], "version": "my-inner-inner-coop@sha256=e09082c663a9e1fc40f3b14bfbdd8d0174e6bc6391e6ab334383e3edca20d8dd"}'
@@ -245,9 +248,9 @@ spec:
                                   type: string
                                 metadata:
                                   labels:
+                                    pipelines.kubeflow.org/cache_enabled: "true"
                                     pipelines.kubeflow.org/pipelinename: ''
                                     pipelines.kubeflow.org/generation: ''
-                                    pipelines.kubeflow.org/cache_enabled: "true"
                                   annotations:
                                     pipelines.kubeflow.org/component_spec_digest: '{"name":
                                       "my-inner-inner-coop", "outputs": [], "version":
@@ -297,9 +300,9 @@ spec:
                                           type: string
                                         metadata:
                                           labels:
+                                            pipelines.kubeflow.org/cache_enabled: "true"
                                             pipelines.kubeflow.org/pipelinename: ''
                                             pipelines.kubeflow.org/generation: ''
-                                            pipelines.kubeflow.org/cache_enabled: "true"
                                           annotations:
                                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                                               "my-inner-inner-coop", "outputs": [],

--- a/sdk/python/tests/compiler/testdata/withitem_multi_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_multi_nested_noninlined.yaml
@@ -40,8 +40,7 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=7da1ee1a43a4ddb0a66d5603e5a1f097b9d88d4602cdbd92637408a6278ce663\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1-subvar-a", "type": "string"}],
+      "true"}}, "params": [{"name": "loop-item-param-1-subvar-a", "type": "string"}],
       "steps": [{"args": ["set -e\necho op1 \"$0\"\n", "$(inputs.params.loop-item-param-1-subvar-a)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "my-in-coop2", "params": [{"name": "loop-item-param-1-subvar-b",
@@ -49,8 +48,7 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-in-coop2\", \"outputs\": [], \"version\": \"my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"}],
+      "true"}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"}],
       "steps": [{"args": ["set -e\necho op2 \"$0\"\n", "$(inputs.params.loop-item-param-1-subvar-b)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "withitem-multiple-nesting-pipeline-for-loop-3",
@@ -72,12 +70,11 @@ metadata:
       {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"my-inner-inner-coop\",
       \"outputs\": [], \"version\": \"my-inner-inner-coop@sha256=e09082c663a9e1fc40f3b14bfbdd8d0174e6bc6391e6ab334383e3edca20d8dd\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1-subvar-a", "type": "string"}, {"name":
-      "my_pipe_param-loop-item", "type": "string"}], "steps": [{"args": ["set -e\necho
-      op11 \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-a)", "$(inputs.params.my_pipe_param-loop-item)"],
-      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
-      "timeout": "525600m"}, {"name": "withitem-multiple-nesting-pipeline-for-loop-5",
+      "true"}}, "params": [{"name": "loop-item-param-1-subvar-a", "type": "string"},
+      {"name": "my_pipe_param-loop-item", "type": "string"}], "steps": [{"args": ["set
+      -e\necho op11 \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-a)",
+      "$(inputs.params.my_pipe_param-loop-item)"], "command": ["sh", "-c"], "image":
+      "library/bash:4.4.23", "name": "main"}]}, "timeout": "525600m"}, {"name": "withitem-multiple-nesting-pipeline-for-loop-5",
       "params": [{"name": "loop-item-param-1-subvar-b", "value": "$(params.loop-item-param-1-subvar-b)"},
       {"name": "loop-item-param-4", "value": "[4, 5]"}, {"name": "my_pipe_param3-loop-item",
       "value": "$(params.my_pipe_param3-loop-item)"}, {"name": "my_pipe_param3", "value":
@@ -94,10 +91,9 @@ metadata:
       {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-inner-inner-coop\", \"outputs\": [], \"version\": \"my-inner-inner-coop@sha256=e09082c663a9e1fc40f3b14bfbdd8d0174e6bc6391e6ab334383e3edca20d8dd\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"}, {"name":
-      "loop-item-param-4", "type": "string"}], "steps": [{"args": ["set -e\necho op11
-      \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-b)", "$(inputs.params.loop-item-param-4)"],
+      "true"}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"},
+      {"name": "loop-item-param-4", "type": "string"}], "steps": [{"args": ["set -e\necho
+      op11 \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-b)", "$(inputs.params.loop-item-param-4)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "withitem-multiple-nesting-pipeline-for-loop-6",
       "params": [{"name": "loop-item-param-1-subvar-b", "value": "$(params.loop-item-param-1-subvar-b)"},
@@ -113,12 +109,14 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-inner-inner-coop\", \"outputs\": [], \"version\": \"my-inner-inner-coop@sha256=e09082c663a9e1fc40f3b14bfbdd8d0174e6bc6391e6ab334383e3edca20d8dd\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"}, {"name":
-      "my_pipe_param3-loop-item", "type": "string"}], "steps": [{"args": ["set -e\necho
-      op11 \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-b)", "$(inputs.params.my_pipe_param3-loop-item)"],
-      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
-      "timeout": "525600m"}]}}}]'
+      "true"}}, "params": [{"name": "loop-item-param-1-subvar-b", "type": "string"},
+      {"name": "my_pipe_param3-loop-item", "type": "string"}], "steps": [{"args":
+      ["set -e\necho op11 \"$0\" \"$1\"\n", "$(inputs.params.loop-item-param-1-subvar-b)",
+      "$(inputs.params.my_pipe_param3-loop-item)"], "command": ["sh", "-c"], "image":
+      "library/bash:4.4.23", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -28,6 +28,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "10", "name": "my_pipe_param",
       "optional": true, "type": "Integer"}], "name": "my-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -57,9 +60,9 @@ spec:
         - name: my_pipe_param
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop",
               "outputs": [], "version": "my-out-cop@sha256=942fd3ea38163121c38a9536c2d67d9762e5bdf825ffe6c62e963a15d44a6173"}'
@@ -108,9 +111,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -137,9 +140,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop2",
                       "outputs": [], "version": "my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe"}'
@@ -197,9 +200,9 @@ spec:
                           type: string
                         metadata:
                           labels:
+                            pipelines.kubeflow.org/cache_enabled: "true"
                             pipelines.kubeflow.org/pipelinename: ''
                             pipelines.kubeflow.org/generation: ''
-                            pipelines.kubeflow.org/cache_enabled: "true"
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-inner-inner-coop", "outputs": [], "version": "my-inner-inner-coop@sha256=4764fa47e98613a0f6b2067c594991720452accccaf5924136b0cffdde2814aa"}'

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -61,8 +61,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop",
               "outputs": [], "version": "my-out-cop@sha256=942fd3ea38163121c38a9536c2d67d9762e5bdf825ffe6c62e963a15d44a6173"}'
@@ -112,8 +110,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop1",
                       "outputs": [], "version": "my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628"}'
@@ -141,8 +137,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-coop2",
                       "outputs": [], "version": "my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe"}'
@@ -201,8 +195,6 @@ spec:
                         metadata:
                           labels:
                             pipelines.kubeflow.org/cache_enabled: "true"
-                            pipelines.kubeflow.org/pipelinename: ''
-                            pipelines.kubeflow.org/generation: ''
                           annotations:
                             pipelines.kubeflow.org/component_spec_digest: '{"name":
                               "my-inner-inner-coop", "outputs": [], "version": "my-inner-inner-coop@sha256=4764fa47e98613a0f6b2067c594991720452accccaf5924136b0cffdde2814aa"}'
@@ -211,13 +203,9 @@ spec:
                   iterateParam: loop-item-param-3
                 metadata:
                   labels:
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                     pipelines.kubeflow.org/cache_enabled: "true"
           iterateParam: loop-item-param-1
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withitem_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested_noninlined.yaml
@@ -37,18 +37,16 @@ metadata:
       {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-coop1\", \"outputs\": [], \"version\": \"my-in-coop1@sha256=42f0c6a60c7e435441b8afaeb382a771a9741fe3aabb203748fdbd72b25f1628\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name": "my_pipe_param",
-      "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\" \"$1\"\n",
-      "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"], "command":
-      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
-      "525600m"}, {"name": "my-in-coop2", "params": [{"name": "loop-item-param-1",
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name":
+      "my_pipe_param", "type": "string"}], "steps": [{"args": ["set -e\necho op1 \"$0\"
+      \"$1\"\n", "$(inputs.params.loop-item-param-1)", "$(inputs.params.my_pipe_param)"],
+      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
+      "timeout": "525600m"}, {"name": "my-in-coop2", "params": [{"name": "loop-item-param-1",
       "value": "$(params.loop-item-param-1)"}], "taskSpec": {"metadata": {"annotations":
       {"pipelines.kubeflow.org/component_spec_digest": "{\"name\": \"my-in-coop2\",
       \"outputs\": [], \"version\": \"my-in-coop2@sha256=6984788637aec7d6eb2453d5f2bfb249047e634e5959b7ec9813371238742dfe\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}], "steps":
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}], "steps":
       [{"args": ["set -e\necho op2 \"$0\"\n", "$(inputs.params.loop-item-param-1)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}, {"name": "my-pipeline-for-loop-4", "params": [{"name":
@@ -66,13 +64,15 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-inner-inner-coop\", \"outputs\": [], \"version\": \"my-inner-inner-coop@sha256=4764fa47e98613a0f6b2067c594991720452accccaf5924136b0cffdde2814aa\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name": "loop-item-param-3",
-      "type": "string"}, {"name": "my_pipe_param", "type": "string"}], "steps": [{"args":
-      ["set -e\necho op11 \"$0\" \"$1\" \"$2\"\n", "$(inputs.params.loop-item-param-1)",
+      "true"}}, "params": [{"name": "loop-item-param-1", "type": "string"}, {"name":
+      "loop-item-param-3", "type": "string"}, {"name": "my_pipe_param", "type": "string"}],
+      "steps": [{"args": ["set -e\necho op11 \"$0\" \"$1\" \"$2\"\n", "$(inputs.params.loop-item-param-1)",
       "$(inputs.params.loop-item-param-3)", "$(inputs.params.my_pipe_param)"], "command":
       ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
       "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: my_pipe_param
@@ -102,8 +102,6 @@ spec:
         - name: my_pipe_param
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop",

--- a/sdk/python/tests/compiler/testdata/withparam_global.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global.yaml
@@ -62,8 +62,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
               "outputs": [{"name": "out", "type": "String"}], "version": "my-out-cop0@sha256=a450661d6f7ba02ab00054fcb4afae65774d94dfcf4611aff04ec134a0fcf9a3"}'
@@ -90,8 +88,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",
               "outputs": [], "version": "my-out-cop2@sha256=12b6747bf40c6d422bf91475437e40331e1809caa920e7012bc09c5fb81be91d"}'
@@ -136,8 +132,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-cop1",
                       "outputs": [], "version": "my-in-cop1@sha256=636096cc65b3fe23f6fd1d965dd294fae75e328c1fb46f036f9ccad27dc692eb"}'
@@ -147,7 +141,5 @@ spec:
           iterateParam: loopidy_doop-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_global.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global.yaml
@@ -30,6 +30,9 @@ metadata:
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[3, 5, 7, 9]",
       "name": "loopidy_doop", "optional": true, "type": "JsonArray"}], "name": "withparam-global"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: loopidy_doop
@@ -58,9 +61,9 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
               "outputs": [{"name": "out", "type": "String"}], "version": "my-out-cop0@sha256=a450661d6f7ba02ab00054fcb4afae65774d94dfcf4611aff04ec134a0fcf9a3"}'
@@ -86,9 +89,9 @@ spec:
         - name: my-out-cop0-out
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",
               "outputs": [], "version": "my-out-cop2@sha256=12b6747bf40c6d422bf91475437e40331e1809caa920e7012bc09c5fb81be91d"}'
@@ -132,9 +135,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-cop1",
                       "outputs": [], "version": "my-in-cop1@sha256=636096cc65b3fe23f6fd1d965dd294fae75e328c1fb46f036f9ccad27dc692eb"}'

--- a/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
@@ -31,6 +31,9 @@ metadata:
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "[{\"a\": \"1\",
       \"b\": \"2\"}, {\"a\": \"10\", \"b\": \"20\"}]", "name": "loopidy_doop", "optional":
       true, "type": "JsonObject"}], "name": "withparam-global-dict"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: loopidy_doop
@@ -59,9 +62,9 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
               "outputs": [{"name": "out", "type": "String"}], "version": "my-out-cop0@sha256=a450661d6f7ba02ab00054fcb4afae65774d94dfcf4611aff04ec134a0fcf9a3"}'
@@ -87,9 +90,9 @@ spec:
         - name: my-out-cop0-out
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",
               "outputs": [], "version": "my-out-cop2@sha256=12b6747bf40c6d422bf91475437e40331e1809caa920e7012bc09c5fb81be91d"}'
@@ -138,9 +141,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-cop1",
                       "outputs": [], "version": "my-in-cop1@sha256=a5d6b8deed0ed377333b9790a4db5be7b5e48196c768bf502fd1da020ab55cac"}'

--- a/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
@@ -63,8 +63,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
               "outputs": [{"name": "out", "type": "String"}], "version": "my-out-cop0@sha256=a450661d6f7ba02ab00054fcb4afae65774d94dfcf4611aff04ec134a0fcf9a3"}'
@@ -91,8 +89,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",
               "outputs": [], "version": "my-out-cop2@sha256=12b6747bf40c6d422bf91475437e40331e1809caa920e7012bc09c5fb81be91d"}'
@@ -142,8 +138,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-cop1",
                       "outputs": [], "version": "my-in-cop1@sha256=a5d6b8deed0ed377333b9790a4db5be7b5e48196c768bf502fd1da020ab55cac"}'
@@ -153,7 +147,5 @@ spec:
           iterateParam: loopidy_doop-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_global_dict_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_dict_noninlined.yaml
@@ -41,12 +41,14 @@ metadata:
       {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-cop1\", \"outputs\": [], \"version\": \"my-in-cop1@sha256=a5d6b8deed0ed377333b9790a4db5be7b5e48196c768bf502fd1da020ab55cac\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loopidy_doop-loop-item-subvar-a", "type": "string"},
+      "true"}}, "params": [{"name": "loopidy_doop-loop-item-subvar-a", "type": "string"},
       {"name": "loopidy_doop-loop-item-subvar-b", "type": "string"}], "steps": [{"args":
       ["set -e\necho no output global op1, item.a: \"$0\" , item.b: \"$1\"\n", "$(inputs.params.loopidy_doop-loop-item-subvar-a)",
       "$(inputs.params.loopidy_doop-loop-item-subvar-b)"], "command": ["sh", "-c"],
       "image": "library/bash:4.4.23", "name": "main"}]}, "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: loopidy_doop
@@ -75,8 +77,6 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
@@ -103,8 +103,6 @@ spec:
         - name: my-out-cop0-out
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",

--- a/sdk/python/tests/compiler/testdata/withparam_global_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_noninlined.yaml
@@ -38,11 +38,13 @@ metadata:
       "runAfter": [], "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-cop1\", \"outputs\": [], \"version\": \"my-in-cop1@sha256=636096cc65b3fe23f6fd1d965dd294fae75e328c1fb46f036f9ccad27dc692eb\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "loopidy_doop-loop-item", "type": "string"}], "steps":
-      [{"args": ["set -e\necho no output global op1, item: \"$0\"\n", "$(inputs.params.loopidy_doop-loop-item)"],
+      "true"}}, "params": [{"name": "loopidy_doop-loop-item", "type": "string"}],
+      "steps": [{"args": ["set -e\necho no output global op1, item: \"$0\"\n", "$(inputs.params.loopidy_doop-loop-item)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   params:
   - name: loopidy_doop
@@ -71,8 +73,6 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
@@ -99,8 +99,6 @@ spec:
         - name: my-out-cop0-out
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",

--- a/sdk/python/tests/compiler/testdata/withparam_output.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output.yaml
@@ -55,8 +55,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
               "outputs": [{"name": "out", "type": "String"}], "version": "my-out-cop0@sha256=a450661d6f7ba02ab00054fcb4afae65774d94dfcf4611aff04ec134a0fcf9a3"}'
@@ -83,8 +81,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",
               "outputs": [], "version": "my-out-cop2@sha256=12b6747bf40c6d422bf91475437e40331e1809caa920e7012bc09c5fb81be91d"}'
@@ -127,8 +123,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-cop1",
                       "outputs": [], "version": "my-in-cop1@sha256=636096cc65b3fe23f6fd1d965dd294fae75e328c1fb46f036f9ccad27dc692eb"}'
@@ -137,7 +131,5 @@ spec:
           iterateParam: my-out-cop0-out-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_output.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output.yaml
@@ -29,6 +29,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "withparam-output"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -51,9 +54,9 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
               "outputs": [{"name": "out", "type": "String"}], "version": "my-out-cop0@sha256=a450661d6f7ba02ab00054fcb4afae65774d94dfcf4611aff04ec134a0fcf9a3"}'
@@ -79,9 +82,9 @@ spec:
         - name: my-out-cop0-out
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",
               "outputs": [], "version": "my-out-cop2@sha256=12b6747bf40c6d422bf91475437e40331e1809caa920e7012bc09c5fb81be91d"}'
@@ -123,9 +126,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-cop1",
                       "outputs": [], "version": "my-in-cop1@sha256=636096cc65b3fe23f6fd1d965dd294fae75e328c1fb46f036f9ccad27dc692eb"}'

--- a/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
@@ -29,6 +29,9 @@ metadata:
     sidecar.istio.io/inject: "false"
     pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
     pipelines.kubeflow.org/pipeline_spec: '{"name": "withparam-output-dict"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -51,9 +54,9 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
               "outputs": [{"name": "out", "type": "String"}], "version": "my-out-cop0@sha256=5e11d51d337651bf7bfff083ab2d970f4797e3d281abb395ec3f8200841d8ad8"}'
@@ -79,9 +82,9 @@ spec:
         - name: my-out-cop0-out
         metadata:
           labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
             pipelines.kubeflow.org/pipelinename: ''
             pipelines.kubeflow.org/generation: ''
-            pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",
               "outputs": [], "version": "my-out-cop2@sha256=12b6747bf40c6d422bf91475437e40331e1809caa920e7012bc09c5fb81be91d"}'
@@ -123,9 +126,9 @@ spec:
                   type: string
                 metadata:
                   labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
                     pipelines.kubeflow.org/pipelinename: ''
                     pipelines.kubeflow.org/generation: ''
-                    pipelines.kubeflow.org/cache_enabled: "true"
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-cop1",
                       "outputs": [], "version": "my-in-cop1@sha256=baa1db1377a71388e9f7b0054485105678c0911a3e478a5a2873bca4a7e13ab5"}'

--- a/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
@@ -55,8 +55,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
               "outputs": [{"name": "out", "type": "String"}], "version": "my-out-cop0@sha256=5e11d51d337651bf7bfff083ab2d970f4797e3d281abb395ec3f8200841d8ad8"}'
@@ -83,8 +81,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",
               "outputs": [], "version": "my-out-cop2@sha256=12b6747bf40c6d422bf91475437e40331e1809caa920e7012bc09c5fb81be91d"}'
@@ -127,8 +123,6 @@ spec:
                 metadata:
                   labels:
                     pipelines.kubeflow.org/cache_enabled: "true"
-                    pipelines.kubeflow.org/pipelinename: ''
-                    pipelines.kubeflow.org/generation: ''
                   annotations:
                     pipelines.kubeflow.org/component_spec_digest: '{"name": "my-in-cop1",
                       "outputs": [], "version": "my-in-cop1@sha256=baa1db1377a71388e9f7b0054485105678c0911a3e478a5a2873bca4a7e13ab5"}'
@@ -137,7 +131,5 @@ spec:
           iterateParam: my-out-cop0-out-loop-item
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
   timeout: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_output_dict_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_dict_noninlined.yaml
@@ -38,11 +38,14 @@ metadata:
       {"annotations": {"pipelines.kubeflow.org/component_spec_digest": "{\"name\":
       \"my-in-cop1\", \"outputs\": [], \"version\": \"my-in-cop1@sha256=baa1db1377a71388e9f7b0054485105678c0911a3e478a5a2873bca4a7e13ab5\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "my-out-cop0-out-loop-item-subvar-a", "type": "string"}],
-      "steps": [{"args": ["set -e\necho no output global op1, item.a: \"$0\"\n", "$(inputs.params.my-out-cop0-out-loop-item-subvar-a)"],
-      "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
-      "timeout": "525600m"}]}}}]'
+      "true"}}, "params": [{"name": "my-out-cop0-out-loop-item-subvar-a", "type":
+      "string"}], "steps": [{"args": ["set -e\necho no output global op1, item.a:
+      \"$0\"\n", "$(inputs.params.my-out-cop0-out-loop-item-subvar-a)"], "command":
+      ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]}, "timeout":
+      "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -65,8 +68,6 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
@@ -93,8 +94,6 @@ spec:
         - name: my-out-cop0-out
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",

--- a/sdk/python/tests/compiler/testdata/withparam_output_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_noninlined.yaml
@@ -37,11 +37,13 @@ metadata:
       "taskSpec": {"metadata": {"annotations": {"pipelines.kubeflow.org/component_spec_digest":
       "{\"name\": \"my-in-cop1\", \"outputs\": [], \"version\": \"my-in-cop1@sha256=636096cc65b3fe23f6fd1d965dd294fae75e328c1fb46f036f9ccad27dc692eb\"}",
       "tekton.dev/template": ""}, "labels": {"pipelines.kubeflow.org/cache_enabled":
-      "true", "pipelines.kubeflow.org/generation": "", "pipelines.kubeflow.org/pipelinename":
-      ""}}, "params": [{"name": "my-out-cop0-out-loop-item", "type": "string"}], "steps":
-      [{"args": ["set -e\necho no output global op1, item: \"$0\"\n", "$(inputs.params.my-out-cop0-out-loop-item)"],
+      "true"}}, "params": [{"name": "my-out-cop0-out-loop-item", "type": "string"}],
+      "steps": [{"args": ["set -e\necho no output global op1, item: \"$0\"\n", "$(inputs.params.my-out-cop0-out-loop-item)"],
       "command": ["sh", "-c"], "image": "library/bash:4.4.23", "name": "main"}]},
       "timeout": "525600m"}]}}}]'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
 spec:
   pipelineSpec:
     tasks:
@@ -64,8 +66,6 @@ spec:
           description: /tmp/outputs/out/data
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop0",
@@ -92,8 +92,6 @@ spec:
         - name: my-out-cop0-out
         metadata:
           labels:
-            pipelines.kubeflow.org/pipelinename: ''
-            pipelines.kubeflow.org/generation: ''
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "my-out-cop2",


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
Move common task labels to pipeline labels to reduce yaml size. The label pipelines.kubeflow.org/pipelinename and pipelines.kubeflow.org/generation is only updated during pod mutations, not task mutation. Hence defining the task key in the pipeline entry won't impact our current Tekton caching solution.

As for Argo, there's no pipeline level labels. Therefore the labels are needed to define in the task level.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
