### PR TITLE
feat(backend): specify the image for result step

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -45,6 +45,7 @@ const (
 	InjectDefaultScript                     string = "INJECT_DEFAULT_SCRIPT"
 	ApplyTektonCustomResource               string = "APPLY_TEKTON_CUSTOM_RESOURCE"
 	TerminateStatus                         string = "TERMINATE_STATUS"
+	MoveResultsImage                        string = "MOVERESULTS_IMAGE"
 	Path4InternalResults                    string = "PATH_FOR_INTERNAL_RESULTS"
 	ObjectStoreAccessKey                    string = "OBJECTSTORECONFIG_ACCESSKEY"
 	ObjectStoreSecretKey                    string = "OBJECTSTORECONFIG_SECRETKEY"
@@ -142,6 +143,10 @@ func GetPodNamespace() string {
 
 func GetArtifactImage() string {
 	return GetStringConfigWithDefault(ArtifactImage, DefaultArtifactImage)
+}
+
+func GetMoveResultsImage() string {
+	return GetStringConfigWithDefault(MoveResultsImage, DefaultMoveResultImage)
 }
 
 func GetCopyStepTemplate() *workflowapi.Step {

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -73,6 +73,7 @@ const (
 	DefaultArtifactEndpoint       string = "minio-service.kubeflow:9000"
 	DefaultArtifactEndpointScheme string = "http://"
 	DefaultArtifactImage          string = "minio/mc"
+	DefaultMoveResultImage        string = "busybox"
 )
 
 const (

--- a/backend/src/apiserver/template/tekton_template.go
+++ b/backend/src/apiserver/template/tekton_template.go
@@ -308,7 +308,7 @@ func (t *Tekton) injectArchivalStep(workflow util.Workflow, artifactItemsJSON ma
 					// move all results to /tekton/home/tep-results to avoid result duplication in copy-artifacts step
 					// TODO: disable eof strip, since no results under /tekton/results after this step
 					moveResults := workflowapi.Step{
-						Image:   "busybox",
+						Image:   common.GetMoveResultsImage(),
 						Name:    "move-all-results-to-tekton-home",
 						Command: []string{"sh", "-c"},
 						Args: []string{fmt.Sprintf("if [ -d /tekton/results ]; then mkdir -p %s; mv /tekton/results/* %s/ || true; fi\n",

--- a/manifests/kustomize/base/pipeline/apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/apiserver-deployment.yaml
@@ -110,6 +110,11 @@ spec:
             configMapKeyRef:
               name: kfp-tekton-config
               key: artifact_image
+        - name: MOVERESULTS_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              name: kfp-tekton-config
+              key: moveresults_image
         - name: INJECT_DEFAULT_SCRIPT
           valueFrom:
             configMapKeyRef:

--- a/manifests/kustomize/base/pipeline/kfp-pipeline-config.yaml
+++ b/manifests/kustomize/base/pipeline/kfp-pipeline-config.yaml
@@ -8,6 +8,7 @@ data:
   artifact_endpoint_scheme: "http://"
   artifact_image: "minio/mc:RELEASE.2020-11-25T23-04-07Z"
   archive_logs: "true"
+  moveresults_image: "busybox:1.34.1"
   track_artifacts: "true"
   strip_eof: "true"
   inject_default_script: "true"


### PR DESCRIPTION
Allow users to specify the image for `step-move-all-results-to-tekton-home` step. Add an env variable for the custom image: `MOVERESULTS_IMAGE` in the api server.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

**Which issue is resolved by this Pull Request:** 
Resolves #1103 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
