### PR TITLE
v2(backend): fix multi-user issue in swf

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
@@ -36,6 +36,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
   - tekton.dev
   resources:
   - pipelineruns

--- a/manifests/kustomize/base/installs/multi-user/scheduled-workflow/deployment-patch.yaml
+++ b/manifests/kustomize/base/installs/multi-user/scheduled-workflow/deployment-patch.yaml
@@ -11,3 +11,9 @@ spec:
         - name: NAMESPACE
           value: '' # Empty namespace let viewer controller watch all namespaces
           valueFrom: null # HACK: https://github.com/kubernetes-sigs/kustomize/issues/2606
+        - name: KUBEFLOW_USERID_HEADER
+          value: kubeflow-userid
+        - name: KUBEFLOW_USERID_PREFIX
+          value: ""
+        - name: MULTIUSER
+          value: "true"

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
@@ -31,6 +31,12 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
   - ''
   resources:
   - events


### PR DESCRIPTION
**Description of your changes:**
When calling the `CreateRun` API in multi-user mode, a kubeflow-user id needs to inject to gRPC metadata.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
