### PR TITLE
feat(sdk): Add alpha env flag to opt out artifact tracking annotations

### DIFF
--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -20,6 +20,7 @@ import hashlib
 
 from collections import OrderedDict
 from typing import List, Text, Dict, Any
+from os import environ as env
 
 from kfp import dsl
 from kfp_tekton.compiler._k8s_helper import convert_k8s_obj_to_json, sanitize_k8s_name
@@ -564,6 +565,8 @@ def _op_to_template(op: BaseOp,
         }
         template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/component_spec_digest'] = \
             json.dumps(digested_component_spec_dict, sort_keys=True)
+        if env.get('DISABLE_ARTIFACT_TRACKING', 'false').lower() == 'true':
+            template['metadata']['annotations'].pop('pipelines.kubeflow.org/component_spec_digest', None)
 
     if isinstance(op, dsl.ContainerOp) and op.execution_options:
         if op.execution_options.caching_strategy.max_cache_staleness:

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -1331,9 +1331,9 @@ class TektonCompiler(Compiler):
     }
 
     if env.get('DISABLE_ARTIFACT_TRACKING', 'false').lower() == 'true':
-      pipeline_run['metadata']['annotations']['tekton.dev/output_artifacts'] = {}
-      pipeline_run['metadata']['annotations']['tekton.dev/input_artifacts'] = {}
-      pipeline_run['metadata']['annotations']['tekton.dev/artifact_items'] = {}
+      pipeline_run['metadata']['annotations'].pop('tekton.dev/output_artifacts', None)
+      pipeline_run['metadata']['annotations'].pop('tekton.dev/input_artifacts', None)
+      pipeline_run['metadata']['annotations'].pop('tekton.dev/artifact_items', None)
 
     if self.pipeline_labels:
       pipeline_run['metadata']['labels'] = pipeline_run['metadata'].setdefault('labels', {})

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -1330,6 +1330,11 @@ class TektonCompiler(Compiler):
       }
     }
 
+    if env.get('DISABLE_ARTIFACT_TRACKING', 'false').lower() == 'true':
+      pipeline_run['metadata']['annotations']['tekton.dev/output_artifacts'] = {}
+      pipeline_run['metadata']['annotations']['tekton.dev/input_artifacts'] = {}
+      pipeline_run['metadata']['annotations']['tekton.dev/artifact_items'] = {}
+
     if self.pipeline_labels:
       pipeline_run['metadata']['labels'] = pipeline_run['metadata'].setdefault('labels', {})
       pipeline_run['metadata']['labels'].update(self.pipeline_labels)

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -939,10 +939,11 @@ class TestTektonCompiler(unittest.TestCase):
           obj = yaml.safe_load(f)
         text = yaml.safe_dump(obj)
         self.assertNotRegex(text, "stepTemplate")
-        artifact_items = obj['metadata']['annotations']['tekton.dev/artifact_items']
-        items_for_op0 = list(json.loads(artifact_items).values())[0]
-        names_of_items_for_op0 = set([item[0] for item in items_for_op0])
-        self.assertSetEqual(names_of_items_for_op0, {"incr_i", "sq_i"})
+        artifact_items = obj['metadata']['annotations'].get('tekton.dev/artifact_items', {})
+        if artifact_items:
+          items_for_op0 = list(json.loads(artifact_items).values())[0]
+          names_of_items_for_op0 = set([item[0] for item in items_for_op0])
+          self.assertSetEqual(names_of_items_for_op0, {"incr_i", "sq_i"})
     finally:
       shutil.rmtree(temp_dir)
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
Add alpha env flag to opt out artifact tracking annotations to further reduce Tekton yaml size for pipelines that need high throughputs without tracking.

Usage:
Enable the following env variable flag before compiling the pipeline
```
export DISABLE_ARTIFACT_TRACKING=true
```

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
