### PR TITLE
fix(deployment): Added additional ConfigMap to support requirements of pipelineloop webhook pod in V2

### DIFF
--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/205-config-artifact-pvc.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/205-config-artifact-pvc.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-pvc
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  {}

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/206-config-artifact-bucket.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/206-config-artifact-bucket.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-bucket
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  {}

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/207-config-trusted-resources.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/207-config-trusted-resources.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-trusted-resources
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  {}

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/kustomization.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
   - 202-clusterrolebinding.yaml
   - 203-object-store-config.yaml
   - 204-cache-config.yaml
+  - 205-config-artifact-pvc.yaml
+  - 206-config-artifact-bucket.yaml
+  - 207-config-trusted-resources.yaml
   - 300-pipelineloop.yaml
   - 301-breaktask.yaml
   - 500-controller.yaml


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #1298 

**Description of your changes:**

As reported in #1298 , the pipelineloop webhook pod does not start due to missing `ConfigMap` associated with the configuration of Tekton. I've added the required ConfigMap in this PR. I was not able to locate in the code where (if at all) we make reference to these ConfigMap, so the question remains as to whether or not they are actually required as the Tekton documentation would suggest these are optional unless using specific features of the framework.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
