### PR TITLE
feat(tekton-kfptask): Update kfptask to publish completed dag status

### DIFF
--- a/tekton-catalog/tekton-kfptask/go.mod
+++ b/tekton-catalog/tekton-kfptask/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/kubeflow/pipelines v0.0.0-20231027040853-58ce09e07d03
 	github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03
 	github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20231027040853-58ce09e07d03
+	github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20231027040853-58ce09e07d03
 	github.com/tektoncd/pipeline v0.53.2
 	go.uber.org/zap v1.26.0
+	google.golang.org/protobuf v1.31.0
 	k8s.io/api v0.27.1
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.27.2
@@ -64,7 +66,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -101,7 +102,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231009173412-8bfb1ae86b6c // indirect
 	google.golang.org/grpc v1.58.3 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/tekton-catalog/tekton-kfptask/go.sum
+++ b/tekton-catalog/tekton-kfptask/go.sum
@@ -945,8 +945,9 @@ github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03/go.mod h1:T
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20230404213301-bd9f74e34de6/go.mod h1:CJkKr356RlpZP/gQRuHf3Myrn1qJtoUVe4EMCmtwarg=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20231027040853-58ce09e07d03 h1:5GgKSLMNvwRfrLxKCrHvlVVcAo+bfrTZzbR+hOGHDIs=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20231027040853-58ce09e07d03/go.mod h1:CJkKr356RlpZP/gQRuHf3Myrn1qJtoUVe4EMCmtwarg=
-github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800 h1:YAW+X9xCW8Yq5tQaBBQaLTNU9CJj8Nr7lx1+k66ZHJ0=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800/go.mod h1:chIDffBaVQ/asNl1pTTdbAymYcuBKf8BR3YtSP+3FEU=
+github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20231027040853-58ce09e07d03 h1:SYa9l3PTThV0+g6bSNL5rRieqLvZ0Go2Gd+nzIH0Zi8=
+github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20231027040853-58ce09e07d03/go.mod h1:gh5+EFvuVywvSOYxqT0N91VKuPtScUke/F66RT0NJ80=
 github.com/labstack/echo v3.2.1+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/gommon v0.2.7/go.mod h1:/tj9csK2iPSBvn+3NLM9e52usepMtrd5ilFYA+wQNJ4=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=

--- a/tekton-catalog/tekton-kfptask/pkg/reconciler/kfptask/reconciler.go
+++ b/tekton-catalog/tekton-kfptask/pkg/reconciler/kfptask/reconciler.go
@@ -496,7 +496,7 @@ func execDriver(ctx context.Context, options *driverOptions) (*[]tektonv1beta1.C
 	case "DAG":
 		execution, err = driver.DAG(ctx, options.options, options.mlmdClient)
 	case "DAG_PUB":
-		// no-op for now
+		// current DAG_PUB only scheduled when the dag execution is completed
 		err = DAGPublisher(ctx, options.options, options.mlmdClient)
 		return &[]tektonv1beta1.CustomRunResult{}, taskRunDecision, executionID, executorInput, podSpecPatch, err
 	default:

--- a/tekton-catalog/tekton-kfptask/pkg/reconciler/kfptask/reconciler.go
+++ b/tekton-catalog/tekton-kfptask/pkg/reconciler/kfptask/reconciler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/driver"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
+	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -43,6 +44,7 @@ import (
 	listeners "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
 	listenersv1beta1 "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
 	k8score "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -462,6 +464,21 @@ func v1ParamsConversion(ctx context.Context, v1beta1Params tektonv1beta1.Params)
 	return v1Params
 }
 
+func DAGPublisher(ctx context.Context, opts driver.Options, mlmd *metadata.Client) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("failed to publish driver DAG execution %s: %w", fmt.Sprint(opts.DAGExecutionID), err)
+		}
+	}()
+	var outputParameters map[string]*structpb.Value
+	status := pb.Execution_COMPLETE
+	execution, err := mlmd.GetExecution(ctx, opts.DAGExecutionID)
+	if err = mlmd.PublishExecution(ctx, execution, outputParameters, nil, status); err != nil {
+		return fmt.Errorf("failed to publish: %w", err)
+	}
+	return nil
+}
+
 func execDriver(ctx context.Context, options *driverOptions) (*[]tektonv1beta1.CustomRunResult, bool, string, string, string, error) {
 	var execution *driver.Execution
 	var err error
@@ -480,7 +497,8 @@ func execDriver(ctx context.Context, options *driverOptions) (*[]tektonv1beta1.C
 		execution, err = driver.DAG(ctx, options.options, options.mlmdClient)
 	case "DAG_PUB":
 		// no-op for now
-		return &[]tektonv1beta1.CustomRunResult{}, taskRunDecision, executionID, executorInput, podSpecPatch, nil
+		err = DAGPublisher(ctx, options.options, options.mlmdClient)
+		return &[]tektonv1beta1.CustomRunResult{}, taskRunDecision, executionID, executorInput, podSpecPatch, err
 	default:
 		err = fmt.Errorf("unknown driverType %s", options.driverType)
 	}

--- a/tekton-catalog/tekton-kfptask/pkg/reconciler/kfptask/reconciler.go
+++ b/tekton-catalog/tekton-kfptask/pkg/reconciler/kfptask/reconciler.go
@@ -473,6 +473,9 @@ func DAGPublisher(ctx context.Context, opts driver.Options, mlmd *metadata.Clien
 	var outputParameters map[string]*structpb.Value
 	status := pb.Execution_COMPLETE
 	execution, err := mlmd.GetExecution(ctx, opts.DAGExecutionID)
+	if err != nil {
+		return fmt.Errorf("failed to get execution: %w", err)
+	}
 	if err = mlmd.PublishExecution(ctx, execution, outputParameters, nil, status); err != nil {
 		return fmt.Errorf("failed to publish: %w", err)
 	}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
Our current publisher only being executed when the dag is completed. Thus it make sense to also update mlmd status as complete for that dag. 

For failing status, caching entry, and dag output artifacts, it only make sense to implement it after we merged the publisher as part of the sub-dag reconciliation logic. Otherwise any failed sub-dag will never run the publisher task and the cache entry and output artifacts info has different logic when it became part of the sub-dag reconciliation logic.

**Environment tested:**

* Python Version (use `python --version`):
* Tekton Version (use `tkn version`):
* Kubernetes Version (use `kubectl version`):
* OS (e.g. from `/etc/os-release`):

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
