### PR TITLE
fix(deployment): Update image name and version for pipelineloop controllers

### DIFF
--- a/manifests/kustomize/third-party/tekton-custom-task/kustomization.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/kustomization.yaml
@@ -11,9 +11,9 @@ namespace: tekton-pipelines
 
 images:
   - name: quay.io/aipipeline/pipelineloop-controller
-    newTag: 1.7.0
+    newTag: 1.7.1
   - name: quay.io/aipipeline/pipelineloop-webhook
-    newTag: 1.7.0
+    newTag: 1.7.1
   - name: kfp-v2-dev-driver-controller
     newName: docker.io/aipipeline/tekton-driver-dev
     newTag: ba1029b6b

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/500-controller.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/500-controller.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: tekton-pipelineloop-controller
       containers:
       - name: tekton-pipelineloop-controller
-        image: docker.io/aipipeline/pipelineloop-controller:nightly
+        image: quay.io/aipipeline/pipelineloop-controller:nightly
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/500-webhook.yaml
+++ b/manifests/kustomize/third-party/tekton-custom-task/pipeline-loops/500-webhook.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: tekton-pipelineloop-webhook
       containers:
       - name: webhook
-        image: docker.io/aipipeline/pipelineloop-webhook:nightly
+        image: quay.io/aipipeline/pipelineloop-webhook:nightly
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #1298 

**Description of your changes:**

1.7.0 images include a version of Tekton that has a dependency on config-trusted-resources, config-artifact-pvc and config-artifact-bucket ConfigMap. These have been removed in the most recent versions of Tekton that deprecate PipelineResources.

Updating to 1.7.1 of the images resolves the need for these ConfigMap to exist and allows the pipelineloop controllers to boot.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
