### PR TITLE
feat(sdk): make metadata component spec gen flag configurable on pipeline level

### DIFF
--- a/guides/advanced_user_guide.md
+++ b/guides/advanced_user_guide.md
@@ -195,6 +195,7 @@ Below are the usages and input types:
 - add_pipeline_env() - InputType: name `str`, value `str`
 - set_pipeline_env() - InputType: `Dict`
 - add_pipeline_workspace() - InputType: workspace_name `str`, volume `V1Volume` (optional), volume_claim_template_spec `V1PersistentVolumeClaimSpec` (optional), path_prefix `str`
+- set_generate_component_spec_annotations() - InputType: `Bool`
 
 ```python
 from kfp_tekton.compiler.pipeline_utils import TektonPipelineConf
@@ -215,6 +216,7 @@ pipeline_conf.add_pipeline_workspace(workspace_name="new-ws-template",
         access_modes=["ReadWriteOnce"],
         resources=V1ResourceRequirements(requests={"storage": "30Gi"})
 )) # InputType: workspace_name `str`, volume_claim_template_spec `V1PersistentVolumeClaimSpec`
+pipeline_conf.set_generate_component_spec_annotations(True) # InputType: Bool
 self._test_pipeline_workflow(test_pipeline, 'test.yaml', tekton_pipeline_conf=pipeline_conf)
 ```
 

--- a/sdk/python/kfp_tekton/compiler/_op_to_template.py
+++ b/sdk/python/kfp_tekton/compiler/_op_to_template.py
@@ -36,7 +36,7 @@ TEKTON_HOME_RESULT_PATH = "/tekton/home/tep-results/"
 # The image to use in basic bash steps such as copying results in multi-step.
 TEKTON_BASH_STEP_IMAGE = 'busybox'
 TEKTON_COPY_RESULTS_STEP_IMAGE = 'library/bash'
-GENERATE_COMPONENT_SPEC_ANNOTATIONS = True
+GENERATE_COMPONENT_SPEC_ANNOTATIONS = env.get('GENERATE_COMPONENT_SPEC_ANNOTATIONS', True)
 
 
 def _get_base_step(name: str):
@@ -397,7 +397,8 @@ def _process_base_ops(op: BaseOp):
 
 def _op_to_template(op: BaseOp,
                     pipelinerun_output_artifacts={},
-                    artifact_items={}):
+                    artifact_items={},
+                    generate_component_spec_annotations=True):
     """Generate template given an operator inherited from BaseOp."""
 
     # Display name
@@ -556,7 +557,7 @@ def _op_to_template(op: BaseOp,
                                                                             for volume in processed_op.volumes]
         template['spec']['volumes'].sort(key=lambda x: x['name'])
 
-    if isinstance(op, dsl.ContainerOp) and op._metadata and GENERATE_COMPONENT_SPEC_ANNOTATIONS:
+    if isinstance(op, dsl.ContainerOp) and op._metadata and GENERATE_COMPONENT_SPEC_ANNOTATIONS and generate_component_spec_annotations:
         component_spec_dict = op._metadata.to_dict()
         component_spec_digest = hashlib.sha256(json.dumps(component_spec_dict, sort_keys=True).encode()).hexdigest()
         component_name = component_spec_dict.get('name', op.name)

--- a/sdk/python/kfp_tekton/compiler/compiler.py
+++ b/sdk/python/kfp_tekton/compiler/compiler.py
@@ -150,6 +150,7 @@ class TektonCompiler(Compiler):
     self.pipeline_env = {}
     self.pipeline_workspaces = {}
     self.task_workspaces = {}
+    self.generate_component_spec_annotations = True
     super().__init__(**kwargs)
 
   def _set_pipeline_conf(self, tekton_pipeline_conf: TektonPipelineConf):
@@ -164,6 +165,7 @@ class TektonCompiler(Compiler):
     self.automount_service_account_token = tekton_pipeline_conf.automount_service_account_token
     self.pipeline_env = tekton_pipeline_conf.pipeline_env
     self.pipeline_workspaces = tekton_pipeline_conf.pipeline_workspaces
+    self.generate_component_spec_annotations = tekton_pipeline_conf.generate_component_spec_annotations
 
   def _resolve_value_or_reference(self, value_or_reference, potential_references):
     """_resolve_value_or_reference resolves values and PipelineParams, which could be task parameters or input parameters.
@@ -619,7 +621,8 @@ class TektonCompiler(Compiler):
 
     op_to_steps_handler = op_to_templates_handler or (lambda op: [_op_to_template(op,
                                                                   self.output_artifacts,
-                                                                  self.artifact_items)])
+                                                                  self.artifact_items,
+                                                                  self.generate_component_spec_annotations)])
     root_group = pipeline.groups[0]
 
     # Call the transformation functions before determining the inputs/outputs, otherwise
@@ -1140,8 +1143,10 @@ class TektonCompiler(Compiler):
           task_annotations = template['metadata'].get('annotations', {})
 
           # Updata default metadata at the end.
-          task_ref['taskSpec']['metadata']['labels'] = task_labels
-          task_ref['taskSpec']['metadata']['annotations'] = task_annotations
+          if task_labels:
+            task_ref['taskSpec']['metadata']['labels'] = task_labels
+          if task_annotations:
+            task_ref['taskSpec']['metadata']['annotations'] = task_annotations
 
         task_refs.append(task_ref)
 

--- a/sdk/python/kfp_tekton/compiler/pipeline_utils.py
+++ b/sdk/python/kfp_tekton/compiler/pipeline_utils.py
@@ -33,6 +33,7 @@ class TektonPipelineConf(dsl.PipelineConf):
         self.automount_service_account_token = None
         self.pipeline_env = {}
         self.pipeline_workspaces = {}
+        self.generate_component_spec_annotations = True
         super().__init__(**kwargs)
 
     def copy(self):
@@ -88,4 +89,8 @@ class TektonPipelineConf(dsl.PipelineConf):
                              workspace_name)
         volumeSpec = volume if volume else volume_claim_template_spec
         self.pipeline_workspaces[workspace_name] = (volumeSpec, path_prefix)
+        return self
+
+    def set_generate_component_spec_annotations(self, value: bool):
+        self.generate_component_spec_annotations = value
         return self

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -850,6 +850,7 @@ class TestTektonCompiler(unittest.TestCase):
           access_modes=["ReadWriteOnce"],
           resources=V1ResourceRequirements(requests={"storage": "30Gi"})
     ))
+    pipeline_conf.set_generate_component_spec_annotations(False)
     self._test_pipeline_workflow(echo_pipeline, 'tekton_pipeline_conf.yaml',
                                  tekton_pipeline_conf=pipeline_conf,
                                  skip_noninlined=True)

--- a/sdk/python/tests/compiler/testdata/pipelineparam_env.yaml
+++ b/sdk/python/tests/compiler/testdata/pipelineparam_env.yaml
@@ -61,4 +61,3 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-          annotations: {}

--- a/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/resourceop_basic.yaml
@@ -130,4 +130,3 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-          annotations: {}

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.py
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.py
@@ -63,6 +63,7 @@ pipeline_conf.add_pipeline_workspace(workspace_name="new-ws-template",
         access_modes=["ReadWriteOnce"],
         resources=V1ResourceRequirements(requests={"storage": "30Gi"})
 ))
+pipeline_conf.set_generate_component_spec_annotations(False)
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.yaml
+++ b/sdk/python/tests/compiler/testdata/tekton_pipeline_conf.yaml
@@ -54,9 +54,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-          annotations:
-            pipelines.kubeflow.org/component_spec_digest: '{"name": "echo", "outputs":
-              [], "version": "echo@sha256=14be762d0ac645b725d45e703104370b0816a8b2b9abf44ca01c405e3bbf45c3"}'
       workspaces:
       - name: new-ws
         workspace: new-ws

--- a/sdk/python/tests/compiler/testdata/volume_op.yaml
+++ b/sdk/python/tests/compiler/testdata/volume_op.yaml
@@ -130,7 +130,6 @@ spec:
         metadata:
           labels:
             pipelines.kubeflow.org/cache_enabled: "true"
-          annotations: {}
     - name: cop
       params:
       - name: create-pvc-name


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
The flag for disabling component spec annotation metadata was only available on package level, we want to expose this flag on pipeline level as well so our users can control what pipeline is allowed to be tracked for metadata.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
