### PR TITLE
v2(tekton compiler): add env vars for caching

### DIFF
--- a/manifests/kustomize/env/platform-agnostic-tekton/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic-tekton/kustomization.yaml
@@ -16,13 +16,13 @@ resources:
 images:
 - name: gcr.io/ml-pipeline/api-server
   newName: docker.io/aipipeline/apiserver-dev
-  newTag: 47c9dc29e
+  newTag: ffca08e6d
 - name: gcr.io/ml-pipeline/persistenceagent
   newName: docker.io/aipipeline/persistenceagent-dev
-  newTag: 47c9dc29e
+  newTag: ffca08e6d
 - name: gcr.io/ml-pipeline/scheduledworkflow
   newName: docker.io/aipipeline/swf-dev
-  newTag: 47c9dc29e
+  newTag: ffca08e6d
 
 labels:
 - includeSelectors: true

--- a/manifests/kustomize/env/platform-openshift-pipelines/kustomization.yaml
+++ b/manifests/kustomize/env/platform-openshift-pipelines/kustomization.yaml
@@ -67,13 +67,13 @@ patches:
 images:
 - name: gcr.io/ml-pipeline/api-server
   newName: docker.io/aipipeline/apiserver-dev
-  newTag: 47c9dc29e
+  newTag: ffca08e6d
 - name: gcr.io/ml-pipeline/persistenceagent
   newName: docker.io/aipipeline/persistenceagent-dev
-  newTag: 47c9dc29e
+  newTag: ffca08e6d
 - name: gcr.io/ml-pipeline/scheduledworkflow
   newName: docker.io/aipipeline/swf-dev
-  newTag: 47c9dc29e
+  newTag: ffca08e6d
 
 labels:
 - includeSelectors: true

--- a/manifests/kustomize/third-party/tekton-custom-task/kustomization.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/kustomization.yaml
@@ -17,16 +17,16 @@ images:
     newTag: 1.6.5
   - name: kfp-v2-dev-driver-controller
     newName: docker.io/aipipeline/tekton-driver-dev
-    newTag: 47c9dc29e
+    newTag: ffca08e6d
   - name: tekton-exithandler-controller
     newName: docker.io/aipipeline/tekton-exithandler-controller-dev
-    newTag: 47c9dc29e
+    newTag: ffca08e6d
   - name: tekton-exithandler-webhook
     newName: docker.io/aipipeline/tekton-exithandler-webhook-dev
-    newTag: 47c9dc29e
+    newTag: ffca08e6d
   - name: tekton-kfptask-controller
     newName: docker.io/aipipeline/tekton-kfptask-controller-dev
-    newTag: 47c9dc29e
+    newTag: ffca08e6d
   - name: tekton-kfptask-webhook
     newName: docker.io/aipipeline/tekton-kfptask-webhook-dev
-    newTag: 47c9dc29e
+    newTag: ffca08e6d


### PR DESCRIPTION
**Description of your changes:**
Propagate the Env vars in ml-pipeline to executor pods, and the launcher can use them to set up MLMD and ml-pipeline endpoints. This change assumes the ml-pipeline and MLMD are using the following service names:
- ml-pipeline
- metadata-grpc-service

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
