### PR TITLE
Update pipelinerun timeout format to timeouts

### DIFF
--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -54,8 +54,12 @@ DEFAULT_ARTIFACT_ENDPOINT_SCHEME = env.get('DEFAULT_ARTIFACT_ENDPOINT_SCHEME', '
 TEKTON_GLOBAL_DEFAULT_TIMEOUT = strtobool(env.get('TEKTON_GLOBAL_DEFAULT_TIMEOUT', 'false'))
 # DISABLE_CEL_CONDITION should be True until CEL is officially merged into Tekton main API.
 DISABLE_CEL_CONDITION = True
-# Default timeout is one year
+# Default tasks timeout is one year
 DEFAULT_TIMEOUT_MINUTES = "525600m"
+# Default whole pipeline timeout is two year
+DEFAULT_TIMEOUT_WITH_FINALLY_MINUTES = "1051200m"
+# Default finally extension is 5 minutes
+DEFAULT_FINALLY_SECONDS = 300
 
 
 def _get_super_condition_template():
@@ -1386,11 +1390,13 @@ class TektonCompiler(Compiler):
 
     # add workflow level timeout to pipeline run
     if not TEKTON_GLOBAL_DEFAULT_TIMEOUT or pipeline.conf.timeout:
+      pipeline_run['spec']['timeouts'] = {'pipeline': '0s', 'tasks': '0s'}
       if pipeline.conf.timeout > 0:
-        pipeline_run['spec']['timeout'] = '%ds' % pipeline.conf.timeout
+        pipeline_run['spec']['timeouts']['tasks'] = '%ds' % pipeline.conf.timeout
+        pipeline_run['spec']['timeouts']['pipeline'] = '%ds' % (pipeline.conf.timeout + DEFAULT_FINALLY_SECONDS)
       else:
-        pipeline_run['spec']['timeout'] = DEFAULT_TIMEOUT_MINUTES
-
+        pipeline_run['spec']['timeouts']['tasks'] = DEFAULT_TIMEOUT_MINUTES
+        pipeline_run['spec']['timeouts']['pipeline'] = DEFAULT_TIMEOUT_WITH_FINALLY_MINUTES
     # generate the Tekton podTemplate for image pull secret
     if len(pipeline.conf.image_pull_secrets) > 0:
       pipeline_run['spec']['podTemplate'] = pipeline_run['spec'].get('podTemplate', {})

--- a/sdk/python/tests/compiler/testdata/affinity.yaml
+++ b/sdk/python/tests/compiler/testdata/affinity.yaml
@@ -65,4 +65,6 @@ spec:
                 operator: In
                 values:
                 - linux
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/any_sequencer.yaml
+++ b/sdk/python/tests/compiler/testdata/any_sequencer.yaml
@@ -213,4 +213,6 @@ spec:
         value: $(context.pipelineRun.name)
       - name: pipelineRun-namespace
         value: $(context.pipelineRun.namespace)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/any_sequencer_looped.yaml
+++ b/sdk/python/tests/compiler/testdata/any_sequencer_looped.yaml
@@ -249,4 +249,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/any_sequencer_looped_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/any_sequencer_looped_noninlined.yaml
@@ -182,4 +182,6 @@ spec:
       params:
       - name: param-loop-item
         value: $(params.param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_outputs.yaml
@@ -130,7 +130,9 @@ spec:
         workspace: artifact-out-pipeline
     workspaces:
     - name: artifact-out-pipeline
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   workspaces:
   - name: artifact-out-pipeline
     volumeClaimTemplate:

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
@@ -350,7 +350,9 @@ spec:
       timeout: 525600m
     workspaces:
     - name: artifact-passing-pipeline
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   workspaces:
   - name: artifact-passing-pipeline
     persistentVolumeClaim:

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -134,4 +134,6 @@ spec:
     taskPodTemplate:
       nodeSelector:
         kubernetes.io/os: linux
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/big_data_multi_volumes_1.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_multi_volumes_1.yaml
@@ -116,4 +116,6 @@ spec:
           - name: input-text
             mountPath: /tmp/inputs/input_text
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/big_data_multi_volumes_2.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_multi_volumes_2.yaml
@@ -125,4 +125,6 @@ spec:
           - name: input-text-1
             mountPath: /tmp/inputs/input_text_1
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/big_data_passing.yaml
+++ b/sdk/python/tests/compiler/testdata/big_data_passing.yaml
@@ -977,7 +977,9 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
     workspaces:
     - name: big-data-passing
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   workspaces:
   - name: big-data-passing
     volumeClaimTemplate:

--- a/sdk/python/tests/compiler/testdata/break_task_pipeline.yaml
+++ b/sdk/python/tests/compiler/testdata/break_task_pipeline.yaml
@@ -113,4 +113,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/break_task_pipeline_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/break_task_pipeline_noninlined.yaml
@@ -68,4 +68,6 @@ spec:
         value: '[1, 2]'
       - name: param
         value: $(params.param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/cache.yaml
+++ b/sdk/python/tests/compiler/testdata/cache.yaml
@@ -81,4 +81,6 @@ spec:
               "outputs": [{"name": "out", "type": "String"}], "version": "cache-disabled@sha256=c6b73e13a48ba7dfacb66ebd9987eda874087ace7615130da8180b2b46dd53c9"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/compose.yaml
+++ b/sdk/python/tests/compiler/testdata/compose.yaml
@@ -137,4 +137,6 @@ spec:
               [], "version": "save@sha256=6cf2594d27161c1ef289acc82ec53fc038580a22405354932ed32ce46df91687"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/cond_recur.yaml
+++ b/sdk/python/tests/compiler/testdata/cond_recur.yaml
@@ -89,4 +89,6 @@ spec:
         operator: in
         values:
         - "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/cond_recur_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/cond_recur_noninlined.yaml
@@ -90,4 +90,6 @@ spec:
         operator: in
         values:
         - "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/condition.yaml
+++ b/sdk/python/tests/compiler/testdata/condition.yaml
@@ -375,4 +375,6 @@ spec:
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
           image: python:alpine3.6
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/condition_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/condition_custom_task.yaml
@@ -269,4 +269,6 @@ spec:
         values:
         - "true"
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/condition_depend.yaml
+++ b/sdk/python/tests/compiler/testdata/condition_depend.yaml
@@ -242,4 +242,6 @@ spec:
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
           image: python:alpine3.6
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/condition_dependency.yaml
+++ b/sdk/python/tests/compiler/testdata/condition_dependency.yaml
@@ -313,4 +313,6 @@ spec:
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
           image: python:alpine3.6
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/conditions_and_loops.yaml
+++ b/sdk/python/tests/compiler/testdata/conditions_and_loops.yaml
@@ -466,4 +466,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/conditions_and_loops_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/conditions_and_loops_noninlined.yaml
@@ -236,4 +236,6 @@ spec:
         value: $(tasks.produce-numbers.results.Output)
       - name: threshold
         value: $(params.threshold)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/conditions_with_global_params.yaml
+++ b/sdk/python/tests/compiler/testdata/conditions_with_global_params.yaml
@@ -354,4 +354,6 @@ spec:
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
           image: python:alpine3.6
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
+++ b/sdk/python/tests/compiler/testdata/create_component_from_func.yaml
@@ -324,7 +324,9 @@ spec:
       - produce-dir-with-files-python-op
     workspaces:
     - name: create-component-from-function
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   workspaces:
   - name: create-component-from-function
     volumeClaimTemplate:

--- a/sdk/python/tests/compiler/testdata/custom_task_exit.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_exit.yaml
@@ -101,4 +101,6 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "false"
           annotations:
             ws-pipelines.ibm.com/pipeline-cache-enabled: "false"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_long_name.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_long_name.yaml
@@ -111,4 +111,6 @@ spec:
         apiVersion: cel.tekton.dev/v1alpha1
         kind: CEL
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_output.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_output.yaml
@@ -110,4 +110,6 @@ spec:
               "outputs": [{"name": "stdout", "type": "String"}], "version": "artifact-printer-1@sha256=37dc967f8576ece2bc91e571dbaccd7f77043711a66b411d02aa952bd47191bf"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_params_ref.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_params_ref.yaml
@@ -62,4 +62,6 @@ spec:
         apiVersion: custom.tekton.dev/v1alpha1
         kind: custom-task
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_params_spec.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_params_spec.yaml
@@ -75,4 +75,6 @@ spec:
             valid_container: "false"
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond.yaml
@@ -106,4 +106,6 @@ spec:
         operator: in
         values:
         - "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_recur_with_cond_noninlined.yaml
@@ -106,4 +106,6 @@ spec:
         operator: in
         values:
         - "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_ref.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_ref.yaml
@@ -53,4 +53,6 @@ spec:
       runAfter:
       - any-name
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_ref_timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_ref_timeout.yaml
@@ -53,4 +53,6 @@ spec:
       runAfter:
       - any-name
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/custom_task_spec.yaml
+++ b/sdk/python/tests/compiler/testdata/custom_task_spec.yaml
@@ -71,4 +71,6 @@ spec:
       runAfter:
       - any-name
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_complete.yaml
@@ -1885,7 +1885,9 @@ spec:
       - produce-string
     workspaces:
     - name: data-passing-pipeline
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   workspaces:
   - name: data-passing-pipeline
     volumeClaimTemplate:

--- a/sdk/python/tests/compiler/testdata/data_passing_pipeline_param_as_file.yaml
+++ b/sdk/python/tests/compiler/testdata/data_passing_pipeline_param_as_file.yaml
@@ -425,7 +425,9 @@ spec:
         workspace: data-passing-pipeline
     workspaces:
     - name: data-passing-pipeline
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   workspaces:
   - name: data-passing-pipeline
     volumeClaimTemplate:

--- a/sdk/python/tests/compiler/testdata/exception.yaml
+++ b/sdk/python/tests/compiler/testdata/exception.yaml
@@ -132,4 +132,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/exit_handler.yaml
+++ b/sdk/python/tests/compiler/testdata/exit_handler.yaml
@@ -114,4 +114,6 @@ spec:
               [], "version": "echo@sha256=4307d04e3d8d097b882bcd9cba02f5ae7d2433c3a6e5968af9f6bf1e17582984"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
+++ b/sdk/python/tests/compiler/testdata/hidden_output_file.yaml
@@ -98,4 +98,6 @@ spec:
               [], "version": "echo@sha256=441c647e86107abf53108718d190a2c25c8285e42c62289e3b049dbc2a0425af"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets.yaml
@@ -72,7 +72,9 @@ spec:
               "outputs": [{"name": "word", "type": "String"}], "version": "get-frequent@sha256=6ee1acb749583ceffd098100e3e83c4c369aa6b5f295c8bda202b32c853ca5db"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   podTemplate:
     imagePullSecrets:
     - name: secretA

--- a/sdk/python/tests/compiler/testdata/imagepullsecrets_with_node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/imagepullsecrets_with_node_selector.yaml
@@ -72,7 +72,9 @@ spec:
               "outputs": [{"name": "word", "type": "String"}], "version": "get-frequent@sha256=6ee1acb749583ceffd098100e3e83c4c369aa6b5f295c8bda202b32c853ca5db"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   podTemplate:
     imagePullSecrets:
     - name: secretA

--- a/sdk/python/tests/compiler/testdata/init_container.yaml
+++ b/sdk/python/tests/compiler/testdata/init_container.yaml
@@ -54,4 +54,6 @@ spec:
               [], "version": "hello@sha256=df9647340a6623fa5aa8ac28fc99358101f4ca72dab416287eb949b5dbd543ad"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -176,4 +176,6 @@ spec:
         - name: text
           emptyDir: {}
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/katib.yaml
+++ b/sdk/python/tests/compiler/testdata/katib.yaml
@@ -175,4 +175,6 @@ spec:
               "outputs": [], "version": "my-out-cop@sha256=1ba657e86cfa3fa4fd6256830c58aad6b9e7a75b92c522c818526530223a1533"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/literal_params_test.yaml
+++ b/sdk/python/tests/compiler/testdata/literal_params_test.yaml
@@ -138,4 +138,6 @@ spec:
         apiVersion: fetcher.tekton.dev/v1alpha1
         kind: FETCHER
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/load_from_yaml.yaml
+++ b/sdk/python/tests/compiler/testdata/load_from_yaml.yaml
@@ -59,4 +59,6 @@ spec:
               "version": "busybox@sha256=5bed7406f74106b6e31b3b155d13cb203e1f30e41fd93b53f9cd71331513e355"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/long_param_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_param_name.yaml
@@ -99,4 +99,6 @@ spec:
               "outputs": [], "version": "printprintprintprintprintprintprintprintprintprint@sha256=0c820da4b0f6e1a730ec47930324fc44ffbc0be62e903fdbcc91dc36ab9580ef"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/long_pipeline_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_pipeline_name.yaml
@@ -79,4 +79,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/long_pipeline_name_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/long_pipeline_name_noninlined.yaml
@@ -59,4 +59,6 @@ spec:
       params:
       - name: arr-loop-item
         value: $(params.arr)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/long_recursive_group_name.yaml
+++ b/sdk/python/tests/compiler/testdata/long_recursive_group_name.yaml
@@ -75,4 +75,6 @@ spec:
       - name: just_one_iteration
         value:
         - '1'
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/long_recursive_group_name_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/long_recursive_group_name_noninlined.yaml
@@ -75,4 +75,6 @@ spec:
       - name: just_one_iteration
         value:
         - '1'
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_empty.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_empty.yaml
@@ -63,4 +63,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_in_recursion.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_in_recursion.yaml
@@ -205,4 +205,6 @@ spec:
         value: $(params.maxVal)
       - name: my_pipe_param
         value: $(params.my_pipe_param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_in_recursion_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_in_recursion_noninlined.yaml
@@ -207,4 +207,6 @@ spec:
         value: $(params.maxVal)
       - name: my_pipe_param
         value: $(params.my_pipe_param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator.yaml
@@ -95,4 +95,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_literal_separator_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_literal_separator_noninlined.yaml
@@ -66,4 +66,6 @@ spec:
         value: ','
       - name: my_pipe_param
         value: $(params.my_pipe_param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
@@ -100,4 +100,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_over_lightweight_output_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_over_lightweight_output_noninlined.yaml
@@ -81,4 +81,6 @@ spec:
       params:
       - name: produce-list-data_list-loop-item
         value: $(tasks.produce-list.results.data-list)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_static.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static.yaml
@@ -143,4 +143,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_static_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static_noninlined.yaml
@@ -96,4 +96,6 @@ spec:
         value: '[1, 2, 3]'
       - name: my_pipe_param
         value: $(params.my_pipe_param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_static_with_parallelism.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static_with_parallelism.yaml
@@ -144,4 +144,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_static_with_parallelism_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_static_with_parallelism_noninlined.yaml
@@ -98,4 +98,6 @@ spec:
         value: '[1, 2, 3]'
       - name: my_pipe_param
         value: $(params.my_pipe_param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency.yaml
@@ -240,4 +240,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_conditional_dependency_noninlined.yaml
@@ -193,4 +193,6 @@ spec:
       params:
       - name: param-loop-item
         value: $(params.param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic.yaml
@@ -108,4 +108,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_basic_noninlined.yaml
@@ -84,4 +84,6 @@ spec:
       params:
       - name: produce-list-data_list-loop-item
         value: $(tasks.produce-list.results.data-list)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested.yaml
@@ -344,4 +344,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_enumerate_withitem_multi_nested_noninlined.yaml
@@ -156,4 +156,6 @@ spec:
         value: $(params.my_pipe_param3)
       - name: my_pipe_param3-loop-item
         value: $(params.my_pipe_param3)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric.yaml
@@ -159,4 +159,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate.yaml
@@ -175,4 +175,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric_enumerate_noninlined.yaml
@@ -97,4 +97,6 @@ spec:
         value: $(params.my_pipe_param)
       - name: to
         value: $(params.end)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_numeric_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_numeric_noninlined.yaml
@@ -91,4 +91,6 @@ spec:
         value: $(params.my_pipe_param)
       - name: to
         value: $(params.end)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_params_in_json.yaml
@@ -437,4 +437,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_step.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_step.yaml
@@ -166,4 +166,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/loop_with_step_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_with_step_noninlined.yaml
@@ -103,4 +103,6 @@ spec:
         value: $(params.step)
       - name: to
         value: $(params.end)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/many_results.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results.yaml
@@ -193,4 +193,6 @@ spec:
               [], "version": "print@sha256=7414614ece3ba415ce2df0ef0612f4bbb087ebd4f7314a47f65db849f5dd1004"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
+++ b/sdk/python/tests/compiler/testdata/many_results_with_warnings.yaml
@@ -171,4 +171,6 @@ spec:
               "type": "String"}], "version": "Print4results@sha256=2abb522200107ab144eafa6107bb8fde6c10e446a9bdc2a7f4d3a50df6e8a0d2"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/multi_nested_loop_condi.yaml
+++ b/sdk/python/tests/compiler/testdata/multi_nested_loop_condi.yaml
@@ -205,4 +205,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_custom_conditions.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_custom_conditions.yaml
@@ -111,4 +111,6 @@ spec:
         values:
         - "true"
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_loop_global_param.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_loop_global_param.yaml
@@ -183,4 +183,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_loop_global_param_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_loop_global_param_noninlined.yaml
@@ -101,4 +101,6 @@ spec:
         value: $(params.param)
       - name: param
         value: $(params.param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_recur_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_custom_task.yaml
@@ -148,4 +148,6 @@ spec:
         operator: in
         values:
         - "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_recur_custom_task_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_custom_task_noninlined.yaml
@@ -147,4 +147,6 @@ spec:
         operator: in
         values:
         - "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_recur_params.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_params.yaml
@@ -153,4 +153,6 @@ spec:
         operator: in
         values:
         - "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_recur_params_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_params_noninlined.yaml
@@ -152,4 +152,6 @@ spec:
         operator: in
         values:
         - "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_recur_runafter.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_runafter.yaml
@@ -192,4 +192,6 @@ spec:
         - '1'
       - name: maxVal
         value: $(params.maxVal)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/nested_recur_runafter_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/nested_recur_runafter_noninlined.yaml
@@ -191,4 +191,6 @@ spec:
         - '1'
       - name: maxVal
         value: $(params.maxVal)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/node_selector.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector.yaml
@@ -57,4 +57,6 @@ spec:
     taskPodTemplate:
       nodeSelector:
         kubernetes.io/os: linux
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/node_selector_from_pipeline.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector_from_pipeline.yaml
@@ -52,7 +52,9 @@ spec:
               [], "version": "echo@sha256=e351a00f59eb0eb8d614bb41816020b768770ba7513a5b3c0c7ea5c2efa9c6d6"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   podTemplate:
     nodeSelector:
       kubernetes.io/os: linux

--- a/sdk/python/tests/compiler/testdata/node_selector_from_pipeline_override.yaml
+++ b/sdk/python/tests/compiler/testdata/node_selector_from_pipeline_override.yaml
@@ -57,7 +57,9 @@ spec:
     taskPodTemplate:
       nodeSelector:
         kubernetes.io/os: windows
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m
   podTemplate:
     nodeSelector:
       kubernetes.io/os: linux

--- a/sdk/python/tests/compiler/testdata/parallel_join.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join.yaml
@@ -139,4 +139,6 @@ spec:
               [], "version": "echo@sha256=6ba9f3d0658a72a763f9ed77d34a378b19b686b649512adee9831ed4ec7ddcd4"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
+++ b/sdk/python/tests/compiler/testdata/parallel_join_with_argo_vars.yaml
@@ -149,4 +149,6 @@ spec:
               [], "version": "echo@sha256=8f8d23eb8a5175f0212ebf18b3f24dcd26effafb1ed421d18d897ccfdb14dcc0"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -665,4 +665,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving_noninlined.yaml
@@ -457,4 +457,6 @@ spec:
         value: $(tasks.produce-list-of-dicts.results.Output)
       - name: produce-list-of-dicts-Output-loop-item
         value: $(tasks.produce-list-of-dicts.results.Output)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/param_same_prefix.yaml
+++ b/sdk/python/tests/compiler/testdata/param_same_prefix.yaml
@@ -419,4 +419,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/param_same_prefix_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/param_same_prefix_noninlined.yaml
@@ -268,4 +268,6 @@ spec:
         value: $(tasks.foo-12.results.foo-12)
       - name: li-loop-item
         value: $(params.li)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
+++ b/sdk/python/tests/compiler/testdata/pipeline_transformers.yaml
@@ -70,4 +70,6 @@ spec:
               [], "version": "print@sha256=5311fb175a78bc1a90005ec5e77b6c0c5c574afe5fc779b99e9847e08615d618"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/pipelineparam_env.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparam_env.yaml
@@ -63,4 +63,6 @@ spec:
           annotations:
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/pipelineparams.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparams.yaml
@@ -109,4 +109,6 @@ spec:
               [], "version": "echo@sha256=c8973317486147e1eed93d9d1f6a734e64f27c8bf01778c946fa00c7431a7d9a"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/recur_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested.yaml
@@ -204,4 +204,6 @@ spec:
         - '1'
       - name: maxVal
         value: $(params.maxVal)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/recur_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested_noninlined.yaml
@@ -203,4 +203,6 @@ spec:
         - '1'
       - name: maxVal
         value: $(params.maxVal)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/recur_nested_separate.yaml
+++ b/sdk/python/tests/compiler/testdata/recur_nested_separate.yaml
@@ -110,4 +110,6 @@ spec:
         - '1'
       - name: maxVal
         value: $(params.maxVal)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/recursion_while.yaml
+++ b/sdk/python/tests/compiler/testdata/recursion_while.yaml
@@ -147,4 +147,6 @@ spec:
         - '1'
       - name: maxVal
         value: $(params.maxVal)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/recursion_while_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/recursion_while_noninlined.yaml
@@ -147,4 +147,6 @@ spec:
         - '1'
       - name: maxVal
         value: $(params.maxVal)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -130,4 +130,6 @@ spec:
           annotations:
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/retry.yaml
+++ b/sdk/python/tests/compiler/testdata/retry.yaml
@@ -76,4 +76,6 @@ spec:
             tekton.dev/template: ''
       retries: 5
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/separator_from_param.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_param.yaml
@@ -91,4 +91,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/separator_from_param_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_param_noninlined.yaml
@@ -68,4 +68,6 @@ spec:
         value: $(params.separator)
       - name: text-loop-item
         value: $(params.text)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/separator_from_task.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_task.yaml
@@ -136,4 +136,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/separator_from_task_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/separator_from_task_noninlined.yaml
@@ -113,4 +113,6 @@ spec:
         value: $(tasks.separator.results.output-value)
       - name: text-output_value-loop-item
         value: $(tasks.text.results.output-value)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/sequential.yaml
+++ b/sdk/python/tests/compiler/testdata/sequential.yaml
@@ -102,4 +102,6 @@ spec:
       runAfter:
       - gcs-download
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/set_display_name.yaml
+++ b/sdk/python/tests/compiler/testdata/set_display_name.yaml
@@ -53,4 +53,6 @@ spec:
               [], "version": "echo@sha256=14be762d0ac645b725d45e703104370b0816a8b2b9abf44ca01c405e3bbf45c3"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/sidecar.yaml
+++ b/sdk/python/tests/compiler/testdata/sidecar.yaml
@@ -84,4 +84,6 @@ spec:
               [], "version": "echo@sha256=5c21cb3f14cade30f1b3682e50fc1894db5c057aa0cc49d7202e9d86b8efdc86"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/tekton_custom_task.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_custom_task.yaml
@@ -117,4 +117,6 @@ spec:
               [], "version": "print@sha256=e5d74bd54bd5aaa77f1c40ad6346cae3fefcc749bea2f6d1561c09ca1f0fe867"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/tekton_loop_dsl.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_loop_dsl.yaml
@@ -113,4 +113,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/tekton_loop_dsl_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_loop_dsl_noninlined.yaml
@@ -68,4 +68,6 @@ spec:
         value: '[1, 2]'
       - name: my_pipe_param
         value: $(params.my_pipe_param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.yaml
@@ -59,4 +59,6 @@ spec:
     securityContext:
       run_as_user: 0
     automountServiceAccountToken: false
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/timeout.py
+++ b/sdk/python/tests/compiler/testdata/timeout.py
@@ -42,7 +42,7 @@ implementation:
 def timeout_sample_pipeline():
     op1 = random_failure_1Op('0,1,2,3').set_timeout(20)
     op2 = random_failure_1Op('0,1')
-    dsl.get_pipeline_conf().set_timeout(40)
+    dsl.get_pipeline_conf().set_timeout(1)
 
 
 if __name__ == '__main__':

--- a/sdk/python/tests/compiler/testdata/timeout.yaml
+++ b/sdk/python/tests/compiler/testdata/timeout.yaml
@@ -73,4 +73,6 @@ spec:
               "outputs": [], "version": "random-failure@sha256=7a3950e9d0afce355b325b09e2cd5710feb99e6233a330af889d80515c4aaac2"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 40s
+  timeouts:
+    pipeline: 301s
+    tasks: 1s

--- a/sdk/python/tests/compiler/testdata/tolerations.yaml
+++ b/sdk/python/tests/compiler/testdata/tolerations.yaml
@@ -66,4 +66,6 @@ spec:
         key: gpu
         operator: Equal
         value: run
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/volume.yaml
+++ b/sdk/python/tests/compiler/testdata/volume.yaml
@@ -99,4 +99,6 @@ spec:
               [], "version": "echo@sha256=e4d2d039a6fa16abbbb38f76c7b1232f6bf154f7992cf8b4f80a793d743ca29f"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/volume_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_op.yaml
@@ -160,4 +160,6 @@ spec:
               [], "version": "cop@sha256=f639de5a5b68415d6b01ffa4b02ecda5641449bc5b10053298959202a7d27c5c"}'
             tekton.dev/template: ''
       timeout: 525600m
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withitem_multi_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_multi_nested.yaml
@@ -315,4 +315,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withitem_multi_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_multi_nested_noninlined.yaml
@@ -146,4 +146,6 @@ spec:
         value: $(params.my_pipe_param3)
       - name: my_pipe_param3-loop-item
         value: $(params.my_pipe_param3)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -208,4 +208,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withitem_nested_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested_noninlined.yaml
@@ -118,4 +118,6 @@ spec:
         value: '[1, 2]'
       - name: my_pipe_param
         value: $(params.my_pipe_param)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_global.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global.yaml
@@ -142,4 +142,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
@@ -148,4 +148,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_global_dict_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_dict_noninlined.yaml
@@ -119,4 +119,6 @@ spec:
       params:
       - name: loopidy_doop-loop-item
         value: $(params.loopidy_doop)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_global_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_noninlined.yaml
@@ -117,4 +117,6 @@ spec:
       params:
       - name: loopidy_doop-loop-item
         value: $(params.loopidy_doop)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_output.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output.yaml
@@ -132,4 +132,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
@@ -132,4 +132,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_output_dict_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_dict_noninlined.yaml
@@ -110,4 +110,6 @@ spec:
       params:
       - name: my-out-cop0-out-loop-item
         value: $(tasks.my-out-cop0.results.out)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m

--- a/sdk/python/tests/compiler/testdata/withparam_output_noninlined.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_noninlined.yaml
@@ -108,4 +108,6 @@ spec:
       params:
       - name: my-out-cop0-out-loop-item
         value: $(tasks.my-out-cop0.results.out)
-  timeout: 525600m
+  timeouts:
+    pipeline: 1051200m
+    tasks: 525600m


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #1030 

**Description of your changes:**
Update pipelinerun timeout format to the new timeouts syntax to avoid Tekton V1 API deprecation in the future.

Extended default finally timeout to a year and default finally cleanup to 5 minutes.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
