### PR TITLE
fix(sdk): Remove print statement for compiler to reduce log size

### DIFF
--- a/sdk/python/kfp_tekton/compiler/main.py
+++ b/sdk/python/kfp_tekton/compiler/main.py
@@ -20,7 +20,6 @@ import kfp.compiler.main as kfp_compiler_main
 from kfp_tekton.compiler.pipeline_utils import TektonPipelineConf
 
 from . import TektonCompiler
-from .. import __version__
 
 
 def parse_arguments():
@@ -86,7 +85,6 @@ def compile_pyfile(pyfile, function_name, output_path, type_check, tekton_pipeli
 
 
 def main():
-    print(f"KFP-Tekton Compiler {__version__}")
     args = parse_arguments()
     if ((args.py is None and args.package is None) or
         (args.py is not None and args.package is not None)):


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
The version print statement for every time we compile the pipeline can create a significant log size when we are running the sdk in a server for a log time. We have been skipping info logs but removing this print statement can help us get back useful info logs that doesn't grow big over time.

This print statement was not in argo version as well so it make sense to remove it.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
