### PR TITLE
v2(backend): fix persistence agent

### DIFF
--- a/backend/src/agent/persistence/client/pipeline_client.go
+++ b/backend/src/agent/persistence/client/pipeline_client.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	apiv2 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
@@ -44,7 +45,7 @@ type PipelineClientInterface interface {
 type PipelineClient struct {
 	initializeTimeout   time.Duration
 	timeout             time.Duration
-	reportServiceClient api.ReportServiceClient
+	reportServiceClient apiv2.ReportServiceClient
 	runServiceClient    api.RunServiceClient
 }
 
@@ -71,7 +72,7 @@ func NewPipelineClient(
 	return &PipelineClient{
 		initializeTimeout:   initializeTimeout,
 		timeout:             timeout,
-		reportServiceClient: api.NewReportServiceClient(connection),
+		reportServiceClient: apiv2.NewReportServiceClient(connection),
 		runServiceClient:    api.NewRunServiceClient(connection),
 	}, nil
 }
@@ -80,7 +81,7 @@ func (p *PipelineClient) ReportWorkflow(workflow util.ExecutionSpec) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	_, err := p.reportServiceClient.ReportWorkflowV1(ctx, &api.ReportWorkflowRequest{
+	_, err := p.reportServiceClient.ReportWorkflow(ctx, &apiv2.ReportWorkflowRequest{
 		Workflow: workflow.ToStringForStore(),
 	})
 
@@ -113,8 +114,8 @@ func (p *PipelineClient) ReportScheduledWorkflow(swf *util.ScheduledWorkflow) er
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	_, err := p.reportServiceClient.ReportScheduledWorkflowV1(ctx,
-		&api.ReportScheduledWorkflowRequest{
+	_, err := p.reportServiceClient.ReportScheduledWorkflow(ctx,
+		&apiv2.ReportScheduledWorkflowRequest{
 			ScheduledWorkflow: swf.ToStringForStore(),
 		})
 

--- a/backend/src/agent/persistence/worker/swf_saver.go
+++ b/backend/src/agent/persistence/worker/swf_saver.go
@@ -53,6 +53,10 @@ func (c *ScheduledWorkflowSaver) Save(key string, namespace string, name string,
 
 	}
 
+	// TODO: wait for up stream to officially update to v2beta1
+	//       temporally hack this to v2beta1
+	swf.APIVersion = "kubeflow.org/v2beta1"
+	swf.Kind = "ScheduledWorkflow"
 	// Save this Scheduled Workflow to the database.
 	err = c.pipelineClient.ReportScheduledWorkflow(swf)
 	retry := util.HasCustomCode(err, util.CUSTOM_CODE_TRANSIENT)

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -122,13 +122,14 @@ func startRpcServer(resourceManager *resource.ResourceManager) {
 	)
 	sharedJobServer := server.NewJobServer(resourceManager, &server.JobServerOptions{CollectMetrics: *collectMetricsFlag})
 	sharedRunServer := server.NewRunServer(resourceManager, &server.RunServerOptions{CollectMetrics: *collectMetricsFlag})
+	sharedReportServer := server.NewReportServer(resourceManager)
 
 	apiv1beta1.RegisterExperimentServiceServer(s, sharedExperimentServer)
 	apiv1beta1.RegisterPipelineServiceServer(s, sharedPipelineServer)
 	apiv1beta1.RegisterJobServiceServer(s, sharedJobServer)
 	apiv1beta1.RegisterRunServiceServer(s, sharedRunServer)
 	apiv1beta1.RegisterTaskServiceServer(s, server.NewTaskServer(resourceManager))
-	apiv1beta1.RegisterReportServiceServer(s, server.NewReportServer(resourceManager))
+	apiv1beta1.RegisterReportServiceServer(s, sharedReportServer)
 
 	apiv1beta1.RegisterVisualizationServiceServer(
 		s,
@@ -143,6 +144,7 @@ func startRpcServer(resourceManager *resource.ResourceManager) {
 	apiv2beta1.RegisterPipelineServiceServer(s, sharedPipelineServer)
 	apiv2beta1.RegisterRecurringRunServiceServer(s, sharedJobServer)
 	apiv2beta1.RegisterRunServiceServer(s, sharedRunServer)
+	apiv2beta1.RegisterReportServiceServer(s, sharedReportServer)
 
 	// Register reflection service on gRPC server.
 	reflection.Register(s)
@@ -175,6 +177,7 @@ func startHttpProxy(resourceManager *resource.ResourceManager) {
 	registerHttpHandlerFromEndpoint(apiv2beta1.RegisterPipelineServiceHandlerFromEndpoint, "PipelineService", ctx, runtimeMux)
 	registerHttpHandlerFromEndpoint(apiv2beta1.RegisterRecurringRunServiceHandlerFromEndpoint, "RecurringRunService", ctx, runtimeMux)
 	registerHttpHandlerFromEndpoint(apiv2beta1.RegisterRunServiceHandlerFromEndpoint, "RunService", ctx, runtimeMux)
+	registerHttpHandlerFromEndpoint(apiv2beta1.RegisterReportServiceHandlerFromEndpoint, "ReportService", ctx, runtimeMux)
 
 	// Create a top level mux to include both pipeline upload server and gRPC servers.
 	topMux := mux.NewRouter()


### PR DESCRIPTION
**Description of your changes:**
persistence agent can't properly report scheduledworkflow and cause errors on both the persistence agent and apiserver. fix the error by using v2beta1 API to report scheduledworkflow. still need upstream to update scheduledworkflow to v2beta1.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
