### PR TITLE
fix(backend): Use childReference instead of taskRuns

### DIFF
--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -277,22 +277,10 @@ func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeID string, artifactName
 	// TODO: The below artifact keys are only for parameter artifacts. Will need to also implement
 	//       metric and raw input artifacts once we finallized the big data passing in our compiler.
 
-	if w.Status.PipelineRunStatusFields.TaskRuns == nil {
+	if w.Status.PipelineRunStatusFields.ChildReferences == nil || len(w.Status.PipelineRunStatusFields.ChildReferences) == 0 {
 		return ""
 	}
-	var s3Key string
-	s3Key = "artifacts/" + w.ObjectMeta.Name + "/" + nodeID + "/" + artifactName + ".tgz"
-	return s3Key
-}
-
-// FindTaskRunByPodName loops through all workflow task runs and look up by the pod name.
-func (w *Workflow) FindTaskRunByPodName(podName string) (*workflowapi.PipelineRunTaskRunStatus, string) {
-	for id, taskRun := range w.Status.TaskRuns {
-		if taskRun.Status.PodName == podName {
-			return taskRun, id
-		}
-	}
-	return nil, ""
+	return "artifacts/" + w.ObjectMeta.Name + "/" + nodeID + "/" + artifactName + ".tgz"
 }
 
 // IsInFinalState whether the workflow is in a final state.


### PR DESCRIPTION
**Description of your changes:**

After tekton 0.45. status.taskRuns will be removed. Switch to status.childReferences since we can use
them to get all taskRuns and their pipelineTaskNames.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
